### PR TITLE
Add ability to parse the fragment part of an URI

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3693,7 +3693,7 @@ inline void Server::stop() {
 inline bool Server::parse_request_line(const char *s, Request &req) {
   const static std::regex re(
       "(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|PRI) "
-      "(([^?]+)(?:\\?(.*?))?(?:#(.*?))?) (HTTP/1\\.[01])\r\n");
+      "(([^?#]+)(?:\\?(.*?))?(?:#(.*?))?) (HTTP/1\\.[01])\r\n");
 
   std::cmatch m;
   if (std::regex_match(s, m, re)) {

--- a/httplib.h
+++ b/httplib.h
@@ -338,6 +338,7 @@ struct Request {
   // for server
   std::string version;
   std::string target;
+  std::string fragment;
   Params params;
   MultipartFormDataMap files;
   Ranges ranges;
@@ -3692,14 +3693,15 @@ inline void Server::stop() {
 inline bool Server::parse_request_line(const char *s, Request &req) {
   const static std::regex re(
       "(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|PRI) "
-      "(([^?]+)(?:\\?(.*?))?) (HTTP/1\\.[01])\r\n");
+      "(([^?]+)(?:\\?(.*?))?(?:#(.*?))?) (HTTP/1\\.[01])\r\n");
 
   std::cmatch m;
   if (std::regex_match(s, m, re)) {
-    req.version = std::string(m[5]);
+    req.version = std::string(m[6]);
     req.method = std::string(m[1]);
     req.target = std::string(m[2]);
     req.path = detail::decode_url(m[3], false);
+    req.fragment = detail::decode_url(m[5], true);
 
     // Parse query text
     auto len = std::distance(m[4].first, m[4].second);

--- a/test/test.cc
+++ b/test/test.cc
@@ -2378,7 +2378,7 @@ TEST(ServerRequestParsingTest, ParseFragmentWithParams)
     t.join();
 
     EXPECT_EQ(request.fragment, "fragment");
-    ASSERT_TRUE(request.params.size(), 2);
+    ASSERT_EQ(request.params.size(), 2);
     EXPECT_EQ(request.path, "/fooBar");
     EXPECT_EQ(request.target, "/fooBar?par1=val1&par2=val2#fragment");
     EXPECT_EQ(request.version, "HTTP/1.1");


### PR DESCRIPTION
Add ability to parse the fragment part of an URI (this is all stuff following the #-sign, e.g. http://foo.bar?var=value#anyfragment)