### PR TITLE
added server streamhandler to handle large post data. 

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,7 +1,9 @@
 
 #CXX = clang++
 CXXFLAGS = -std=c++14 -I.. -Wall -Wextra -pthread
-OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib -lssl -lcrypto
+#OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib -lssl -lcrypto
+#OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -lssl -lcrypto
+OPENSSL_SUPPORT =
 ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz
 
 all: server client hello simplesvr redirect benchmark

--- a/example/simplesvr.cc
+++ b/example/simplesvr.cc
@@ -109,6 +109,22 @@ int main(int argc, const char **argv) {
     res.set_content(body, "text/plain");
   });
 
+  svr.Post("/multi2", [](Stream& strm, const Request &req, Response &res) {
+    std::string rsp="req body stream is :\n";
+
+    detail::read_content(
+        strm, req, std::numeric_limits<size_t>::max(), res.status
+    ,   req.progress, [&rsp] (const char *buf, size_t n){
+            rsp+="cut(";
+            rsp.append(buf,n);
+            rsp+=")\n";
+            return true;
+        }
+    );
+
+    res.set_content(rsp, "text/plain");
+  });
+
   svr.set_error_handler([](const Request & /*req*/, Response &res) {
     const char *fmt = "<p>Error Status: <span style='color:red;'>%d</span></p>";
     char buf[BUFSIZ];


### PR DESCRIPTION
It is now possible to register a stream handler which has access to the request stream.
The handler is able to call read_content on the stream with its own handler.
Updated simplesvr example