### PR TITLE
Added Client "Transfer-Encoding:Chunked" support when your content length is unpredictable.

### DIFF
--- a/example/chunked_client.vcxproj
+++ b/example/chunked_client.vcxproj
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8D6B6717-EE73-4EC8-B56D-80E23524C408}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>chunkedclient</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>chunked_client</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(Configuration)\$(ProjectName)_obj\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)_obj\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(Configuration)\$(ProjectName)_obj\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)_obj\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="chunkedcli.cc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/example/chunkedcli.cc
+++ b/example/chunkedcli.cc
@@ -1,0 +1,63 @@
+//
+//  chunkedcli.cc
+//
+//  Copyright (c) 2019 Yuji Hirose. All rights reserved.
+//  MIT License
+//
+
+#include <httplib.h>
+#include <iostream>
+
+#define CA_CERT_FILE "./ca-bundle.crt"
+
+int main(void) {
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  httplib::SSLClient cli("localhost");
+  // httplib::SSLClient cli("google.com");
+  // httplib::SSLClient cli("www.youtube.com");
+  cli.set_ca_cert_path(CA_CERT_FILE);
+  cli.enable_server_certificate_verification(true);
+#else
+  httplib::Client cli("localhost", 8080);
+#endif
+
+  httplib::Headers headers;
+  httplib::Params params;
+  size_t stream_size = 0;
+
+  httplib::ContentProvider content_provider;
+  std::ifstream sample_input_file("./ca-bundle.crt", std::ios::in | std::ios::binary);
+
+  if (sample_input_file) {
+    content_provider = [&](size_t offset, size_t length, httplib::DataSink &sink) {
+      do {
+        char buffer[CPPHTTPLIB_RECV_BUFSIZ];
+        sample_input_file.read(buffer, CPPHTTPLIB_RECV_BUFSIZ);
+        unsigned int readBytes = sample_input_file.gcount();
+        if (readBytes > 0) {
+          sink.write(buffer + offset, readBytes);
+          printf("ContentProvider ==> Written Bytes: %lld\n", sample_input_file.gcount());
+        }
+      } while (sample_input_file.gcount() > 0);
+
+      return true;
+    };
+  }
+
+  // It can be a post and patch request.
+  if (auto res = cli.Put(
+          "/upload_receiver", headers, stream_size, content_provider,
+          "application/octet-stream")) {
+      std::cout << "Cert uploaded." << std::endl;
+  } else {
+      std::cout << "error code: " << res.error() << std::endl;
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+    auto result = cli.get_openssl_verify_result();
+    if (result) {
+        std::cout << "verify error: " << X509_verify_cert_error_string(result) << std::endl;
+    }
+#endif
+  }
+
+  return 0;
+}

--- a/httplib.h
+++ b/httplib.h
@@ -4950,10 +4950,22 @@ inline bool ClientImpl::write_request(Stream &strm, const Request &req,
     headers.emplace("User-Agent", "cpp-httplib/0.7");
   }
 
