### PR TITLE
Add meson subproject support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,8 @@
+project('cpp-httplib',
+    'cpp',
+    license : 'MIT',
+)
+
+httplib_dep = declare_dependency(
+    include_directories: include_directories('.')
+)


### PR DESCRIPTION
This PR add meson subproject support.
F.ex., place next wrap in your subprojects directory:
```
[wrap-git]
revision = head
url = https://github.com/smarttowel/cpp-httplib.git
```

In your `meson.build` add next lines:
```
httplib_proj = subproject('httplib')
httplib_dep = httplib_proj.get_variable('httplib_dep')
```
