### PR TITLE
Fix server crash caused due to regex complexity while matching headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ if(Git_FOUND)
 	# Gets the latest tag as a string like "v0.6.6"
 	# Can silently fail if git isn't on the system
 	execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 		OUTPUT_VARIABLE _raw_version_string
 		ERROR_VARIABLE _git_tag_error
 	)

--- a/httplib.h
+++ b/httplib.h
@@ -2979,7 +2979,7 @@ public:
             std::smatch m;
             const std::string header_name = "content-type:";
             if (contains_header(header, header_name)) {
-              header.erase(header.begin(), header.begin() + 13);
+              header.erase(header.begin(), header.begin() + header_name.size());
               trim(header);
               file_.content_type = header;
             } else if (std::regex_match(header, m, re_content_disposition)) {

--- a/httplib.h
+++ b/httplib.h
@@ -1451,6 +1451,13 @@ inline std::pair<int, int> trim(const char *b, const char *e, int left,
   return std::make_pair(left, right);
 }
 
+inline void trim(std::string &s) {
+  auto is_not_space = [](int ch) { return !std::isspace(ch); };
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), is_not_space));
+  s.erase(std::find_if(s.rbegin(), s.rend(), is_not_space).base(), s.end());
+}
+
+
 template <class Fn> void split(const char *b, const char *e, char d, Fn fn) {
   int i = 0;
   int beg = 0;
@@ -2827,6 +2834,18 @@ inline bool redirect(T &cli, const Request &req, Response &res,
   return ret;
 }
 
+inline bool contains_header(const std::string &header, const std::string &name) {
+  if (header.length() >= name.length()) {
+    for (int i = 0; i < name.length(); ++i) {
+      if (std::tolower(header[i]) != std::tolower(name[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
 inline std::string params_to_query_str(const Params &params) {
   std::string query;
 
@@ -2913,8 +2932,6 @@ public:
 
   template <typename T, typename U>
   bool parse(const char *buf, size_t n, T content_callback, U header_callback) {
-    static const std::regex re_content_type(R"(^Content-Type:\s*(.*?)\s*$)",
-                                            std::regex_constants::icase);
 
     static const std::regex re_content_disposition(
         "^Content-Disposition:\\s*form-data;\\s*name=\"(.*?)\"(?:;\\s*filename="
@@ -2960,8 +2977,11 @@ public:
           auto header = buf_.substr(0, pos);
           {
             std::smatch m;
-            if (std::regex_match(header, m, re_content_type)) {
-              file_.content_type = m[1];
+            const std::string header_name = "content-type:";
+            if (contains_header(header, header_name)) {
+              header.erase(header.begin(), header.begin() + 13);
+              trim(header);
+              file_.content_type = header;
             } else if (std::regex_match(header, m, re_content_disposition)) {
               file_.name = m[1];
               file_.filename = m[2];

--- a/httplib.h
+++ b/httplib.h
@@ -697,13 +697,13 @@ enum Error {
 class Result {
 public:
   Result(std::shared_ptr<Response> res, Error err) : res_(res), err_(err) {}
-  operator bool() { return res_ != nullptr; }
+  operator bool() const { return res_ != nullptr; }
   bool operator==(std::nullptr_t) const { return res_ == nullptr; }
   bool operator!=(std::nullptr_t) const { return res_ != nullptr; }
-  const Response &value() { return *res_; }
-  const Response &operator*() { return *res_; }
-  const Response *operator->() { return res_.get(); }
-  Error error() { return err_; }
+  const Response &value() const { return *res_; }
+  const Response &operator*() const { return *res_; }
+  const Response *operator->() const { return res_.get(); }
+  Error error() const { return err_; }
 
 private:
   std::shared_ptr<Response> res_;


### PR DESCRIPTION
While parsing content-type header in multipart form request the server crashes due to the exhaustion of max iterations performed while matching the input string with content-type regex.
Have removed the regex which might use backtracking while matching and replaced it with manual string processing.