### PR TITLE
std::thread::hardware_concurrency

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -49,7 +49,9 @@
 #endif
 
 #ifndef CPPHTTPLIB_THREAD_POOL_COUNT
-#define CPPHTTPLIB_THREAD_POOL_COUNT (std::thread::hardware_concurrency())
+// if hardware_concurrency() outputs 0 we still wants to use threads for this.
+// -1 because we have one thread already in the main function.
+#define CPPHTTPLIB_THREAD_POOL_COUNT std::thread::hardware_concurrency() ? std::thread::hardware_concurrency()-1 : 2
 #endif
 
 /*


### PR DESCRIPTION
If std::thread::hardware_concurrency is 0 use 2 threads. Also -1 thread because we already have one thread from the main function.