### PR TITLE
Fixed bound checks for #74

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1001,9 +1001,9 @@ inline std::string decode_url(const std::string& s)
 {
     std::string result;
 
-    for (size_t i = 0; s[i]; i++) {
+    for (size_t i = 0; i < s.size(); i++) {
         if (s[i] == '%' && i + 1 < s.size()) {
-            if (s[i + 1] && s[i + 1] == 'u') {
+            if (s[i + 1] == 'u') {
                 int val = 0;
                 if (from_hex_to_i(s, i + 2, 4, val)) {
                     // 4 digits Unicode codes


### PR DESCRIPTION
Thank you for your quick reactions. However, I'm afraid 2bb27aa25d51020ad8b3570c880530ba0bff833b to fix #74 is a little bit incomplete. Checking `s[i]` in the for loop does not appear to suffice, because for example the line ` i += 5; // 'u0000'`  will cause an out-of-bounds access on the next iteration.

 Please consider the following patch.