### PR TITLE
Support for deflate compression

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1667,14 +1667,15 @@ inline bool compress(std::string &content) {
 class decompressor {
 public:
   decompressor() {
+    std::memset(&strm, 0, sizeof(strm));
     strm.zalloc = Z_NULL;
     strm.zfree = Z_NULL;
     strm.opaque = Z_NULL;
 
-    // 15 is the value of wbits, which should be at the maximum possible value
-    // to ensure that any gzip stream can be decoded. The offset of 16 specifies
-    // that the stream to decompress will be formatted with a gzip wrapper.
-    is_valid_ = inflateInit2(&strm, 16 + 15) == Z_OK;
+    // 31 is the value of wbits, which should be used for compression auto
+    // detection. In such mode zlib will be able to decompress both gzip
+    // and deflate data.
+    is_valid_ = inflateInit2(&strm, 32 + 15) == Z_OK;
   }
 
   ~decompressor() { inflateEnd(&strm); }
@@ -1872,12 +1873,14 @@ bool read_content(Stream &strm, T &x, size_t payload_max_length, int &status,
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
   decompressor decompressor;
 
-  if (!decompressor.is_valid()) {
-    status = 500;
-    return false;
-  }
+  std::string content_encoding = x.get_header_value("Content-Encoding");
+  if (content_encoding.find("gzip") != std::string::npos
+          || content_encoding.find("deflate") != std::string::npos) {
+    if (!decompressor.is_valid()) {
+      status = 500;
+      return false;
+    }
 
-  if (x.get_header_value("Content-Encoding") == "gzip") {
     out = [&](const char *buf, size_t n) {
       return decompressor.decompress(
           buf, n, [&](const char *buf, size_t n) { return receiver(buf, n); });

--- a/httplib.h
+++ b/httplib.h
@@ -1672,9 +1672,9 @@ public:
     strm.zfree = Z_NULL;
     strm.opaque = Z_NULL;
 
-    // 31 is the value of wbits, which should be used for compression auto
-    // detection. In such mode zlib will be able to decompress both gzip
-    // and deflate data.
+    // 15 is the value of wbits, which should be at the maximum possible value
+    // to ensure that any gzip stream can be decoded. The offset of 32 specifies
+    // that the stream type should be automatically detected either gzip or deflate.
     is_valid_ = inflateInit2(&strm, 32 + 15) == Z_OK;
   }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -1041,6 +1041,16 @@ TEST_F(ServerTest, GetMethod200) {
   EXPECT_EQ("Hello World!", res->body);
 }
 
+TEST_F(ServerTest, GetMethod200withPercentEncoding) {
+  auto res = cli_.Get("/%68%69"); // auto res = cli_.Get("/hi");
+  ASSERT_TRUE(res != nullptr);
+  EXPECT_EQ("HTTP/1.1", res->version);
+  EXPECT_EQ(200, res->status);
+  EXPECT_EQ("text/plain", res->get_header_value("Content-Type"));
+  EXPECT_EQ(1, res->get_header_value_count("Content-Type"));
+  EXPECT_EQ("Hello World!", res->body);
+}
+
 TEST_F(ServerTest, GetMethod302) {
   auto res = cli_.Get("/");
   ASSERT_TRUE(res != nullptr);
@@ -1695,6 +1705,19 @@ TEST_F(ServerTest, PutLargeFileWithGzip) {
   EXPECT_EQ(200, res->status);
   EXPECT_EQ(LARGE_DATA, res->body);
 }
+
+TEST_F(ServerTest, PutContentWithDeflate) {
+  cli_.set_compress(false);
+  httplib::Headers headers;
+  headers.emplace("Content-Encoding", "deflate");
+  // PUT in deflate format:
+  auto res = cli_.Put("/put", headers, "\170\234\013\010\015\001\0\001\361\0\372", "text/plain");
+
+  ASSERT_TRUE(res != nullptr);
+  EXPECT_EQ(200, res->status);
+  EXPECT_EQ("PUT", res->body);
+}
+
 #endif
 
 TEST_F(ServerTest, Patch) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -1041,16 +1041,6 @@ TEST_F(ServerTest, GetMethod200) {
   EXPECT_EQ("Hello World!", res->body);
 }
 
-TEST_F(ServerTest, GetMethod200withPercentEncoding) {
-  auto res = cli_.Get("/%68%69"); // auto res = cli_.Get("/hi");
-  ASSERT_TRUE(res != nullptr);
-  EXPECT_EQ("HTTP/1.1", res->version);
-  EXPECT_EQ(200, res->status);
-  EXPECT_EQ("text/plain", res->get_header_value("Content-Type"));
-  EXPECT_EQ(1, res->get_header_value_count("Content-Type"));
-  EXPECT_EQ("Hello World!", res->body);
-}
-
 TEST_F(ServerTest, GetMethod302) {
   auto res = cli_.Get("/");
   ASSERT_TRUE(res != nullptr);


### PR DESCRIPTION
As long as httplib has gzip support it is easy to add deflate. I did it with automatic encoding detection because some clients could compress content with GZip and to set deflate compression instead of correct gzip.

As a discussion starting point, I'd like to add ContentTranscoder abstraction to encode and decode custom streams, like LZ4, Snappy, etc.