### PR TITLE
Fix: regex can't match when proxy was set to some web debugger(e.g. Fiddler)

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4425,7 +4425,7 @@ inline bool Client::read_response_line(Stream &strm, Response &res) {
 
   if (!line_reader.getline()) { return false; }
 
-  const static std::regex re("(HTTP/1\\.[01]) (\\d+?) .*\r\n");
+  const static std::regex re("(HTTP/1\\.[01]) (\\d+).*?\r\n");
 
   std::cmatch m;
   if (std::regex_match(line_reader.ptr(), m, re)) {


### PR DESCRIPTION
in function inline bool Client::read_response_line(Stream &strm, Response &res)

regex = "(HTTP/1\\.[01]) (\\d+?) .*\r\n" while Fiddler returned "HTTP/1.1 200\r\n"