### PR TITLE
[oss-fuzz-26439] Fix suffix-byte-range issue

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -173,6 +173,7 @@ using socket_t = int;
 #define INVALID_SOCKET (-1)
 #endif //_WIN32
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cassert>
@@ -3153,7 +3154,7 @@ get_range_offset_and_length(const Request &req, size_t content_length,
   auto slen = static_cast<ssize_t>(content_length);
 
   if (r.first == -1) {
-    r.first = slen - r.second;
+    r.first = std::max(static_cast<ssize_t>(0), slen - r.second);
     r.second = slen - 1;
   }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -1897,6 +1897,30 @@ TEST_F(ServerTest, GetStreamedWithRange2) {
   EXPECT_EQ(std::string("bcdefg"), res->body);
 }
 
+TEST_F(ServerTest, GetStreamedWithRangeSuffix1) {
+  auto res = cli_.Get("/streamed-with-range", {
+    {"Range", "bytes=-3"}
+  });
+  ASSERT_TRUE(res);
+  EXPECT_EQ(206, res->status);
+  EXPECT_EQ("3", res->get_header_value("Content-Length"));
+  EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ(std::string("efg"), res->body);
+}
+
+
+TEST_F(ServerTest, GetStreamedWithRangeSuffix2) {
+  auto res = cli_.Get("/streamed-with-range", {
+    {"Range", "bytes=-9999"}
+  });
+  ASSERT_TRUE(res);
+  EXPECT_EQ(206, res->status);
+  EXPECT_EQ("7", res->get_header_value("Content-Length"));
+  EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ(std::string("abcdefg"), res->body);
+}
+
+
 TEST_F(ServerTest, GetStreamedWithRangeError) {
   auto res = cli_.Get("/streamed-with-range", {
     {"Range", "bytes=92233720368547758079223372036854775806-92233720368547758079223372036854775807"}


### PR DESCRIPTION
Hey @yhirose 
This is a fix for oss -fuzz [issue 26439](https://oss-fuzz.com/testcase-detail/5390822188777472). 
For the request with range header value `{"Range", "bytes=-9999"}` (suffix length is greater than response size),  the server used to crash cause of invalid response offset generated by program.  We're supposed to return the whole response entity. 
From [HTTP Spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35) 
``` If the entity is shorter than the specified suffix-length, the entire entity-body is used```

Let me know if this looks good to you. 