### PR TITLE
Removed port from http Header var: Host. Fixes #112 amazonaws reject

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2036,7 +2036,7 @@ inline void Client::write_request(Stream& strm, Request& req)
         path.c_str());
 
     // Headers
-    req.set_header("Host", host_and_port_.c_str());
+    req.set_header("Host", host_.c_str());
 
     if (!req.has_header("Accept")) {
         req.set_header("Accept", "*/*");


### PR DESCRIPTION
With this solution the cpp-httplib becomes able to successfully speak with amazonaws servers.

In my case, I can't observe any problems, if the httplib won't send the port with the Host Header variable.
Therefore I propose to remove it, to be able to speak with amazonaws servers (see #112 File Download Problem).

Another solution might be to make this detail configurable in the `Get` method.
I don't know what might be the nicest solution.