### PR TITLE
Fixed data race when stopping server

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@
 CC = clang++
 #CC = g++
 
-CFLAGS = -ggdb -O0 -std=c++11 -DGTEST_USE_OWN_TR1_TUPLE -I.. -I. -Wall -Wextra -Wtype-limits
+CFLAGS = -ggdb -O0 -std=c++11 -DGTEST_USE_OWN_TR1_TUPLE -I.. -I. -Wall -Wextra -Wtype-limits -fsanitize=thread
 OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib -lssl -lcrypto
 ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz
 


### PR DESCRIPTION
This should address (at least part of) the issue: Race condition between listen and stop, fortify failure #160