### PR TITLE
add http status code 201 to show the right status message in return headers

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1599,6 +1599,7 @@ inline const char *status_message(int status) {
   switch (status) {
   case 100: return "Continue";
   case 200: return "OK";
+  case 201: return "Created";
   case 202: return "Accepted";
   case 204: return "No Content";
   case 206: return "Partial Content";


### PR DESCRIPTION
I need to return the http status code 201. As of now, the corresponding message is "Internal Server Error". I propose this code to show the right message for status code 201.

https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_Success