### PR TITLE
Add Brotli Cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,15 @@
 #[[
 	Build options:
+	* BUILD_SHARED_LIBS (default off) builds as a static library (if HTTPLIB_COMPILE is ON)
 	* HTTPLIB_USE_OPENSSL_IF_AVAILABLE (default on)
 	* HTTPLIB_USE_ZLIB_IF_AVAILABLE (default on)
 	* HTTPLIB_REQUIRE_OPENSSL (default off)
 	* HTTPLIB_REQUIRE_ZLIB (default off)
+	* HTTPLIB_USE_BROTLI_IF_AVAILABLE (default on)
+	* HTTPLIB_REQUIRE_BROTLI (default off)
 	* HTTPLIB_COMPILE (default off)
+	* BROTLI_USE_STATIC_LIBS - tells Cmake to use the static Brotli libs (only works if you have them installed).
+	* OPENSSL_USE_STATIC_LIBS - tells Cmake to use the static OpenSSL libs (only works if you have them installed).
 
 	-------------------------------------------------------------------------------
 
@@ -36,10 +41,11 @@
 	* HTTPLIB_HEADER_PATH - this is the full path to the installed header (e.g. /usr/include/httplib.h).
 	* HTTPLIB_IS_USING_OPENSSL - a bool for if OpenSSL support is enabled.
 	* HTTPLIB_IS_USING_ZLIB - a bool for if ZLIB support is enabled.
+	* HTTPLIB_IS_USING_BROTLI - a bool for if Brotli support is enabled.
 	* HTTPLIB_IS_COMPILED - a bool for if the library is compiled, or otherwise header-only.
 	* HTTPLIB_INCLUDE_DIR - the root path to httplib's header (e.g. /usr/include).
 	* HTTPLIB_LIBRARY - the full path to the library if compiled (e.g. /usr/lib/libhttplib.so).
-	* HTTPLIB_VERSION - the project's version string.
+	* httplib_VERSION or HTTPLIB_VERSION - the project's version string.
 	* HTTPLIB_FOUND - a bool for if the target was found.
 
 	Want to use precompiled headers (Cmake feature since v3.16)?
@@ -86,9 +92,16 @@ option(HTTPLIB_REQUIRE_ZLIB "Requires ZLIB to be found & linked, or fails build.
 # Allow for a build to casually enable OpenSSL/ZLIB support, but silenty continue if not found.
 # Make these options so their automatic use can be specifically disabled (as needed)
 option(HTTPLIB_USE_OPENSSL_IF_AVAILABLE "Uses OpenSSL (if available) to enable HTTPS support." ON)
-option(HTTPLIB_USE_ZLIB_IF_AVAILABLE "Uses ZLIB (if available) to enable compression support." ON)
+option(HTTPLIB_USE_ZLIB_IF_AVAILABLE "Uses ZLIB (if available) to enable Zlib compression support." ON)
 # Lets you compile the program as a regular library instead of header-only
 option(HTTPLIB_COMPILE "If ON, uses a Python script to split the header into a compilable header & source file (requires Python v3)." OFF)
+# Just setting this variable here for people building in-tree
+if(HTTPLIB_COMPILE)
+	set(HTTPLIB_IS_COMPILED TRUE)
+endif()
+
+option(HTTPLIB_REQUIRE_BROTLI "Requires Brotli to be found & linked, or fails build." OFF)
+option(HTTPLIB_USE_BROTLI_IF_AVAILABLE "Uses Brotli (if available) to enable Brotli compression support." ON)
 # Defaults to static library
 option(BUILD_SHARED_LIBS "Build the library as a shared library instead of static. Has no effect if using header-only." OFF)
 if (BUILD_SHARED_LIBS AND WIN32 AND HTTPLIB_COMPILE)
@@ -105,10 +118,32 @@ if(HTTPLIB_REQUIRE_OPENSSL)
 elseif(HTTPLIB_USE_OPENSSL_IF_AVAILABLE)
 	find_package(OpenSSL ${_HTTPLIB_OPENSSL_MIN_VER} COMPONENTS Crypto SSL QUIET)
 endif()
+# Just setting this variable here for people building in-tree
+if(OPENSSL_FOUND)
+	set(HTTPLIB_IS_USING_OPENSSL TRUE)
+endif()
+
 if(HTTPLIB_REQUIRE_ZLIB)
 	find_package(ZLIB REQUIRED)
 elseif(HTTPLIB_USE_ZLIB_IF_AVAILABLE)
 	find_package(ZLIB QUIET)
+endif()
+# Just setting this variable here for people building in-tree
+# FindZLIB doesn't have a ZLIB_FOUND variable, so check the target.
+if(TARGET ZLIB::ZLIB)
+	set(HTTPLIB_IS_USING_ZLIB TRUE)
+endif()
+
+# Adds our cmake folder to the search path for find_package
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+if(HTTPLIB_REQUIRE_BROTLI)
+	find_package(Brotli COMPONENTS encoder decoder common REQUIRED)
+elseif(HTTPLIB_USE_BROTLI_IF_AVAILABLE)
+	find_package(Brotli COMPONENTS encoder decoder common QUIET)
+endif()
+# Just setting this variable here for people building in-tree
+if(Brotli_FOUND)
+	set(HTTPLIB_IS_USING_BROTLI TRUE)
 endif()
 
 # Used for default, common dirs that the end-user can change (if needed)
@@ -185,33 +220,21 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
 		$<$<PLATFORM_ID:Windows>:ws2_32>
 		$<$<PLATFORM_ID:Windows>:crypt32>
 		$<$<PLATFORM_ID:Windows>:cryptui>
+		# Can't put multiple targets in a single generator expression or it bugs out.
+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::common>
+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>
+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::decoder>
+		$<$<BOOL:${HTTPLIB_IS_USING_ZLIB}>:ZLIB::ZLIB>
+		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL>
+		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::Crypto>
 )
 
