### PR TITLE
server: support dual-stack server socket

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1469,6 +1469,11 @@ socket_t create_socket(const char *host, int port, Fn fn,
     int yes = 1;
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char *>(&yes),
                sizeof(yes));
+
+    int no = 0;
+    setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<char *>(&no),
+               sizeof(no));
+
 #ifdef SO_REUSEPORT
     setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<char *>(&yes),
                sizeof(yes));


### PR DESCRIPTION
According to RFC 3493 the socket option IPV6_V6ONLY
should be off by default, see
https://tools.ietf.org/html/rfc3493#page-22 (chapter 5.3).

However this does not seem to be the case on all systems.
For instance on any Windows OS, the option is on by default.

Therefore clear this option in order to allow
an server socket which can support IPv6 and IPv4 at the same time.

Would this change be acceptable to you ?
Or should I make it configurable, using an #define or an param on the server class ?