### PR TITLE
Remove code duplication in converting params to query

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2072,6 +2072,19 @@ inline std::string decode_url(const std::string &s) {
   return result;
 }
 
+inline std::string params_to_query_str(const Params &params) {
+  std::string query;
+
+  for (auto it = params.begin(); it != params.end(); ++it) {
+    if (it != params.begin()) { query += "&"; }
+    query += it->first;
+    query += "=";
+    query += detail::encode_url(it->second);
+  }
+
+  return query;
+}
+
 inline void parse_query_text(const std::string &s, Params &params) {
   split(&s[0], &s[s.size()], '&', [&](const char *b, const char *e) {
     std::string key;
@@ -4112,15 +4125,10 @@ Client::Post(const char *path, const Headers &headers, size_t content_length,
                                     content_type);
 }
 
+
 inline std::shared_ptr<Response>
 Client::Post(const char *path, const Headers &headers, const Params &params) {
-  std::string query;
-  for (auto it = params.begin(); it != params.end(); ++it) {
-    if (it != params.begin()) { query += "&"; }
-    query += it->first;
-    query += "=";
-    query += detail::encode_url(it->second);
-  }
+  std::string query = detail::params_to_query_str(params);
 
   return Post(path, headers, query, "application/x-www-form-urlencoded");
 }
@@ -4193,13 +4201,7 @@ inline std::shared_ptr<Response> Client::Put(const char *path,
 
 inline std::shared_ptr<Response>
 Client::Put(const char *path, const Headers &headers, const Params &params) {
-  std::string query;
-  for (auto it = params.begin(); it != params.end(); ++it) {
-    if (it != params.begin()) { query += "&"; }
-    query += it->first;
-    query += "=";
-    query += detail::encode_url(it->second);
-  }
+  std::string query = detail::params_to_query_str(params);
 
   return Put(path, headers, query, "application/x-www-form-urlencoded");
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -77,6 +77,21 @@ TEST(ParseQueryTest, ParseQueryString) {
   EXPECT_EQ("val3", dic.find("key3")->second);
 }
 
+TEST(ParamsToQueryTest, ConvertParamsToQuery) {
+    Params dic;
+
+    EXPECT_EQ(detail::params_to_query_str(dic), "");
+
+    dic.emplace("key1", "val1");
+
+    EXPECT_EQ(detail::params_to_query_str(dic), "key1=val1");
+
+    dic.emplace("key2", "val2");
+    dic.emplace("key3", "val3");
+
+    EXPECT_EQ(detail::params_to_query_str(dic), "key1=val1&key2=val2&key3=val3");
+}
+
 TEST(GetHeaderValueTest, DefaultValue) {
   Headers headers = {{"Dummy", "Dummy"}};
   auto val = detail::get_header_value(headers, "Content-Type", 0, "text/plain");


### PR DESCRIPTION
I have extracted a free function for converting `Params` to query string and added a unit test.