### PR TITLE
Fix size_t convert to int WARNING with msvc14

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2908,12 +2908,12 @@ inline bool SocketStream::is_writable() const {
 }
 
 inline ssize_t SocketStream::read(char *ptr, size_t size) {
-  if (is_readable()) { return recv(sock_, ptr, size, 0); }
+  if (is_readable()) { return recv(sock_, ptr, (int)size, 0); }
   return -1;
 }
 
 inline ssize_t SocketStream::write(const char *ptr, size_t size) {
-  if (is_writable()) { return send(sock_, ptr, size, 0); }
+  if (is_writable()) { return send(sock_, ptr, (int)size, 0); }
   return -1;
 }
 


### PR DESCRIPTION
Fix size_t convert to int WARNING with msvc14

Modify:
httplib.h SocketStream::read
httplib.h SocketStream::write