### PR TITLE
Fix Keep-Alive behavior and http version parsing

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1528,7 +1528,7 @@ inline bool Server::parse_request_line(const char* s, Request& req)
 
     std::cmatch m;
     if (std::regex_match(s, m, re)) {
-        req.version = std::string(m[4]);
+        req.version = std::string(m[5]);
         req.method = std::string(m[1]);
         req.target = std::string(m[2]);
         req.path = detail::decode_url(m[3]);

--- a/httplib.h
+++ b/httplib.h
@@ -1560,9 +1560,13 @@ inline void Server::write_response(Stream& strm, bool last_connection, const Req
 
     // Headers
     if (last_connection ||
-        req.version == "HTTP/1.0" ||
         req.get_header_value("Connection") == "close") {
         res.set_header("Connection", "close");
+    }
+    
+    if (!last_connection &&
+        req.get_header_value("Connection") == "Keep-Alive") {
+        res.set_header("Connection", "Keep-Alive");
     }
 
     if (!res.body.empty()) {


### PR DESCRIPTION
First of all, thank you for your work. 
I was testing a simple app based on your server and found two issues. First one, I beleive, is a typo: after regex matching you're looking for a protocol version in m[4] while it resides in m[5]. Second one addresses Keep-Alive behavior. I was sending requests with ApacheBenchmark (ab) utility. AB is able to utilize Keep-Alive connections, but being HTTP/1.0 client it requires "Connection: Keep-Alive" explicitly specified in response header. Neither it received "Connection: close", so ab just waited for whole 5 seconds on each request. Also I believe it's not correct to set "Connection: close" in response to each HTTP/1.0 request as it is now in [write_response](https://github.com/yhirose/cpp-httplib/blob/222f49a1252b0dc289818dfb9b4c67bb5dbd6715/httplib.h#L1563). Thankfully it wasn't working because of the first issue :)
So my proposal is to set close, if close was requested or if we're about to close according to last_connection. And to set Keep-Alive if it was requested and it's not the last connection.