### PR TITLE
Fixed signed/unsigned comparison warning.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -173,12 +173,15 @@ inline int socket_read(socket_t sock, char* ptr, size_t size)
     return recv(sock, ptr, size, 0);
 }
 
-inline int socket_write(socket_t sock, const char* ptr, size_t size = -1)
+inline int socket_write(socket_t sock, const char* ptr, size_t size)
 {
-    if (size == -1) {
-        size = strlen(ptr);
-    }
     return send(sock, ptr, size, 0);
+}
+
+inline int socket_write(socket_t sock, const char* ptr)
+{
+    size_t size = strlen(ptr);
+    return socket_write(sock, ptr, size);
 }
 
 inline bool socket_gets(socket_t sock, char* buf, int bufsiz)


### PR DESCRIPTION
Compiling with gcc -Wall caused a warning indicating a comparison between signed and unsigned integer expressions. This is because size_t is unsigned on most platforms, and the socket_write function's size argument was defaulted to -1 (and was then being compared to -1 to check for a defaulted value).
Instead, now we simply overload the socket_write method to have a version with and without the size argument.