+  bool is_chunked_transfer = false;
+
   if (req.body.empty()) {
     if (req.content_provider) {
-      auto length = std::to_string(req.content_length);
-      headers.emplace("Content-Length", length);
+      if (req.content_length > 0) {
+        auto length = std::to_string(req.content_length);
+        headers.emplace("Content-Length", length);
+      } else {
+        if (!req.has_header("Transfer-Encoding")) {
+          headers.emplace("Transfer-Encoding", "chunked");
+        }
+        if (!req.has_header("Content-Length")) {
+          headers.emplace("Content-Length", "0");
+        }
+        is_chunked_transfer = true;
+      }
     } else {
       if (req.method == "POST" || req.method == "PUT" ||
           req.method == "PATCH") {
@@ -5011,20 +5023,66 @@ inline bool ClientImpl::write_request(Stream &strm, const Request &req,
 
       DataSink data_sink;
       data_sink.write = [&](const char *d, size_t l) {
-        if (ok) {
-          if (detail::write_data(strm, d, l)) {
-            offset += l;
-          } else {
+        if (is_chunked_transfer) {
+          // Emit chunked response header and footer for each chunk
+          std::string before_payload_part = detail::from_i_to_hex(l) + "\r\n";
+          size_t chunk_total_size = before_payload_part.size(); // size and r-n
+          chunk_total_size += l;                                // itself
+          chunk_total_size += 2;                                // r-n
+
+          std::vector<unsigned char> chunk_compiled;
+          chunk_compiled.reserve(chunk_total_size);
+          std::memcpy(chunk_compiled.data(), before_payload_part.c_str(),
+                      before_payload_part.size());
+          std::memcpy(chunk_compiled.data() + before_payload_part.size(), d, l);
+          chunk_compiled.data()[before_payload_part.size() + l] = '\r';
+          chunk_compiled.data()[before_payload_part.size() + l + 1] = '\n';
+
+          if (!detail::write_data(strm, (const char *)chunk_compiled.data(),
+                                  chunk_total_size)) {
             ok = false;
+          }
+        } else {
+          if (ok) {
+            if (detail::write_data(strm, d, l)) {
+              offset += l;
+            } else {
+              ok = false;
+            }
           }
         }
       };
       data_sink.is_writable = [&](void) { return ok && strm.is_writable(); };
+      data_sink.done = [&](void) {
+        if (is_chunked_transfer) {
+          static const std::string done_marker("0\r\n\r\n");
+          if (!detail::write_data(strm, done_marker.data(),
+                                  done_marker.size())) {
+            ok = false;
+          }
+        }
+      };
 
-      while (offset < end_offset) {
-        if (!req.content_provider(offset, end_offset - offset, data_sink)) {
+      if (end_offset > 0) // if content_length is provided
+      {
+        while (offset < end_offset) {
+          if (!req.content_provider(offset, end_offset - offset, data_sink)) {
+            error_ = Error::Canceled;
+            return false;
+          }
+          if (!ok) {
+            error_ = Error::Write;
+            return false;
+          }
+        }
+      } else {
+        if (!req.content_provider(offset, -1, data_sink)) {
           error_ = Error::Canceled;
           return false;
+        }
+        else
+        {
+          data_sink.done();
         }
         if (!ok) {
           error_ = Error::Write;

--- a/test/test.cc
+++ b/test/test.cc
@@ -400,7 +400,7 @@ TEST(ChunkedEncodingTest, TransferDataWithoutContentLength) {
 
   // create a put listener for reading content, and write it as an output file
   svr8080.Put("/chunked_transfer_receiver",
-              [&](const Request & /*req*/, Response &res, const ContentReader &content_reader) {
+              [&](const Request & /*req*/, Response /*&res*/, const ContentReader &content_reader) {
                 std::ofstream sample_output_file("./image_out.jpg", std::ios::out | std::ios::binary);
 
                 content_reader([&](const char *data, size_t data_length) {
@@ -419,6 +419,7 @@ TEST(ChunkedEncodingTest, TransferDataWithoutContentLength) {
   std::this_thread::sleep_for(std::chrono::seconds(1));
 
   Client cli("localhost", 8080);
+  //cli.set_compress(true);
 
   // open a sample input file for providing in put request
   ContentProvider content_provider;

--- a/test/test.cc
+++ b/test/test.cc
@@ -395,6 +395,82 @@ TEST(ChunkedEncodingTest, WithResponseHandlerAndContentReceiver) {
   EXPECT_EQ(out, body);
 }
 
+TEST(ChunkedEncodingTest, TransferDataWithoutContentLength) {
+  Server svr8080;
+
+  // create a put listener for reading content, and write it as an output file
+  svr8080.Put("/chunked_transfer_receiver",
+              [&](const Request & /*req*/, Response &res, const ContentReader &content_reader) {
+                std::ofstream sample_output_file("./image_out.jpg", std::ios::out | std::ios::binary);
+
+                content_reader([&](const char *data, size_t data_length) {
+                  sample_output_file.write(data, data_length);
+                  if (data_length < CPPHTTPLIB_RECV_BUFSIZ) {
+                    sample_output_file.close();
+                  }
+                  return true;
+                });
+              });
+
+  auto thread8080 = std::thread([&]() { svr8080.listen("localhost", 8080); });
+  while (!svr8080.is_running()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  Client cli("localhost", 8080);
+
+  // open a sample input file for providing in put request
+  ContentProvider content_provider;
+  std::ifstream sample_input_file("./image.jpg",
+                                  std::ios::in | std::ios::binary);
+  if (sample_input_file) {
+    content_provider = [&](size_t offset, size_t length,
+                           httplib::DataSink &sink) {
+      do {
+        char buffer[CPPHTTPLIB_RECV_BUFSIZ];
+        sample_input_file.read(buffer, CPPHTTPLIB_RECV_BUFSIZ);
+        size_t read_bytes = sample_input_file.gcount();
+        if (read_bytes > 0) { sink.write(buffer + offset, read_bytes); }
+      } while (sample_input_file.gcount() > 0);
+
+      return true;
+    };
+  }
+
+  Headers headers;
+  size_t content_length = 0;
+  // make unknown content length put request
+  auto res = cli.Put("/chunked_transfer_receiver", headers, content_length,
+                     content_provider, "application/octet-stream");
+
+  // calculate output file size
+  std::ifstream result_input_file("./image_out.jpg", std::ios::binary);
+  const auto result_file_size_begin = result_input_file.tellg();
+  result_input_file.seekg(0, std::ios::end);
+  const auto result_file_size_end = result_input_file.tellg();
+  result_input_file.close();
+
+  // calculate input file size
+  std::ifstream input_file("./image.jpg", std::ios::binary);
+  const auto input_file_size_begin = input_file.tellg();
+  input_file.seekg(0, std::ios::end);
+  const auto input_file_size_end = input_file.tellg();
+  input_file.close();
+
+  ASSERT_TRUE(res);
+  EXPECT_EQ(200, res->status);
+  EXPECT_EQ((result_file_size_end - result_file_size_begin),
+            (input_file_size_end - input_file_size_begin));
+
+  // remove output file
+  remove("image_out.jpg");
+
+  svr8080.stop();
+  thread8080.join();
+  ASSERT_FALSE(svr8080.is_running());
+}
+
 TEST(DefaultHeadersTest, FromHTTPBin) {
   Client cli("httpbin.org");
   cli.set_default_headers({make_range_header({{1, 10}})});


### PR DESCRIPTION
When you're working with streams, especially if different threads control this stream, you might not know content-length, but you can transfer your data with Transfer-Encoding: Chunked. It has been implemented based on https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html documentation. I have created an example for transferring your data with chunked.