### PR TITLE
Fix issues reported by oss-fuzz

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3171,7 +3171,7 @@ get_range_offset_and_length(const Request &req, size_t content_length,
     r.second = slen - 1;
   }
 
-  if (r.second == -1 || r.second >= slen) {
+  if (r.second == -1) {
     r.second = slen - 1;
   }
   return std::make_pair(r.first, static_cast<size_t>(r.second - r.first) + 1);

--- a/httplib.h
+++ b/httplib.h
@@ -3171,8 +3171,9 @@ get_range_offset_and_length(const Request &req, size_t content_length,
     r.second = slen - 1;
   }
 
-  if (r.second == -1) { r.second = slen - 1; }
-
+  if (r.second == -1 || r.second >= slen) {
+    r.second = slen - 1;
+  }
   return std::make_pair(r.first, r.second - r.first + 1);
 }
 

--- a/httplib.h
+++ b/httplib.h
@@ -3174,7 +3174,7 @@ get_range_offset_and_length(const Request &req, size_t content_length,
   if (r.second == -1 || r.second >= slen) {
     r.second = slen - 1;
   }
-  return std::make_pair(r.first, r.second - r.first + 1);
+  return std::make_pair(r.first, static_cast<size_t>(r.second - r.first) + 1);
 }
 
 inline std::string make_content_range_header_field(size_t offset, size_t length,

--- a/test/test.cc
+++ b/test/test.cc
@@ -1938,6 +1938,14 @@ TEST_F(ServerTest, GetStreamedWithRangeError) {
   EXPECT_EQ(416, res->status);
 }
 
+TEST_F(ServerTest, GetStreamedWithOffsetGreaterThanContent) {
+  auto res = cli_.Get("/streamed-with-range", {
+    {"Range", "bytes=10000000-"}
+  });
+  ASSERT_TRUE(res);
+  EXPECT_EQ(416, res->status);
+}
+
 TEST_F(ServerTest, GetStreamedWithRangeMultipart) {
   auto res =
       cli_.Get("/streamed-with-range", {{make_range_header({{1, 2}, {4, 5}})}});

--- a/test/test.cc
+++ b/test/test.cc
@@ -1946,6 +1946,16 @@ TEST_F(ServerTest, GetStreamedWithOffsetGreaterThanContent) {
   EXPECT_EQ(416, res->status);
 }
 
+TEST_F(ServerTest, GetStreamedWithMaxLongLength) {
+  auto res = cli_.Get("/streamed-with-range", {
+    {"Range", "bytes=0-9223372036854775807"}
+  });
+  EXPECT_EQ(206, res->status);
+  EXPECT_EQ("7", res->get_header_value("Content-Length"));
+  EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ(std::string("abcdefg"), res->body);
+}
+
 TEST_F(ServerTest, GetStreamedWithRangeMultipart) {
   auto res =
       cli_.Get("/streamed-with-range", {{make_range_header({{1, 2}, {4, 5}})}});

--- a/test/test.cc
+++ b/test/test.cc
@@ -1897,6 +1897,15 @@ TEST_F(ServerTest, GetStreamedWithRange2) {
   EXPECT_EQ(std::string("bcdefg"), res->body);
 }
 
+TEST_F(ServerTest, GetStreamedWithRangeGreaterThanContentSize) {
+  auto res = cli_.Get("/streamed-with-range", {{make_range_header({{0, 999}})}});
+  ASSERT_TRUE(res);
+  EXPECT_EQ(206, res->status);
+  EXPECT_EQ("7", res->get_header_value("Content-Length"));
+  EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ(std::string("abcdefg"), res->body);
+}
+
 TEST_F(ServerTest, GetStreamedWithRangeSuffix1) {
   auto res = cli_.Get("/streamed-with-range", {
     {"Range", "bytes=-3"}


### PR DESCRIPTION
Hey @yhirose , 
This PR fixes 2/3 issues reported by oss-fuzz. https://github.com/yhirose/cpp-httplib/issues/718

**Issue [#26529](https://oss-fuzz.com/testcase-detail/5721235667025920).**   and **Issue [#26632](https://oss-fuzz.com/testcase-detail/4912460286656512).**  , both are caused by same issue


The last statement in get_range_offset_and_length() adds 1 to `ssize_t` result, if the value of the expression `r.second - r.first` is exactly equals LLONG_MAX then adding 1 causes integer overflow. 
I’ve typecasted the result of `r.second - r.first` to ssize_t 

Have added fix and corresponding test for this. 


**Issue [#26598](https://oss-fuzz.com/testcase-detail/6234711166550016).** Status: **Added test**

Issue arises when  the offset in range header is greater than content length e.g if range is `bytes=100-200` and content length = 6, in this case the server tries access illegal memory. [code](https://github.com/yhirose/cpp-httplib/blob/17428a8fbfe5bf08ab0b9cd50ad8574d02bd9b29/httplib.h#L4100), results in crash of server. 

From the code it seems that the [range validations](https://github.com/yhirose/cpp-httplib/blob/17428a8fbfe5bf08ab0b9cd50ad8574d02bd9b29/httplib.h#L2925) are only done while parsing the range headers from the request, and aren't dependent on size of the actual response. As the code for range handling is bit complicated, I've just added tests and commented them  (so you can merge and fix it whenever you get time)  

From [HTTP spec:](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35)
```If a syntactically valid byte-range-set includes at least one byte- range-spec whose first-byte-pos is less than the current length of the entity-body, or at least one suffix-byte-range-spec with a non- zero suffix-length, then the byte-range-set is satisfiable. Otherwise, the byte-range-set is unsatisfiable. If the byte-range-set is unsatisfiable, the server SHOULD return a response with a status of 416 (Requested range not satisfiable)```

