### PR TITLE
Add inline to set_ca_cert_store

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4756,7 +4756,7 @@ inline void SSLClient::set_ca_cert_path(const char *ca_cert_file_path,
   if (ca_cert_dir_path) { ca_cert_dir_path_ = ca_cert_dir_path; }
 }
 
-void SSLClient::set_ca_cert_store(X509_STORE *ca_cert_store) {
+inline void SSLClient::set_ca_cert_store(X509_STORE *ca_cert_store) {
   if (ca_cert_store) { ca_cert_store_ = ca_cert_store; }
 }
 


### PR DESCRIPTION
Fixes:
```
[build] core.lib(server.obj) : error LNK2005: "public: void __cdecl httplib::SSLClient::set_ca_cert_store(struct x509_store_st *)" (?set_ca_cert_store@SSLClient@httplib@@QEAAXPEAUx509_store_st@@@Z) already defined in image.obj [C:\Projects\vvctre\build\src\vvctre\vvctre.vcxproj]
[build] core.lib(service.obj) : error LNK2005: "public: void __cdecl httplib::SSLClient::set_ca_cert_store(struct x509_store_st *)" (?set_ca_cert_store@SSLClient@httplib@@QEAAXPEAUx509_store_st@@@Z) already defined in image.obj [C:\Projects\vvctre\build\src\vvctre\vvctre.vcxproj]
[build] core.lib(http_c.obj) : error LNK2005: "public: void __cdecl httplib::SSLClient::set_ca_cert_store(struct x509_store_st *)" (?set_ca_cert_store@SSLClient@httplib@@QEAAXPEAUx509_store_st@@@Z) already defined in image.obj [C:\Projects\vvctre\build\src\vvctre\vvctre.vcxproj]
```