### PR TITLE
Update httplib.h

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -88,7 +88,7 @@ typedef int socket_t;
 #define CPPHTTPLIB_KEEPALIVE_TIMEOUT_USECOND 0
 #define CPPHTTPLIB_KEEPALIVE_MAX_COUNT 5
 #define CPPHTTPLIB_REQUEST_URI_MAX_LENGTH 8192
-#define CPPHTTPLIB_PAYLOAD_MAX_LENGTH std::numeric_limits<uint64_t>::max()
+#define CPPHTTPLIB_PAYLOAD_MAX_LENGTH std::numeric_limits<size_t>::max()
 
 namespace httplib {
 


### PR DESCRIPTION
CPPHTTPLIB_PAYLOAD_MAX_LENGTH is only used in one place, that is to initialize payload_max_length_. Because payload_max_length_ is a size_t, attempts to intialize it with a 64 bit integer max will generate warnings, notably on 32 bit compilers. Changing the max to the same size as the target resolves that, and this should be no risk.