### PR TITLE
Fix compile error in android ndk

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2773,7 +2773,7 @@ inline bool Client::send(const std::vector<Request> &requests,
 
     if (!process_and_close_socket(
             sock, requests.size() - i,
-            [&](Stream &strm, bool last_connection, bool &connection_close) {
+            [&](Stream &strm, bool last_connection, bool &connection_close) -> bool {
               auto &req = requests[i];
               auto res = Response();
               i++;


### PR DESCRIPTION
Fix a compile error in android NDK.

httplib.h:2794:11: error: return type 'bool' must match previous return type 'int' when lambda expression has unspecified explicit return type
            return ret;
            ^

I'm not familiar with c++,try to declare the  lambda function returns a bool can fix the error.

Looks like a [C++11 restrictions on lambda return type:](https://stackoverflow.com/questions/26692637/c11-restrictions-on-lambda-return-type)



PS:My Android NDK Project using C++11 and clang tool chain.

