### PR TITLE
keepalive: support multiple post using content provider

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -855,6 +855,21 @@ inline void Post(std::vector<Request> &requests, const char *path,
   Post(requests, path, Headers(), body, content_type);
 }
 
+inline void Post(std::vector<Request> &requests,
+     const char *path, size_t content_length,
+    ContentProvider content_provider, const char *content_type) {
+  Request req;
+  req.method = "POST";
+  req.headers = Headers();
+  req.path = path;
+  req.content_length = content_length;
+  req.content_provider = content_provider;
+
+  if (content_type) { req.headers.emplace("Content-Type", content_type); }
+
+  requests.emplace_back(std::move(req));
+}
+
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 class SSLServer : public Server {
 public:

--- a/test/test.cc
+++ b/test/test.cc
@@ -2088,6 +2088,7 @@ TEST_F(ServerTest, KeepAlive) {
   Get(requests, "/hi");
   Get(requests, "/not-exist");
   Post(requests, "/empty", "", "text/plain");
+  Post(requests, "/empty", 0, [&](size_t offset, size_t length, httplib::DataSink &sink){}, "text/plain");
 
   std::vector<Response> responses;
   auto ret = cli_.send(requests, responses);
@@ -2107,8 +2108,8 @@ TEST_F(ServerTest, KeepAlive) {
     EXPECT_EQ(404, res.status);
   }
 
-  {
-    auto &res = responses[4];
+  for (size_t i = 4; i < 6; i++) {
+    auto &res = responses[i];
     EXPECT_EQ(200, res.status);
     EXPECT_EQ("text/plain", res.get_header_value("Content-Type"));
     EXPECT_EQ("empty", res.body);


### PR DESCRIPTION
I would like to use your keepalive functionality in combination with an content provider doing POST.
It greatly increases the performance of my functionality :-)

I extended the related testcase with an simple additional step.
What do you think ?