### PR TITLE
Made svr_sock_ and is_running_ variables atomic

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -70,6 +70,7 @@ typedef int socket_t;
 #include <string>
 #include <sys/stat.h>
 #include <thread>
+#include <atomic>
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 #include <openssl/err.h>
@@ -285,8 +286,8 @@ private:
 
   virtual bool read_and_close_socket(socket_t sock);
 
-  bool is_running_;
-  socket_t svr_sock_;
+  std::atomic<bool> is_running_;
+  std::atomic<socket_t> svr_sock_;
   std::string base_dir_;
   Handlers get_handlers_;
   Handlers post_handlers_;
@@ -1587,8 +1588,7 @@ inline bool Server::is_running() const { return is_running_; }
 inline void Server::stop() {
   if (is_running_) {
     assert(svr_sock_ != INVALID_SOCKET);
-    auto sock = svr_sock_;
-    svr_sock_ = INVALID_SOCKET;
+    std::atomic<socket_t> sock (svr_sock_.exchange(INVALID_SOCKET));
     detail::shutdown_socket(sock);
     detail::close_socket(sock);
   }


### PR DESCRIPTION
As discussed in our last email, here the last try, I will do to ensure that there is no data race condition. This is related to issue #160, which was closed, but the clang sanitizers still issued a warning for an existing data race. Hope, this fixes that. And thanks for the fantastic work on this library.