### PR TITLE
Update httplib.h

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1081,7 +1081,7 @@ inline bool Client::process_request(Stream& strm, const Request& req, Response& 
         return false;
     }
     if (req.method != "HEAD") {
-        if (!detail::read_content(strm, res, false)) {
+        if (!detail::read_content(strm, res, true)) {
             return false;
         }
     }


### PR DESCRIPTION
If no "Content-Length" is sent in the response-header the body is always empty #16 

For the function call with the response (client), the `allow_no_content_length` should be true.