### PR TITLE
Add WinSock2 dependency

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -37,6 +37,8 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
+#pragma comment(lib, "ws2_32.lib")
+
 #ifndef strcasecmp
 #define strcasecmp _stricmp
 #endif //strcasecmp


### PR DESCRIPTION
The library uses WinSock2 on Windows. So, you need to link ws2_32.lib manually to projects, that use the library. I suggest you use pragma comment directive to tell linker to add WinSock2 as dependency. So, the library can be used without additional actions on Windows with VS compiler.