### PR TITLE
SSL_shutdown() only if not already closed by remote

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4397,7 +4397,9 @@ inline bool process_and_close_socket_ssl(
     }
   }
 
-  SSL_shutdown(ssl);
+  if (ret) {
+    SSL_shutdown(ssl);		// shutdown only if not already closed by remote
+  }
   {
     std::lock_guard<std::mutex> guard(ctx_mutex);
     SSL_free(ssl);


### PR DESCRIPTION
This fixes SIGPIPE on SSL_shutdown() in case the connection has already been closed by the remote host.