### PR TITLE
Request cancelation feature

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -107,7 +107,7 @@ std::pair<std::string, std::string> make_range_header(uint64_t value, Args... ar
 
 typedef std::multimap<std::string, std::string>                Params;
 typedef std::smatch                                            Match;
-typedef std::function<void (uint64_t current, uint64_t total)> Progress;
+typedef std::function<bool (uint64_t current, uint64_t total)> Progress;
 
 struct MultipartFile {
     std::string filename;
@@ -804,7 +804,9 @@ inline bool read_content_with_length(Stream& strm, std::string& out, size_t len,
         r += n;
 
         if (progress) {
-            progress(r, len);
+            if (!progress(r, len)) {
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
This commit modifies the signature of the `Progress` callback so that its return value will indicate whether the request shall continue to be processed by returning `true`, or if it shall be aborted by returning `false`. Such modification will allow one to cancel an ongoing request before it has completed.

When migrating, developers should modify there `Progress` callbacks to always return `true` by default in case there do not want to benefit from the cancelation feature.

A few unit tests use cases were provided, but anyone should feel free to provide additional uses cases that they find relevant.
