### PR TITLE
Fix multiple threading bugs including #699 and #697

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,12 @@ cli.set_ca_cert_path("./ca-bundle.crt");
 cli.enable_server_certificate_verification(true);
 ```
 
+Note: When using SSL, it seems impossible to avoid SIGPIPE in all cases, since on some operating systems, SIGPIPE
+can only be suppressed on a per-message basis, but there is no way to make the OpenSSL library do so for its
+internal communications. If your program needs to avoid being terminated on SIGPIPE, the only fully general way might
+be to set up a signal handler for SIGPIPE to handle or ignore it yourself.
+
+
 Compression
 -----------
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <future>
 #include <thread>
+#include <atomic>
 
 #define SERVER_CERT_FILE "./cert.pem"
 #define SERVER_PRIVATE_KEY_FILE "./key.pem"
@@ -2612,7 +2613,7 @@ TEST_F(ServerTest, Brotli) {
 // Sends a raw request to a server listening at HOST:PORT.
 static bool send_request(time_t read_timeout_sec, const std::string &req,
                          std::string *resp = nullptr) {
-  Error error = Error::Success;
+  std::atomic<Error> error(Error::Success);
 
   auto client_sock =
       detail::create_client_socket(HOST, PORT, false, nullptr,


### PR DESCRIPTION
In the process of fixing #697 and #699, I found that actually the situation is much more complicated. There were multiple issues with the old code, and simply applying the logical fix for those issues alone resulted in failures of test and other things due to the other bugs.

Many of these issues were a bit difficult to untangle individually, and required a nontrivial rework of the shutdown functions, so this pull request reworks all of the shutdown-related functions for the client to fix those thread-safety issues.

Here is the list of things that were fixed:
* In 0743d78c9bab62120422c56868c91eb67bff62ef it looks like a race condition that causes segfaults was buried under the rug by adding a timeout. This isn't a good fix because the segfault can still happen even with the timeout, the timeout only makes it less common. The race condition is that `close_socket` is *unsafe* to call when there are other threads still using the socket because other code might end up attempting to access `INVALID_SOCKET` believing it is a correct socket. And even if that were patched, theoretically the OS could reassign that socket id again causing it to be a valid but completely different socket corresponding to anything else in the application.
\
The proper fix is to add a `socket_requests_in_flight_` variable that is also maintained under `socket_mutex_` that tracks when a request might be actively using the socket despite holding the mutex. See in the new implementation of `inline void ClientImpl::stop()` - when this variable is > 0, we now refrain from closing the socket and instead *only* shutdown the socket (which *should* be thread-safe) to disable read/write on the socket. We then set another new variable `socket_should_be_closed_when_request_is_done_` so that the thread that is still involved in the active request can know to close the socket when it is done. 
\
So now, if there is any ongoing request, the request thread takes full responsibility for closing the socket, later. That way, there can be no race - the same thread making the requests is the one closing the socket.

* In #699 and #697 it was observed that on some OSes, it can cause an error to attempt to SSL_shutdown on a closed socket. In general, one should never use a closed socket with any SSL functions. 
\
The fix is to refactor the shutdown logic into three separate functions `shutdown_ssl` and `shutdown_socket` and `close_socket` because each of them needs to be called in different situations, and we now we no longer ever call `shutdown_ssl` after calling `close_socket`. 
\
It might be a bit confusing to need three functions here, but I don't know of a good way to do it with fewer than three. The general order of calling them should be `shutdown_ssl` then `shutdown_socket` then `close_socket`, but it is also necessary to call the second one alone (as in the first bullet point above), and `shutdown_ssl` needs to be virtual.

* There was a memory and an SSL resource leak in the `~ClientImpl` destructor, because it used to simply call `ClientImpl::close_socket`, which set `socket_.ssl` to nullptr without freeing it. The tricky subtle cause of this bug is that ~ClientImpl runs, virtual functions no longer call SSLClient's version of those functions! Only SSLClient's version of those functions clean up `socket_.ssl` properly. The proper fix, which is implemented now, is to explicitly make sure `~SSLClient` cleans up the `socket_.ssl` first.

* `error_` was accessed from multiple threads without synchronization. Strictly speaking, this is undefined C++ behavior unless this value is made atomic, so it is now made atomic.

All the tests (mostly) pass, for me, at least, and the code seems to work properly in my own personal application, so I think the state of things is good, but of course the logic is still a bit tricky. Let me know what you think.

