### PR TITLE
fix the example Makefile

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,6 +1,6 @@
 
 #CXX = clang++
-CXXFLAGS = -std=c++14 -I.. -Wall -Wextra -lpthread
+CXXFLAGS = -std=c++14 -I.. -Wall -Wextra -pthread
 OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib -lssl -lcrypto
 ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz
 


### PR DESCRIPTION
on my computer, if i use the makefile to make the examples, there will be some errors like:

> g++ -o server -std=c++14 -I.. -Wall -Wextra -lpthread server.cc -DCPPHTTPLIB_OPENSSL_SUPPORT -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib -lssl -lcrypto -DCPPHTTPLIB_ZLIB_SUPPORT -lz
> /tmp/cc9x6vP1.o: In function `std::thread::thread<httplib::Server::listen_internal()::{lambda()#1}>(httplib::Server::listen_internal()::{lambda()#1}&&)':
> server.cc:
> (.text._ZNSt6threadC2IZN7httplib6Server15listen_internalEvEUlvE_JEEEOT_DpOT0_[_ZNSt6threadC5IZN7httplib6Server15listen_internalEvEUlvE_JEEEOT_DpOT0_]+0x30): undefined reference to `pthread_create'
> collect2: error: ld returned 1 exit status
> Makefile:10: recipe for target 'server' failed
> make: *** [server] Error 1

it is caused by the makefile in line 3, where there is a "-lpthread". By changing the "-lpthread" to "-pthread" can fix this problem.
After that everything goes well.