### PR TITLE
Read \r\n terminator after chunked encoding

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -828,6 +828,12 @@ bool read_content_chunked(Stream& strm, T& x)
         chunk_len = std::stoi(reader.ptr(), 0, 16);
     }
 
+    if (chunk_len == 0) {
+        // Reader terminator after chunks
+        if (!reader.getline() || strcmp(reader.ptr(), "\r\n"))
+            return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
I believe according to https://en.wikipedia.org/wiki/Chunked_transfer_encoding, after the terminating zero-sized chunk of "0\r\n", there's an additional "\r\n" that should be read.

(I was seeing 400 errors due to this following a chunked upload because the server would try to dispatch an empty method+resource due to the additional blank line.)