### PR TITLE
Add compression buffer size customization

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2381,10 +2381,10 @@ public:
 
     decoder_r = BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT;
 
+    std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff;
     while (decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
-      std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> output;
-      char *next_out = output.data();
-      size_t avail_out = output.size();
+      char *next_out = buff.data();
+      size_t avail_out = buff.size();
 
       decoder_r = BrotliDecoderDecompressStream(
           decoder_s, &avail_in, &next_in, &avail_out,
@@ -2392,7 +2392,7 @@ public:
 
       if (decoder_r == BROTLI_DECODER_RESULT_ERROR) { return false; }
 
-      if (!callback(output.data(), output.size() - avail_out)) {
+      if (!callback(buff.data(), buff.size() - avail_out)) {
         return false;
       }
     }

--- a/httplib.h
+++ b/httplib.h
@@ -2381,7 +2381,7 @@ public:
 
     decoder_r = BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT;
 
-    std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff;
+    std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff{};
     while (decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
       char *next_out = buff.data();
       size_t avail_out = buff.size();


### PR DESCRIPTION
While working on a previous pull request, I noticed following note in zlib documentation https://zlib.net/zlib_how.html:
```
CHUNK is simply the buffer size for feeding data to and pulling data from the zlib routines.
Larger buffer sizes would be more efficient, especially for inflate().
If the memory is available, buffers sizes on the order of 128K or 256K bytes should be used.
```

So I decided to add CPPHTTPLIB_COMPRESSION_BUFSIZ macro in line with CPPHTTPLIB_RECV_BUFSIZ macro to allow for buffer size customization on different systems.

Also, I found that brotli decomressor code is written using C-array instead of std::array (as in other [de]compressors), so I refactored it slightly. 

Hope it is useful.

Thank you.