### PR TITLE
add missing 'done' in write_request

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4112,7 +4112,9 @@ inline bool Client::write_request(Stream &strm, const Request &req,
         written_length = strm.write(d, l);
         offset += static_cast<size_t>(written_length);
       };
-      data_sink.is_writable = [&](void) { return strm.is_writable(); };
+      data_sink.is_writable = [&](void) {
+        return strm.is_writable() && written_length >= 0;
+      };
       data_sink.done = [&](void) { written_length = -1; };
 
       while (offset < end_offset) {

--- a/httplib.h
+++ b/httplib.h
@@ -4142,6 +4142,7 @@ inline std::shared_ptr<Response> Client::send_with_content_provider(
   if (compress_) {
     if (content_provider) {
       size_t offset = 0;
+      ssize_t written_length = 0;
 
       DataSink data_sink;
       data_sink.write = [&](const char *data, size_t data_len) {
@@ -4149,9 +4150,11 @@ inline std::shared_ptr<Response> Client::send_with_content_provider(
         offset += data_len;
       };
       data_sink.is_writable = [&](void) { return true; };
+      data_sink.done = [&](void) { written_length = -1; };
 
       while (offset < content_length) {
         content_provider(offset, content_length - offset, data_sink);
+        if (written_length < 0) { return nullptr; }
       }
     } else {
       req.body = body;

--- a/test/test.cc
+++ b/test/test.cc
@@ -1928,6 +1928,17 @@ TEST_F(ServerTest, PutWithContentProvider) {
   EXPECT_EQ("PUT", res->body);
 }
 
+TEST_F(ServerTest, PostWithContentProviderAbort) {
+  auto res = cli_.Post(
+      "/post", 42,
+      [](size_t /*offset*/, size_t /*length*/, httplib::DataSink &sink) {
+        sink.done();
+      },
+      "text/plain");
+
+  ASSERT_TRUE(res == nullptr);
+}
+
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
 TEST_F(ServerTest, PutWithContentProviderWithGzip) {
   cli_.set_compress(true);


### PR DESCRIPTION
DataSink::done was not assigned in write_request. 
Therefore it was not possible to call "done" in an content provider. 
I expected that should be the way to go, in case of failure to provide the content.
As an example, this could happen because the file to provide has vanished from disk in mean time. 
I tried to implement it the same way as in other places, I hope it makes sense to you ?