-# We check for the target when using IF_AVAILABLE since it's possible we didn't find it.
-if(HTTPLIB_USE_OPENSSL_IF_AVAILABLE AND TARGET OpenSSL::SSL AND TARGET OpenSSL::Crypto OR HTTPLIB_REQUIRE_OPENSSL)
-	target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
-		OpenSSL::SSL OpenSSL::Crypto
-	)
-	target_compile_definitions(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
-		CPPHTTPLIB_OPENSSL_SUPPORT
-	)
-	set(HTTPLIB_IS_USING_OPENSSL TRUE)
-else()
-	set(HTTPLIB_IS_USING_OPENSSL FALSE)
-endif()
-
-# We check for the target when using IF_AVAILABLE since it's possible we didn't find it.
-if(HTTPLIB_USE_ZLIB_IF_AVAILABLE AND TARGET ZLIB::ZLIB OR HTTPLIB_REQUIRE_ZLIB)
-	target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
-		ZLIB::ZLIB
-	)
-	target_compile_definitions(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
-		CPPHTTPLIB_ZLIB_SUPPORT
-	)
-	set(HTTPLIB_IS_USING_ZLIB TRUE)
-else()
-	set(HTTPLIB_IS_USING_ZLIB FALSE)
-endif()
+# Set the definitions to enable optional features
+target_compile_definitions(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
+	$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:"CPPHTTPLIB_BROTLI_SUPPORT">
+	$<$<BOOL:${HTTPLIB_IS_USING_ZLIB}>:"CPPHTTPLIB_ZLIB_SUPPORT">
+	$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:"CPPHTTPLIB_OPENSSL_SUPPORT">
+)
 
 # Cmake's find_package search path is different based on the system
 # See https://cmake.org/cmake/help/latest/command/find_package.html for the list
