### PR TITLE
include <wincrypt.h> as otherwise CertOpenSystemStoreW can not be found

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -145,6 +145,7 @@ using ssize_t = int;
 #include <io.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <wincrypt.h>
 
 #ifndef WSA_FLAG_NO_HANDLE_INHERIT
 #define WSA_FLAG_NO_HANDLE_INHERIT 0x80


### PR DESCRIPTION
- visual studio 2019, version 16.6.3
- 64 bit target

It is not clear for me, why it seems only I run into this problem.