### PR TITLE
Fix compilation error with musl libc

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -61,6 +61,7 @@ typedef int socket_t;
 #include <string>
 #include <thread>
 #include <sys/stat.h>
+#include <sys/select.h>
 #include <fcntl.h>
 #include <assert.h>
 

--- a/httplib.h
+++ b/httplib.h
@@ -48,6 +48,7 @@ typedef SOCKET socket_t;
 #include <arpa/inet.h>
 #include <signal.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 
 typedef int socket_t;
 #endif
@@ -61,7 +62,6 @@ typedef int socket_t;
 #include <string>
 #include <thread>
 #include <sys/stat.h>
-#include <sys/select.h>
 #include <fcntl.h>
 #include <assert.h>
 


### PR DESCRIPTION
Compiling cpp-httplib with musl clib caused errors about missing types.
Adding the `<sys/select.h>` header fixes the issues.

Below is the gcc 6.4.0 output


```
/src/lib/httplib.h: In function 'int httplib::detail::select_read(socket_t, size_t, size_t)':
/src/lib/httplib.h:425:3: error: 'fd_set' was not declared in this scope
   fd_set fds;
   ^~~~~~
/src/lib/httplib.h:426:12: error: 'fds' was not declared in this scope
   FD_ZERO(&fds);
            ^~~
/src/lib/httplib.h:426:15: error: 'FD_ZERO' was not declared in this scope
   FD_ZERO(&fds);
               ^
/src/lib/httplib.h:427:20: error: 'FD_SET' was not declared in this scope
   FD_SET(sock, &fds);
                    ^
/src/lib/httplib.h:429:3: error: 'timeval' was not declared in this scope
   timeval tv;
   ^~~~~~~
/src/lib/httplib.h:430:3: error: 'tv' was not declared in this scope
   tv.tv_sec = sec;
   ^~
/src/lib/httplib.h:433:48: error: 'select' was not declared in this scope
   return select(sock + 1, &fds, NULL, NULL, &tv);
                                                ^
/src/lib/httplib.h: In function 'bool httplib::detail::is_socket_writable(socket_t, size_t, size_t)':
/src/lib/httplib.h:438:3: error: 'fd_set' was not declared in this scope
   fd_set fdsw;
   ^~~~~~
/src/lib/httplib.h:439:12: error: 'fdsw' was not declared in this scope
   FD_ZERO(&fdsw);
            ^~~~
/src/lib/httplib.h:439:16: error: 'FD_ZERO' was not declared in this scope
   FD_ZERO(&fdsw);
                ^
/src/lib/httplib.h:440:21: error: 'FD_SET' was not declared in this scope
   FD_SET(sock, &fdsw);
                     ^
/src/lib/httplib.h:442:10: error: expected ';' before 'fdse'
   fd_set fdse;
          ^~~~
/src/lib/httplib.h:443:12: error: 'fdse' was not declared in this scope
   FD_ZERO(&fdse);
            ^~~~
/src/lib/httplib.h:446:3: error: 'timeval' was not declared in this scope
   timeval tv;
   ^~~~~~~
/src/lib/httplib.h:447:3: error: 'tv' was not declared in this scope
   tv.tv_sec = sec;
   ^~
/src/lib/httplib.h:450:47: error: 'select' was not declared in this scope
   if (select(sock + 1, NULL, &fdsw, &fdse, &tv) <= 0) {
                                               ^
/src/lib/httplib.h:454:30: error: 'FD_ISSET' was not declared in this scope
   return FD_ISSET(sock, &fdsw) != 0;
                              ^
```