### PR TITLE
Fix build warning with Boost::asio

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -29,7 +29,9 @@
 #define S_ISDIR(m)  (((m)&S_IFDIR)==S_IFDIR)
 #endif //S_ISDIR
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif //NOMINMAX
 
 #include <io.h>
 #include <winsock2.h>


### PR DESCRIPTION
This commit fixes a minor build warning if including boost::asio before cpp-httplib:

1>c:\\...\src\httplib.h(32): warning C4005: 'NOMINMAX': macro redefinition (compiling source file src\APIManager.cpp)
1>C:\\...\boost_1_67_0\boost/asio/detail/config.hpp(954): note: see previous definition of 'NOMINMAX' 