### PR TITLE
Add some compresion helpers

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -616,7 +616,9 @@ protected:
   time_t idle_interval_sec_ = CPPHTTPLIB_IDLE_INTERVAL_SECOND;
   time_t idle_interval_usec_ = CPPHTTPLIB_IDLE_INTERVAL_USECOND;
   size_t payload_max_length_ = CPPHTTPLIB_PAYLOAD_MAX_LENGTH;
+#ifdef CPPHTTPLIB_ZLIB_SUPPORT  
   int    compression_level_ = Z_DEFAULT_COMPRESSION;
+#endif
 
 private:
   using Handlers = std::vector<std::pair<std::regex, Handler>>;
@@ -3783,9 +3785,11 @@ inline void Server::set_payload_max_length(size_t length) {
   payload_max_length_ = length;
 }
 
+#ifdef CPPHTTPLIB_ZLIB_SUPPORT
 inline void Server::set_compression_level(int level) {
   compression_level_ = level;
 }
+#endif
 
 inline bool Server::bind_to_port(const char *host, int port, int socket_flags) {
   if (bind_internal(host, port, socket_flags) < 0) return false;


### PR DESCRIPTION
Usually servers can not configure compresion level in zlib. however for embedded servers this maybe useful, for example in our project we send data across gsm link and preffer to spend a little more CPU and save send time.

In other side, chunked transfer does not use compresion. At first I tried to add compresion support to it but i see if chunked transfers uses compresion, send small chunks (like SSE) doesnt work correctly becouse zlib stream must be flushed at each message write, making packets even bigger. Compression is not useful in this situation.

As an alternative i changed Accept-Encoding detection to run before request handler and save this information in Response. Program can choose to send gzipped contents, seeing if client support it, adding Content-Encoding and sending an already gzipped messages. 

We send long realtime generated JSON for this I send text as it if no compression is aceptable or send text to compressor and if output is produced (at end of blocks) i send it with sink.write. At final write Z_FINISH flag is used to get all remaining bytes and send it.

With the added functions and a intermediate gzip layer is possible to send long content with compresion without the need to compress it at once.

```
//EXAMPLE!
new HTTPChunkedWriter(response, "application/json",
    [](HTTPChunkedWriter *writer) -> bool {
      uint Items = 0;
      writer->Write("[\n  ");
      for(uint n = 0; n < 100; n++) writer->Write(((Items++ != 0) ? ",\n  " : "") + JSON.dump());
      writer->Write("\n]", true);
      return false;
    }
  );
// MY BINDING CLASS
class HTTPChunkedWriter final {
  private :
    uint8_t   pOutBuff[ZLIB_ENCODING_BLOCK];
    z_stream  pStream;
    bool      pCompress;
    DataSink *pDataSink;
  public :
    HTTPChunkedWriter(Response &res, const char *mime, function<bool(HTTPChunkedWriter *writer)> callback);
    ~HTTPChunkedWriter();
    void SetSink(DataSink &sink);
    void Write(const string &data, bool flush = false);
};
HTTPChunkedWriter::HTTPChunkedWriter(Response &res, const char *mime, function<bool(HTTPChunkedWriter *writer)> callback) {
  res.set_header("Content-Type", mime);
  res.status = HTTP_OK;
  pDataSink = NULL;
  if(res.accept_gzip_encoding == true) {
    pStream.zalloc    = Z_NULL;
    pStream.zfree     = Z_NULL;
    pStream.opaque    = Z_NULL;
    if(deflateInit2(&pStream, res.gzip_compression_level, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY) == Z_OK) {
      pCompress = true;
      res.set_header("Content-Encoding", "gzip");
    }
  }
  res.set_chunked_content_provider(
    [=](size_t offset, DataSink &sink) -> bool {
      SetSink(sink);
      while(callback(this) == true);
      return false;
    },
    [=]() { delete this; }
  );
}
HTTPChunkedWriter::~HTTPChunkedWriter() {
  if(pCompress == true) deflateEnd(&pStream);
}
void HTTPChunkedWriter::SetSink(DataSink &sink) {
  pDataSink = &sink;
}
void HTTPChunkedWriter::Write(const string &data, bool flush) {
  if(pDataSink == NULL) return;
  if(pCompress == false) {
    pDataSink->write(data.c_str(), data.size());
  } else {
    pStream.avail_in = data.size();
    pStream.next_in  = (uint8_t*)data.c_str();
    do {
      pStream.avail_out = ZLIB_ENCODING_BLOCK;
      pStream.next_out  = pOutBuff;
      deflate(&pStream, flush ? Z_FINISH : Z_NO_FLUSH);
      size_t Count = (ZLIB_ENCODING_BLOCK - pStream.avail_out);
      if(Count > 0) pDataSink->write((char*)pOutBuff, Count);
    } while(pStream.avail_out == 0);
  }
  if(flush) pDataSink->done();
}
```