### PR TITLE
Fix cmake execute_process working directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ if(Git_FOUND)
 	# Gets the latest tag as a string like "v0.6.6"
 	# Can silently fail if git isn't on the system
 	execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 		OUTPUT_VARIABLE _raw_version_string
 		ERROR_VARIABLE _git_tag_error
 	)


### PR DESCRIPTION
Correct the working directory of the execute_process call, to get the version from git tags.
The working directory should be the the directory of this libary. Otherwise, if you include httplib
as a git submodule and call add_subdirectory, the execute_process command will be run in a wrong
directory leading to error.