### PR TITLE
Fail to read a chunk if its length is >= ULONG_MAX

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1900,6 +1900,7 @@ inline bool read_content_chunked(Stream &strm, ContentReceiver out) {
     chunk_len = std::strtoul(line_reader.ptr(), &end_ptr, 16);
 
     if (end_ptr == line_reader.ptr()) { return false; }
+    if (chunk_len == ULONG_MAX) { return false; }
 
     if (chunk_len == 0) { break; }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -2343,6 +2343,20 @@ TEST(ServerRequestParsingTest, InvalidSecondChunkLengthInRequest) {
   EXPECT_EQ("HTTP/1.1 400 Bad Request", out.substr(0, 24));
 }
 
+TEST(ServerRequestParsingTest, ChunkLengthTooHighInRequest) {
+  std::string out;
+
+  test_raw_request(
+      "PUT /put_hi HTTP/1.1\r\n"
+      "Content-Type: text/plain\r\n"
+      "Transfer-Encoding: chunked\r\n"
+      "\r\n"
+      // Length is too large for 64 bits.
+      "1ffffffffffffffff\r\n"
+      "xyz\r\n", &out);
+  EXPECT_EQ("HTTP/1.1 400 Bad Request", out.substr(0, 24));
+}
+
 TEST(ServerStopTest, StopServerWithChunkedTransmission) {
   Server svr;
 


### PR DESCRIPTION
We cannot trivially support such large chunks, and the maximum value
std::strtoul can parse accurately is ULONG_MAX-1. Error out early if the
length is longer than that.