@@ -266,6 +289,9 @@ install(FILES "${_httplib_build_includedir}/httplib.h" DESTINATION ${CMAKE_INSTA
 install(FILES
 		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
 		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+		# Install it so it can be used later by the httplibConfig.cmake file.
+		# Put it in the same dir as our config file instead of a global path so we don't potentially stomp on other packages.
+		"${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindBrotli.cmake"
 	DESTINATION ${_TARGET_INSTALL_CMAKEDIR}
 )
 

--- a/cmake/FindBrotli.cmake
+++ b/cmake/FindBrotli.cmake
@@ -1,0 +1,185 @@
+# A simple FindBrotli package for Cmake's find_package function.
+# Note: This find package doesn't have version support, as the version file doesn't seem to be installed on most systems.
+# 
+# If you want to find the static packages instead of shared (the default), define BROTLI_USE_STATIC_LIBS as TRUE.
+# The targets will have the same names, but it will use the static libs.
+#
+# Valid find_package COMPONENTS names: "decoder", "encoder", and "common"
+#
+# Defines the libraries (if found): Brotli::decoder, Brotli::encoder, Brotli::common
+# and the includes path variable: Brotli_INCLUDE_DIR
+
+function(brotli_err_msg _err_msg)
+	# If the package is required, throw a fatal error
+	# Otherwise, if not running quietly, we throw a warning
+	if(Brotli_FIND_REQUIRED)
+		message(FATAL_ERROR "${_err_msg}")
+	elseif(NOT Brotli_FIND_QUIETLY)
+		message(WARNING "${_err_msg}")
+	endif()
+endfunction()
+
+# If they asked for a specific version, warn/fail since we don't support it.
+if(Brotli_FIND_VERSION)
+	brotli_err_msg("FindBrotli.cmake doesn't have version support!")
+endif()
+
+# Since both decoder & encoder require the common lib (I think), force its requirement..
+# if the user is requiring either of those other libs.
+if(Brotli_FIND_REQUIRED_decoder OR Brotli_FIND_REQUIRED_encoder)
+	set(Brotli_FIND_REQUIRED_common TRUE)
+endif()
+
+# Make PkgConfig optional, since some users (mainly Windows) don't have it.
+# But it's a lot more clean than manually using find_library.
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+	if(BROTLI_USE_STATIC_LIBS)
+		pkg_check_modules(Brotli_common_STATIC QUIET IMPORTED_TARGET libbrotlicommon)
+		pkg_check_modules(Brotli_decoder_STATIC QUIET IMPORTED_TARGET libbrotlidec)
+		pkg_check_modules(Brotli_encoder_STATIC QUIET IMPORTED_TARGET libbrotlienc)
+	else()
+		pkg_check_modules(Brotli_common QUIET IMPORTED_TARGET libbrotlicommon)
+		pkg_check_modules(Brotli_decoder QUIET IMPORTED_TARGET libbrotlidec)
+		pkg_check_modules(Brotli_encoder QUIET IMPORTED_TARGET libbrotlienc)
+	endif()
+endif()
+
+# Only used if the PkgConfig libraries aren't used.
+find_path(Brotli_INCLUDE_DIR
+	NAMES "brotli/decode.h" "brotli/encode.h"
+	PATH_SUFFIXES "include" "includes"
+	DOC "The path to Brotli's include directory."
+)
+
+# Also check if Brotli_decoder was defined, as it can be passed by the end-user
+if(NOT TARGET PkgConfig::Brotli_decoder AND NOT Brotli_decoder)
+	if(BROTLI_USE_STATIC_LIBS)
+		list(APPEND _brotli_decoder_lib_names
+			"brotlidec-static"
+			"libbrotlidec-static"
+		)
+	else()
+		list(APPEND _brotli_decoder_lib_names
+			"brotlidec"
+			"libbrotlidec"
+		)
+	endif()
+	find_library(Brotli_decoder
+		NAMES ${_brotli_decoder_lib_names}
+		PATH_SUFFIXES
+			"lib"
+			"lib64"
+			"libs"
+			"libs64"
+			"lib/x86_64-linux-gnu"
+	)
+endif()
+
+# Also check if Brotli_encoder was defined, as it can be passed by the end-user
+if(NOT TARGET PkgConfig::Brotli_encoder AND NOT Brotli_encoder)
+	if(BROTLI_USE_STATIC_LIBS)
+		list(APPEND _brotli_encoder_lib_names
+			"brotlienc-static"
+			"libbrotlienc-static"
+		)
+	else()
+		list(APPEND _brotli_encoder_lib_names
+			"brotlienc"
+			"libbrotlienc"
+		)
+	endif()
+	find_library(Brotli_encoder
+		NAMES ${_brotli_encoder_lib_names}
+		PATH_SUFFIXES
+			"lib"
+			"lib64"
+			"libs"
+			"libs64"
+			"lib/x86_64-linux-gnu"
+	)
+endif()
+
+# Also check if Brotli_common was defined, as it can be passed by the end-user
+if(NOT TARGET PkgConfig::Brotli_common AND NOT Brotli_common)
+	if(BROTLI_USE_STATIC_LIBS)
+		list(APPEND _brotli_common_lib_names
+			"brotlicommon-static"
+			"libbrotlicommon-static"
+		)
+	else()
+		list(APPEND _brotli_common_lib_names
+			"brotlicommon"
+			"libbrotlicommon"
+		)
+	endif()
+	find_library(Brotli_common
+		NAMES ${_brotli_common_lib_names}
+		PATH_SUFFIXES
+			"lib"
+			"lib64"
+			"libs"
+			"libs64"
+			"lib/x86_64-linux-gnu"
+	)
+endif()
+
+set(_brotli_req_vars "")
+# Generic loop to either create all the aliases for the end-user, or throw errors/warnings.
+# Note that the case here needs to match the case we used elsewhere in this file.
+foreach(_target_name "common" "decoder" "encoder")
+	# The PkgConfig IMPORTED_TARGET has PkgConfig:: prefixed to it.
+	if(TARGET PkgConfig::Brotli_${_target_name})
+		add_library(Brotli::${_target_name} ALIAS PkgConfig::Brotli_${_target_name})
+
+		if(Brotli_FIND_REQUIRED_${_target_name})
+			# The PkgConfig version of the library has a slightly different path to its lib.
+			if(BROTLI_USE_STATIC_LIBS)
+				list(APPEND _brotli_req_vars "Brotli_${_target_name}_STATIC_LINK_LIBRARIES")
+			else()
+				list(APPEND _brotli_req_vars "Brotli_${_target_name}_LINK_LIBRARIES")
+			endif()
+		endif()
+	# This will only trigger for libraries we found using find_library
+	elseif(Brotli_${_target_name})
+		add_library("Brotli::${_target_name}" UNKNOWN IMPORTED)
+		# Safety-check the includes dir
+		if(NOT Brotli_INCLUDE_DIR)
+			brotli_err_msg("Failed to find Brotli's includes directory. Try manually defining \"Brotli_INCLUDE_DIR\" to Brotli's header path on your system.")
+		endif()
+		# Attach the literal library and include dir to the IMPORTED target for the end-user
+		set_target_properties("Brotli::${_target_name}" PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES "${Brotli_INCLUDE_DIR}"
+			IMPORTED_LOCATION "${Brotli_${_target_name}}"
+		)
+		# Attach the library from find_library to our required vars (if it's required)
+		if(Brotli_FIND_REQUIRED_${_target_name})
+			list(APPEND _brotli_req_vars "Brotli_${_target_name}")
+		endif()
+	# This will only happen if it's a required library but we didn't find it.
+	elseif(Brotli_FIND_REQUIRED_${_target_name})
+		# Only bother with an error/failure if they actually required the lib.
+		brotli_err_msg("Failed to find Brotli's ${_target_name} library. Try manually defining \"Brotli_${_target_name}\" to its path on your system.")
+	endif()
+endforeach()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Brotli
+	FOUND_VAR Brotli_FOUND
+	REQUIRED_VARS ${_brotli_req_vars}
+)
+
+if(Brotli_FOUND)
+	include(FindPackageMessage)
+	foreach(_lib_name ${_brotli_req_vars})
+		# TODO: remove this if/when The Cmake PkgConfig file fixes the non-quiet message about libbrotlicommon being found.
+		if(${_lib_name} MATCHES "common")
+			# This avoids a duplicate "Found Brotli: /usr/lib/libbrotlicommon.so" type message.
+			continue()
+		endif()
+		# Double-expand the var to get the actual path instead of the variable's name.
+		find_package_message(Brotli "Found Brotli: ${${_lib_name}}"
+			"[${${_lib_name}}][${Brotli_INCLUDE_DIR}]"
+		)
+	endforeach()
+endif()

--- a/httplibConfig.cmake.in
+++ b/httplibConfig.cmake.in
@@ -6,6 +6,7 @@
 set(HTTPLIB_IS_USING_OPENSSL @HTTPLIB_IS_USING_OPENSSL@)
 set(HTTPLIB_IS_USING_ZLIB @HTTPLIB_IS_USING_ZLIB@)
 set(HTTPLIB_IS_COMPILED @HTTPLIB_COMPILE@)
+set(HTTPLIB_IS_USING_BROTLI @HTTPLIB_IS_USING_BROTLI@)
 set(HTTPLIB_VERSION @PROJECT_VERSION@)
 
 include(CMakeFindDependencyMacro)
@@ -24,6 +25,14 @@ if(@HTTPLIB_IS_USING_OPENSSL@)
 endif()
 if(@HTTPLIB_IS_USING_ZLIB@)
 	find_dependency(ZLIB REQUIRED)
+endif()
+
+if(@HTTPLIB_IS_USING_BROTLI@)
+	# Needed so we can use our own FindBrotli.cmake in this file.
+	# Note that the FindBrotli.cmake file is installed in the same dir as this file.
+	list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+	set(BROTLI_USE_STATIC_LIBS @BROTLI_USE_STATIC_LIBS@)
+	find_dependency(Brotli COMPONENTS common encoder decoder REQUIRED)
 endif()
 
 # Mildly useful for end-users


### PR DESCRIPTION
Had to create a custom FindBrotli package, as not all users have
PkgConfig installed (which Brotli uses). This file gets installed
alongside `httplibConfig.cmake` for the end-users convenience.

Set `BROTLI_USE_STATIC_LIBS` to ON if you want to find the static libs
instead of default shared.

Adds the `HTTPLIB_REQUIRE_BROTLI` (default off) and `HTTPLIB_USE_BROTLI_IF_AVAILABLE`
(default on) options, which work in the same manner as the other optional/required
dependency options.

Moved the scattered linking and definitions to a single call.

Updated some documentation about the new options.

Improved the in-tree support by setting the `HTTPLIB_IS_USING_XYZ`
variables in the main CMakeLists (as well as having them in the
httplibConfig.cmake file).

Fixes #582