### PR TITLE
Fix memory leak due caused due to X509_STORE

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -839,6 +839,10 @@ public:
   void set_proxy_digest_auth(const char *username, const char *password);
 #endif
 
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  void enable_server_certificate_verification(bool enabled);
+#endif
+
   void set_logger(Logger logger);
 
 protected:
@@ -858,6 +862,8 @@ protected:
                        bool close_connection);
 
   Error get_last_error() const;
+
+  void copy_settings(const ClientImpl &rhs);
 
   // Error state
   mutable Error error_ = Error::Success;
@@ -916,41 +922,11 @@ protected:
   std::string proxy_digest_auth_password_;
 #endif
 
-  Logger logger_;
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  bool server_certificate_verification_ = true;
+#endif
 
-  void copy_settings(const ClientImpl &rhs) {
-    client_cert_path_ = rhs.client_cert_path_;
-    client_key_path_ = rhs.client_key_path_;
-    connection_timeout_sec_ = rhs.connection_timeout_sec_;
-    read_timeout_sec_ = rhs.read_timeout_sec_;
-    read_timeout_usec_ = rhs.read_timeout_usec_;
-    write_timeout_sec_ = rhs.write_timeout_sec_;
-    write_timeout_usec_ = rhs.write_timeout_usec_;
-    basic_auth_username_ = rhs.basic_auth_username_;
-    basic_auth_password_ = rhs.basic_auth_password_;
-    bearer_token_auth_token_ = rhs.bearer_token_auth_token_;
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    digest_auth_username_ = rhs.digest_auth_username_;
-    digest_auth_password_ = rhs.digest_auth_password_;
-#endif
-    keep_alive_ = rhs.keep_alive_;
-    follow_location_ = rhs.follow_location_;
-    tcp_nodelay_ = rhs.tcp_nodelay_;
-    socket_options_ = rhs.socket_options_;
-    compress_ = rhs.compress_;
-    decompress_ = rhs.decompress_;
-    interface_ = rhs.interface_;
-    proxy_host_ = rhs.proxy_host_;
-    proxy_port_ = rhs.proxy_port_;
-    proxy_basic_auth_username_ = rhs.proxy_basic_auth_username_;
-    proxy_basic_auth_password_ = rhs.proxy_basic_auth_password_;
-    proxy_bearer_token_auth_token_ = rhs.proxy_bearer_token_auth_token_;
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    proxy_digest_auth_username_ = rhs.proxy_digest_auth_username_;
-    proxy_digest_auth_password_ = rhs.proxy_digest_auth_password_;
-#endif
-    logger_ = rhs.logger_;
-  }
+  Logger logger_;
 
 private:
   socket_t create_client_socket() const;
@@ -1096,16 +1072,18 @@ public:
   void set_proxy_digest_auth(const char *username, const char *password);
 #endif
 
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  void enable_server_certificate_verification(bool enabled);
+#endif
+
   void set_logger(Logger logger);
 
   // SSL
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  Client &set_ca_cert_path(const char *ca_cert_file_path,
-                           const char *ca_cert_dir_path = nullptr);
+  void set_ca_cert_path(const char *ca_cert_file_path,
+                        const char *ca_cert_dir_path = nullptr);
 
-  Client &set_ca_cert_store(X509_STORE *ca_cert_store);
-
-  Client &enable_server_certificate_verification(bool enabled);
+  void set_ca_cert_store(X509_STORE *ca_cert_store);
 
   long get_openssl_verify_result() const;
 
@@ -1163,8 +1141,6 @@ public:
 
   void set_ca_cert_store(X509_STORE *ca_cert_store);
 
-  void enable_server_certificate_verification(bool enabled);
-
   long get_openssl_verify_result() const;
 
   SSL_CTX *ssl_context() const;
@@ -1195,7 +1171,6 @@ private:
 
   std::string ca_cert_file_path_;
   std::string ca_cert_dir_path_;
-  bool server_certificate_verification_ = true;
   long verify_result_ = 0;
 
   friend class ClientImpl;
@@ -4615,6 +4590,43 @@ inline bool ClientImpl::is_valid() const { return true; }
 
 inline Error ClientImpl::get_last_error() const { return error_; }
 
