### PR TITLE
don't replace plus with space in headers

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4768,7 +4768,7 @@ inline bool ClientImpl::redirect(const Request &req, Response &res) {
     return false;
   }
 
-  auto location = res.get_header_value("location");
+  auto location = detail::decode_url(res.get_header_value("location"), true);
   if (location.empty()) { return false; }
 
   const static std::regex re(

--- a/httplib.h
+++ b/httplib.h
@@ -2464,7 +2464,7 @@ inline bool parse_header(const char *beg, const char *end, T fn) {
   }
 
   if (p < end) {
-    fn(std::string(beg, key_end), decode_url(std::string(p, end), true));
+    fn(std::string(beg, key_end), decode_url(std::string(p, end), false));
     return true;
   }
 


### PR DESCRIPTION
Hello
I ran into a problem uploading a file to httplib using cordovas FileTransfer plugin.
The plugin uses '+' signs in the boundary part of the Content-Type header field

here a capture:
`Content-Type: multipart/form-data; boundary=+++++`

Those + signs are replaced by spaces during the parsing of the headers, causing MultipartFormDataParser to fail.

I have to admin that i don't know wether this is a standard violation of the Filetransfer plugin or a implementation error in httplib, but the attached commit fixes the problem for me.