### PR TITLE
fix #592 -- add check for static-linked OpenSSL

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -199,7 +199,7 @@ using socket_t = int;
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(OPENSSL_USE_APPLINK)
 #include <openssl/applink.c>
 #endif
 


### PR DESCRIPTION
**Applink is not necessary if OpenSSL is statically linked.**
OpenSSL should work statically on Windows even if applink is included.
However, when building OpenSSL from source, `applink.c` is only dynamically created at build time when built as a shared library. Therefore, it could cause confusion to some users if applink.c is missing, and it should be included only if [`OPENSSL_USE_APPLINK` is defined.](http://openssl.6102.n7.nabble.com/Win32-OPENSSL-USE-APPLINK-usage-tp41476p41477.html)