### PR TITLE
replace usage of [[deprecated]] with CPPHTTPLIB_DEPRECATED

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -780,7 +780,7 @@ public:
 
   void stop();
 
-  [[deprecated]] void set_timeout_sec(time_t timeout_sec);
+  CPPHTTPLIB_DEPRECATED void set_timeout_sec(time_t timeout_sec);
   void set_connection_timeout(time_t sec, time_t usec = 0);
   void set_read_timeout(time_t sec, time_t usec = 0);
   void set_write_timeout(time_t sec, time_t usec = 0);


### PR DESCRIPTION
Sorry, my previous PR missed this, since I was basing it off of v0.6.5 instead of master.