### PR TITLE
Support system-assigned port via two part listen()

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -240,6 +240,13 @@ TEST(ConnectionErrorTest, Timeout)
     ASSERT_TRUE(res == nullptr);
 }
 
+TEST(Server, BindAndListenSeparately) {
+    Server svr(httplib::HttpVersion::v1_1);
+    int port = svr.bind_to_any_port("localhost");
+    ASSERT_TRUE(port > 0);
+    svr.stop();
+}
+
 class ServerTest : public ::testing::Test {
 protected:
     ServerTest()


### PR DESCRIPTION
This fixes #46 by allowing the user to separate the port bind from the
blocking listen(). Two new API functions bind_to_any_port() (which
returns the system-assigned port) and listen_after_bind() are equivalent
to the existing listen().