### PR TITLE
Use git to get full project version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,25 @@
 ]]
 cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
 
-# Get the user agent and use it as a version
-# This gets the string with the user agent from the header.
-# This is so the maintainer doesn't actually need to update this manually.
-file(STRINGS httplib.h _user_agent_match REGEX "User\-Agent.*cpp\-httplib/([0-9]+\.?)+")
-# Need to pull out just the version for use
-string(REGEX MATCH "([0-9]+\\.?)+" _httplib_version "${_user_agent_match}")
+# Gets the latest tag as a string like "v0.6.6"
+# Can silently fail if git isn't on the system
+execute_process(COMMAND git describe --tags --abbrev=0
+	OUTPUT_VARIABLE _raw_version_string
+	ERROR_VARIABLE _git_tag_error
+)
+
+# execute_process can fail silenty, so check for an error
+# if there was an error, just use the user agent as a version
+if(_git_tag_error)
+	message(WARNING "cpp-httplib failed to find the latest git tag, falling back to using user agent as the version.")
+	# Get the user agent and use it as a version
+	# This gets the string with the user agent from the header.
+	# This is so the maintainer doesn't actually need to update this manually.
+	file(STRINGS httplib.h _raw_version_string REGEX "User\-Agent.*cpp\-httplib/([0-9]+\.?)+")
+endif()
+# Needed since git tags have "v" prefixing them.
+# Also used if the fallback to user agent string is being used.
+string(REGEX MATCH "([0-9]+\\.?)+" _httplib_version "${_raw_version_string}")
 
 project(httplib VERSION ${_httplib_version} LANGUAGES CXX)
 


### PR DESCRIPTION
This gets us the full version (aka with the patch version), instead of
just major and minor version from user agent.

Falls back to the user agent if it fails.

Not sure why I didn't think of this before, but oh well.