### PR TITLE
Set response content-length of zero to prevent client hangs

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1643,6 +1643,11 @@ inline void Server::write_response(Stream& strm, bool last_connection, const Req
         res.set_header("Connection", "Keep-Alive");
     }
 
+    /* Set length even if it's empty - connections sometimes hang if no length
+       given with an empty response */
+    auto length = std::to_string(res.body.size());
+    res.set_header("Content-Length", length.c_str());
+
     if (!res.body.empty()) {
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
         // TODO: 'Accpet-Encoding' has gzip, not gzip;q=0
@@ -1657,9 +1662,6 @@ inline void Server::write_response(Stream& strm, bool last_connection, const Req
         if (!res.has_header("Content-Type")) {
             res.set_header("Content-Type", "text/plain");
         }
-
-        auto length = std::to_string(res.body.size());
-        res.set_header("Content-Length", length.c_str());
     } else if (res.streamcb) {
         // Streamed response
         bool chunked_response = !res.has_header("Content-Length");


### PR DESCRIPTION
If we have an empty body, the content length doesn't get set. This can cause hangs in some clients, for example, curl. A simple program to illustrate:

```cpp
#include "httplib.h"

using namespace httplib;

int main()
{
    Server svr;

    svr.Get("/", [](const Request &req, Response &res)
    {
        res.status = 200;
    });

    svr.listen("127.0.0.1", 1234);
}
```

If we then perform `curl http://127.0.0.1:1234 -v` - We can see:

```
< HTTP/1.1 200 OK
* no chunk, no close, no size. Assume close to signal end
< 
* Closing connection 0
```

On my machine, this hangs for approximately 3 or so seconds.
If you then apply the patch in my PR, and try again, it should complete instantly:

```
< HTTP/1.1 200 OK
< Content-Length: 0
< 
* Connection #0 to host 127.0.0.1 left intact
```

Environment: Arch Linux 4.19.1, Curl 7.62.0