### PR TITLE
Accept content by value to allow moving

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -313,7 +313,7 @@ struct Response {
 
   void set_redirect(const char *url);
   void set_content(const char *s, size_t n, const char *content_type);
-  void set_content(const std::string &s, const char *content_type);
+  void set_content(std::string s, const char *content_type);
 
   void set_content_provider(
       size_t length,
@@ -2736,9 +2736,9 @@ inline void Response::set_content(const char *s, size_t n,
   set_header("Content-Type", content_type);
 }
 
-inline void Response::set_content(const std::string &s,
+inline void Response::set_content(std::string s,
                                   const char *content_type) {
-  body = s;
+  body = std::move(s);
   set_header("Content-Type", content_type);
 }
 


### PR DESCRIPTION
Previously, calling set_content always resulted in 's' being copied. With this change, there will still be the same number of copies made (1) when doing `set_content(my_value, ...)`, but there will be no copies if a caller elects to do `set_content(std::move(value), ...)` or `set_content(some_function_that_returns_a_temporary(), ...)` instead.