### PR TITLE
Don't fail chunked read if buffer not yet filled

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -817,10 +817,8 @@ bool read_content_chunked(Stream& strm, std::string& out)
     auto chunk_len = std::stoi(reader.ptr(), 0, 16);
 
     while (chunk_len > 0){
-        std::string chunk(chunk_len, 0);
-
-        auto n = strm.read(&chunk[0], chunk_len);
-        if (n <= 0) {
+        std::string chunk;
+        if (!read_content_with_length(strm, chunk, chunk_len, nullptr)) {
             return false;
         }
 


### PR DESCRIPTION
I found on large chunked uploads on Windows 7, the buffer might not yet have received the entire chunk's data. Instead of bailing when all the bytes aren't available, I believe this needs to loop until the full specified size has been read, or the read returns -1.

(Perhaps a looping read should be in a lower level helper function? I'm not certain if there's other places this might realistically be needed.)