### PR TITLE
travis and appveyor configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Release
 ipch
 *.dSYM
 .*
+!/.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# Environment
+language: cpp
+os: osx
+
+# Compiler selection
+compiler:
+  - clang
+
+# Build/test steps
+script: 
+  - cd ${TRAVIS_BUILD_DIR}/test
+  - make all

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+build_script:
+- cmd: >-
+    cd test
+
+    msbuild.exe test.sln /verbosity:minimal /t:Build /p:Configuration=Debug;Platform=Win32
+test_script:
+- cmd: Debug\test.exe


### PR DESCRIPTION
This will need some extra work, you have to register the project on https://travis.ci.org and https://ci.appveyor.com for this to trigger. Currently it will build+test on Windows+macOS (because std::regex doesn't appear to be working on ubuntu 14).

Once the projects are created badges can be added to the README