### PR TITLE
Fix a test, ConnectionErrorTest::InvalidPort. 

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -335,7 +335,7 @@ TEST(RangeTest, FromHTTPBin) {
 }
 
 TEST(ConnectionErrorTest, InvalidHost) {
-  auto host = "abcde.com";
+  auto host = "-abcde.com";
   auto sec = 2;
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT


### PR DESCRIPTION
currently, the `abcde.com` is valid, so I change it. The hyphen is not permitted at the first byte in hostname.