### PR TITLE
fix warning about send/recv and size_t on 64-bit windows compiler

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2936,12 +2936,20 @@ inline bool SocketStream::is_writable() const {
 }
 
 inline ssize_t SocketStream::read(char *ptr, size_t size) {
+#ifdef _WIN32
+  if (is_readable() && size <= std::numeric_limits<int>::max()) { return recv(sock_, ptr, static_cast<int>(size), 0); }
+#else
   if (is_readable()) { return recv(sock_, ptr, size, 0); }
+#endif
   return -1;
 }
 
 inline ssize_t SocketStream::write(const char *ptr, size_t size) {
+#ifdef _WIN32
+  if (is_writable() && size <= std::numeric_limits<int>::max()) { return send(sock_, ptr, static_cast<int>(size), 0); }
+#else
   if (is_writable()) { return send(sock_, ptr, size, 0); }
+#endif
   return -1;
 }
 

--- a/httplib.h
+++ b/httplib.h
@@ -2937,6 +2937,8 @@ inline bool SocketStream::is_writable() const {
 
 inline ssize_t SocketStream::read(char *ptr, size_t size) {
 #ifdef _WIN32
+#pragma warning( push )
+#pragma warning( disable : 4018 )
   if (is_readable() && size <= std::numeric_limits<int>::max()) { return recv(sock_, ptr, static_cast<int>(size), 0); }
 #else
   if (is_readable()) { return recv(sock_, ptr, size, 0); }
@@ -2947,6 +2949,7 @@ inline ssize_t SocketStream::read(char *ptr, size_t size) {
 inline ssize_t SocketStream::write(const char *ptr, size_t size) {
 #ifdef _WIN32
   if (is_writable() && size <= std::numeric_limits<int>::max()) { return send(sock_, ptr, static_cast<int>(size), 0); }
+#pragma warning( pop )
 #else
   if (is_writable()) { return send(sock_, ptr, size, 0); }
 #endif

--- a/httplib.h
+++ b/httplib.h
@@ -2937,9 +2937,11 @@ inline bool SocketStream::is_writable() const {
 
 inline ssize_t SocketStream::read(char *ptr, size_t size) {
 #ifdef _WIN32
-#pragma warning( push )
-#pragma warning( disable : 4018 )
-  if (is_readable() && size <= std::numeric_limits<int>::max()) { return recv(sock_, ptr, static_cast<int>(size), 0); }
+#pragma warning(push)
+#pragma warning(disable : 4018)
+  if (is_readable() && size <= std::numeric_limits<int>::max()) {
+    return recv(sock_, ptr, static_cast<int>(size), 0);
+  }
 #else
   if (is_readable()) { return recv(sock_, ptr, size, 0); }
 #endif
@@ -2948,8 +2950,10 @@ inline ssize_t SocketStream::read(char *ptr, size_t size) {
 
 inline ssize_t SocketStream::write(const char *ptr, size_t size) {
 #ifdef _WIN32
-  if (is_writable() && size <= std::numeric_limits<int>::max()) { return send(sock_, ptr, static_cast<int>(size), 0); }
-#pragma warning( pop )
+  if (is_writable() && size <= std::numeric_limits<int>::max()) {
+    return send(sock_, ptr, static_cast<int>(size), 0);
+  }
+#pragma warning(pop)
 #else
   if (is_writable()) { return send(sock_, ptr, size, 0); }
 #endif


### PR DESCRIPTION
Hi

I tried to fix 2 warnings I get when I am compiling httplib.h with Visual Studio 2019 - 64 bit compiler
Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28319 for x64

httplib.h(2939): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
httplib.h(2944): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data

because 'size' (which is of type size_t) is 64bit wide on this platform,
but send/recv even these days only take an int, which is 32bit wide.

What do you think about this ?