### PR TITLE
Missing <cctype> header

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -196,6 +196,7 @@ using socket_t = int;
 #include <string>
 #include <sys/stat.h>
 #include <thread>
+#include <cctype>
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 #include <openssl/err.h>


### PR DESCRIPTION
Hello,
when using Visual C++ 2017 (version 15.9.26) for compiling this library, i get the following error:

> cpp-httplib\httplib.h(1258): error C2672: 'std::tolower': no matching overloaded function found
> cpp-httplib\httplib.h(1258): error C2780: '_Elem std::tolower(_Elem,const std::locale &)': expects 2 arguments - 1 provided
>   C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.16.27023\include\locale(274): note: see declaration of 'std::tolower'

The function [std::tolower](https://en.cppreference.com/w/cpp/string/byte/tolower) used in this lib is defined in the header `<cctype>` by the standard. There is also another function with the same name but a different signature defined in `<locale>`, which explains the second error, see [here](https://en.cppreference.com/w/cpp/locale/tolower). Including the correct header in this PR fixes this issue.