+inline void ClientImpl::copy_settings(const ClientImpl &rhs) {
+  client_cert_path_ = rhs.client_cert_path_;
+  client_key_path_ = rhs.client_key_path_;
+  connection_timeout_sec_ = rhs.connection_timeout_sec_;
+  read_timeout_sec_ = rhs.read_timeout_sec_;
+  read_timeout_usec_ = rhs.read_timeout_usec_;
+  write_timeout_sec_ = rhs.write_timeout_sec_;
+  write_timeout_usec_ = rhs.write_timeout_usec_;
+  basic_auth_username_ = rhs.basic_auth_username_;
+  basic_auth_password_ = rhs.basic_auth_password_;
+  bearer_token_auth_token_ = rhs.bearer_token_auth_token_;
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  digest_auth_username_ = rhs.digest_auth_username_;
+  digest_auth_password_ = rhs.digest_auth_password_;
+#endif
+  keep_alive_ = rhs.keep_alive_;
+  follow_location_ = rhs.follow_location_;
+  tcp_nodelay_ = rhs.tcp_nodelay_;
+  socket_options_ = rhs.socket_options_;
+  compress_ = rhs.compress_;
+  decompress_ = rhs.decompress_;
+  interface_ = rhs.interface_;
+  proxy_host_ = rhs.proxy_host_;
+  proxy_port_ = rhs.proxy_port_;
+  proxy_basic_auth_username_ = rhs.proxy_basic_auth_username_;
+  proxy_basic_auth_password_ = rhs.proxy_basic_auth_password_;
+  proxy_bearer_token_auth_token_ = rhs.proxy_bearer_token_auth_token_;
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  proxy_digest_auth_username_ = rhs.proxy_digest_auth_username_;
+  proxy_digest_auth_password_ = rhs.proxy_digest_auth_password_;
+#endif
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  server_certificate_verification_ = rhs.server_certificate_verification_;
+#endif
+  logger_ = rhs.logger_;
+}
+
 inline socket_t ClientImpl::create_client_socket() const {
   if (!proxy_host_.empty() && proxy_port_ != -1) {
     return detail::create_client_socket(
@@ -5488,6 +5500,12 @@ inline void ClientImpl::set_proxy_digest_auth(const char *username,
 }
 #endif
 
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+inline void ClientImpl::enable_server_certificate_verification(bool enabled) {
+  server_certificate_verification_ = enabled;
+}
+#endif
+
 inline void ClientImpl::set_logger(Logger logger) {
   logger_ = std::move(logger);
 }
@@ -5835,10 +5853,6 @@ inline void SSLClient::set_ca_cert_store(X509_STORE *ca_cert_store) {
       X509_STORE_free(ca_cert_store);
     }
   }
-}
-
-inline void SSLClient::enable_server_certificate_verification(bool enabled) {
-  server_certificate_verification_ = enabled;
 }
 
 inline long SSLClient::get_openssl_verify_result() const {
@@ -6417,31 +6431,27 @@ inline void Client::set_proxy_digest_auth(const char *username,
 }
 #endif
 
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+inline void Client::enable_server_certificate_verification(bool enabled) {
+  cli_->enable_server_certificate_verification(enabled);
+}
+#endif
+
 inline void Client::set_logger(Logger logger) { cli_->set_logger(logger); }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline Client &Client::set_ca_cert_path(const char *ca_cert_file_path,
-                                        const char *ca_cert_dir_path) {
+inline void Client::set_ca_cert_path(const char *ca_cert_file_path,
+                                     const char *ca_cert_dir_path) {
   if (is_ssl_) {
     static_cast<SSLClient &>(*cli_).set_ca_cert_path(ca_cert_file_path,
                                                      ca_cert_dir_path);
   }
-  return *this;
 }
 
-inline Client &Client::set_ca_cert_store(X509_STORE *ca_cert_store) {
+inline void Client::set_ca_cert_store(X509_STORE *ca_cert_store) {
   if (is_ssl_) {
     static_cast<SSLClient &>(*cli_).set_ca_cert_store(ca_cert_store);
   }
-  return *this;
-}
-
-inline Client &Client::enable_server_certificate_verification(bool enabled) {
-  if (is_ssl_) {
-    static_cast<SSLClient &>(*cli_).enable_server_certificate_verification(
-        enabled);
-  }
-  return *this;
 }
 
 inline long Client::get_openssl_verify_result() const {

--- a/httplib.h
+++ b/httplib.h
@@ -5815,6 +5815,9 @@ inline SSLClient::SSLClient(const std::string &host, int port,
 
 inline SSLClient::~SSLClient() {
   if (ctx_) { SSL_CTX_free(ctx_); }
+  if (ca_cert_store_) {
+    X509_STORE_free(ca_cert_store_);
+  }
 }
 
 inline bool SSLClient::is_valid() const { return ctx_; }
@@ -5912,6 +5915,7 @@ inline bool SSLClient::load_certs() {
       if (SSL_CTX_get_cert_store(ctx_) != ca_cert_store_) {
         SSL_CTX_set_cert_store(ctx_, ca_cert_store_);
       }
+      ca_cert_store_ = nullptr;
     } else {
 #ifdef _WIN32
       detail::load_system_certs_on_windows(SSL_CTX_get_cert_store(ctx_));

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 
 #CXX = clang++
-CXXFLAGS = -ggdb -O0 -std=c++11 -DGTEST_USE_OWN_TR1_TUPLE -I.. -I. -Wall -Wextra -Wtype-limits -Wconversion
+CXXFLAGS = -ggdb -O0 -std=c++11 -DGTEST_USE_OWN_TR1_TUPLE -I.. -I. -Wall -Wextra -Wtype-limits -Wconversion -fsanitize=address
 
 OPENSSL_DIR = /usr/local/opt/openssl@1.1
 OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I$(OPENSSL_DIR)/include -L$(OPENSSL_DIR)/lib -lssl -lcrypto

--- a/test/test.cc
+++ b/test/test.cc
@@ -3124,6 +3124,8 @@ TEST(SSLClientTest, UnusedClient) {
   X509_STORE_load_locations(ca_store, "/etc/ssl/certs/ca-certificates.crt",
                             nullptr);
   httplib_client.set_ca_cert_store(ca_store);
+  //Uncommenting following line will leak ca_store
+  // httplib_client->Get("/");
 }
 
 TEST(SSLClientTest, ServerNameIndication) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -2070,9 +2070,14 @@ TEST_F(ServerTest, SlowPost) {
 
   ASSERT_TRUE(res);
   EXPECT_EQ(200, res->status);
+}
+
+TEST_F(ServerTest, SlowPostFail) {
+  char buffer[64 * 1024];
+  memset(buffer, 0x42, sizeof(buffer));
 
   cli_.set_write_timeout(0, 0);
-  res = cli_.Post(
+  auto res = cli_.Post(
       "/slowpost", 64 * 1024 * 1024,
       [&](size_t /*offset*/, size_t /*length*/, DataSink &sink) {
         sink.write(buffer, sizeof(buffer));

--- a/test/test.cc
+++ b/test/test.cc
@@ -1333,8 +1333,11 @@ protected:
 
   virtual void TearDown() {
     svr_.stop();
-    for (auto &t : request_threads_) {
-      t.join();
+    if (!request_threads_.empty()) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      for (auto &t : request_threads_) {
+        t.join();
+      }
     }
     t_.join();
   }
@@ -2051,7 +2054,6 @@ TEST_F(ServerTest, SlowRequest) {
       std::thread([=]() { auto res = cli_.Get("/slow"); }));
   request_threads_.push_back(
       std::thread([=]() { auto res = cli_.Get("/slow"); }));
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
 
 TEST_F(ServerTest, SlowPost) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -3120,14 +3120,17 @@ TEST_F(PayloadMaxLengthTest, ExceedLimit) {
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-TEST(SSLClientTest, UnusedClient) {
-  httplib::SSLClient httplib_client("www.google.com", 443, "", "");
-  auto ca_store = X509_STORE_new();
-  X509_STORE_load_locations(ca_store, "/etc/ssl/certs/ca-certificates.crt",
+TEST(SSLClientTest, UpdateCAStore) {
+  httplib::SSLClient httplib_client("www.google.com");
+  auto ca_store_1 = X509_STORE_new();
+  X509_STORE_load_locations(ca_store_1, "/etc/ssl/certs/ca-certificates.crt",
                             nullptr);
-  httplib_client.set_ca_cert_store(ca_store);
-  //Uncommenting following line will leak ca_store
-  // httplib_client->Get("/");
+  httplib_client.set_ca_cert_store(ca_store_1);
+
+  auto ca_store_2 = X509_STORE_new();
+  X509_STORE_load_locations(ca_store_2, "/etc/ssl/certs/ca-certificates.crt",
+                            nullptr);
+  httplib_client.set_ca_cert_store(ca_store_2);
 }
 
 TEST(SSLClientTest, ServerNameIndication) {


### PR DESCRIPTION
When X509_STORE objects are associated with a SSL_CTX (ctx_), they will automatically be deleted when the parent SSL_CTX is deleted (in the destructor). However, library lazily sets these in load_certs(), only doing it on a valid HTTP request (after the socket connects inside the call to initialize_ssl()). It causes a memory leak when connecting to an invalid URL, since it can't establish the socket.
The current PR has quick fix for the issue, although not sure if this is the ideal solution. Should we associate the X509_STORE with the ctx_t immediately in set_ca_cert_store() ? 
