### PR TITLE
 A detail about Gzip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ cli.enable_server_certificate_verification(true);
 Zlib Support
 ------------
 
-'gzip' compression is available with `CPPHTTPLIB_ZLIB_SUPPORT`.
+'gzip' compression is available with `CPPHTTPLIB_ZLIB_SUPPORT`. `libz` should be linked.
 
 The server applies gzip compression to the following MIME type contents:
 

--- a/httplib.h
+++ b/httplib.h
@@ -241,18 +241,18 @@ public:
   using MultipartReader = std::function<bool(MultipartContentHeader header,
                                              ContentReceiver receiver)>;
 
-  ContentReader(Reader reader, MultipartReader muitlpart_reader)
-      : reader_(reader), muitlpart_reader_(muitlpart_reader) {}
+  ContentReader(Reader reader, MultipartReader multipart_reader)
+      : reader_(reader), multipart_reader_(multipart_reader) {}
 
   bool operator()(MultipartContentHeader header,
                   ContentReceiver receiver) const {
-    return muitlpart_reader_(header, receiver);
+    return multipart_reader_(header, receiver);
   }
 
   bool operator()(ContentReceiver receiver) const { return reader_(receiver); }
 
   Reader reader_;
-  MultipartReader muitlpart_reader_;
+  MultipartReader multipart_reader_;
 };
 
 using Range = std::pair<ssize_t, ssize_t>;


### PR DESCRIPTION
Just like for OpenSSL support (`libcrypto` and `libssl`), `libz` must be linked while building for Gzip support.