### PR TITLE
Add ssl_context member function to SSLClient

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -706,6 +706,8 @@ public:
 
   long get_openssl_verify_result() const;
 
+  SSL_CTX* ssl_context() const noexcept;
+
 private:
   virtual bool process_and_close_socket(
       socket_t sock, size_t request_count,
@@ -3480,6 +3482,10 @@ inline void SSLClient::enable_server_certificate_verification(bool enabled) {
 
 inline long SSLClient::get_openssl_verify_result() const {
   return verify_result_;
+}
+
+inline SSL_CTX* SSLClient::ssl_context() const noexcept {
+	return ctx_;
 }
 
 inline bool SSLClient::process_and_close_socket(


### PR DESCRIPTION
Access to the underlying SSL_CTX struct can be quite useful if you dont want to ship a cert with your application and instead want to load the windows cert store. Example code looks like this

```c++
void load_win_cert_store(const SSL_CTX* ssl_ctx)
{
	PCCERT_CONTEXT win_cert_context{};
	X509_STORE* x509_store = SSL_CTX_get_cert_store(ssl_ctx);
	HCERTSTORE store = CertOpenSystemStoreA(NULL, "ROOT");

	if (!store) return;

	while (win_cert_context = CertEnumCertificatesInStore(store, win_cert_context)) {
		X509* x509{};
		const unsigned char* encoded_cert = win_cert_context->pbCertEncoded;
		x509 = d2i_X509(NULL, &encoded_cert, win_cert_context->cbCertEncoded);
		if (x509) {
			X509_STORE_add_cert(x509_store, x509);
			X509_free(x509);
		}
	}
	CertCloseStore(store, 0);
}
```