### PR TITLE
Added MACRO for server_certificate_verification

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -87,6 +87,10 @@
                       : 0))
 #endif
 
+#ifndef CPPHTTPLIB_SERVER_CERTIFICATE_VERIFICATION
+#define CPPHTTPLIB_SERVER_CERTIFICATE_VERIFICATION true
+#endif
+
 /*
  * Headers
  */
@@ -1196,7 +1200,7 @@ private:
   std::string ca_cert_file_path_;
   std::string ca_cert_dir_path_;
   X509_STORE *ca_cert_store_ = nullptr;
-  bool server_certificate_verification_ = true;
+  bool server_certificate_verification_ = CPPHTTPLIB_SERVER_CERTIFICATE_VERIFICATION;
   long verify_result_ = 0;
 
   friend class ClientImpl;


### PR DESCRIPTION
If I have a request (made with universal interface httplib::Client) which redirects (set_follow_location) from HTTP to HTTPS and I had server_certificate_verification_ set to false, the redirection won't copy my server_certificate_verification_ setting and will make an erroneous request.

This solution allows me to keep server_certificate_verification configuration_ = false for my whole code and surrounds my problem.

Also, setting server_certificate_verification_ in the universal interface won't have effect (before it had been redirected from HTTP to HTTPS) and SSLClient instance had been created.