### PR TITLE
Fix Cmake build for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,10 @@ target_include_directories(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
 # Always require threads
 target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
 		Threads::Threads
+		# Needed for Windows libs on Mingw, as the pragma comment(lib, "xyz") aren't triggered.
+		$<$<PLATFORM_ID:Windows>:ws2_32>
+		$<$<PLATFORM_ID:Windows>:crypt32>
+		$<$<PLATFORM_ID:Windows>:cryptui>
 )
 
 # We check for the target when using IF_AVAILABLE since it's possible we didn't find it.


### PR DESCRIPTION
Seems certain targets/hosts failed without these, as `_MSC_VER` is
undefined on MinGW, which caused the `#pragma comment(lib "libname")` to
fail.

Note that the build actually succeeds without linking `cryptui` as long as we link `crypt32`. I just added it because you were originally linking it, and I didn't really investigate the reason. But it might be able to be removed?