### PR TITLE
Update httplib.h

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -156,6 +156,7 @@ using socket_t = SOCKET;
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <resolv.h>
 #include <netinet/tcp.h>
 #ifdef CPPHTTPLIB_USE_POLL
 #include <poll.h>
@@ -1821,6 +1822,7 @@ socket_t create_socket(const char *host, int port, int socket_flags,
   auto service = std::to_string(port);
 
   if (getaddrinfo(host, service.c_str(), &hints, &result)) {
+    res_init();
     return INVALID_SOCKET;
   }
 


### PR DESCRIPTION
When you disconnect and reconnect from the network, your network stack rewrites and updates /etc/resolv.conf accordingly. This configuration file is needed by the DNS resolver in the C library. The C library reads the DNS configuration from /etc/resolv.conf the first time, and caches it. It doesn't check, with every lookup, if the contents of /etc/resolv.conf have changed.
the solution is to add a call to res_init(), defined in resolv.h.

It would seem that the getaddrinfo (...) function initializes the info only the first time.
With the use of the res_init () function one forces to reinitialize its internal structure.