### PR TITLE
Fix issue with Windows getnameinfo

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1545,7 +1545,7 @@ inline std::string get_remote_addr(socket_t sock) {
     std::array<char, NI_MAXHOST> ipstr{};
 
     if (!getnameinfo(reinterpret_cast<struct sockaddr *>(&addr), len,
-                     ipstr.data(), ipstr.size(), nullptr, 0, NI_NUMERICHOST)) {
+                     ipstr.data(), static_cast<unsigned int>(ipstr.size()), nullptr, 0, NI_NUMERICHOST)) {
       return ipstr.data();
     }
   }


### PR DESCRIPTION
Converting from `size_t` to `DWORD` gives a compilation error: https://gist.github.com/bunnei/9c09b2853e8a3b5c7c66777d496192ca