### PR TITLE
Fix suppressed Response class objects moving

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -300,7 +300,7 @@ struct Request {
 
 struct Response {
   std::string version;
-  int status;
+  int status = -1;
   Headers headers;
   std::string body;
 
@@ -324,8 +324,11 @@ struct Response {
       std::function<void(size_t offset, DataSink &sink)> provider,
       std::function<void()> resource_releaser = [] {});
 
-  Response() : status(-1), content_length(0) {}
-
+  Response() = default;
+  Response(const Response&) = default;
+  Response& operator=(const Response&) = default;
+  Response(Response&&) = default;
+  Response& operator=(Response&&) = default;
   ~Response() {
     if (content_provider_resource_releaser) {
       content_provider_resource_releaser();
@@ -333,7 +336,7 @@ struct Response {
   }
 
   // private members...
-  size_t content_length;
+  size_t content_length = 0;
   ContentProvider content_provider;
   std::function<void()> content_provider_resource_releaser;
 };


### PR DESCRIPTION
I have found that each time when we want to move `Response` class objects copying operation is executed.  For instance,
```
...
    if (!process_and_close_socket(sock, requests.size() - i,
                                  [&](Stream &strm, bool last_connection,
                                      bool &connection_close) -> bool {
                                    auto &req = requests[i++];
                                    auto res = Response();
                                    auto ret = handle_request(strm, req, res,
                                                              last_connection,
                                                              connection_close);
                                    if (ret) {
                                      responses.emplace_back(std::move(res));
                                    }
...
```

There is an used defined `~Response()` destructor. It causes compiler to suppress the default move constructor/ assigment generation and as a result the optimization is missed. See more details [here](https://www.modernescpp.com/index.php/c-core-guidelines-constructors-assignments-and-desctructors).