### PR TITLE
TaskQueue method to internal size adjust

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -365,6 +365,7 @@ public:
   TaskQueue() = default;
   virtual ~TaskQueue() = default;
   virtual void enqueue(std::function<void()> fn) = 0;
+  virtual void queue_adjust() { };
   virtual void shutdown() = 0;
 };
 
@@ -3460,6 +3461,7 @@ inline bool Server::listen_internal() {
       auto val = detail::select_read(svr_sock_, 0, 100000);
 
       if (val == 0) { // Timeout
+        task_queue->queue_adjust();
         continue;
       }
 


### PR DESCRIPTION
I use a custom TaskQueue, with variable number of workers, adding workers on demand is an easy task when new connection arrive (in enqueue function) however i need another funtion to be called even (or better) went no new connections arrives to reduce workers count. I only added a new virtual method in TaskQueue class to allow custom class to adjust workers size over time. Even if this methods is called frequenlty custom class can keep a "last_update" counter to check if need to adjust worker count or any other internal task. Without this function i need an external thread to make this adjust task.