### PR TITLE
[oss-fuzz] Enable msan for fuzz tests

### DIFF
--- a/test/fuzzing/Makefile
+++ b/test/fuzzing/Makefile
@@ -19,7 +19,8 @@ all : server_fuzzer
 
 # Fuzz target, so that you can choose which $(LIB_FUZZING_ENGINE) to use.
 server_fuzzer : server_fuzzer.cc ../../httplib.h
-	$(CXX) $(CXXFLAGS) -o $@  $<  -Wl,-Bstatic $(OPENSSL_SUPPORT)  -Wl,-Bdynamic -ldl  $(ZLIB_SUPPORT)  $(LIB_FUZZING_ENGINE) -pthread
+# 	$(CXX) $(CXXFLAGS) -o $@  $<  -Wl,-Bstatic $(OPENSSL_SUPPORT)  -Wl,-Bdynamic -ldl  $(ZLIB_SUPPORT)  $(LIB_FUZZING_ENGINE) -pthread
+	$(CXX) $(CXXFLAGS) -o $@  $<  $(ZLIB_SUPPORT)  $(LIB_FUZZING_ENGINE) -pthread
 	zip -q -r server_fuzzer_seed_corpus.zip corpus
 
 clean:

--- a/test/test.cc
+++ b/test/test.cc
@@ -1974,8 +1974,7 @@ TEST_F(ServerTest, ClientStop) {
     }));
   }
 
-  std::this_thread::sleep_for(std::chrono::seconds(1));
-
+  std::this_thread::sleep_for(std::chrono::seconds(2));
   while (cli_.is_socket_open()) {
     cli_.stop();
     std::this_thread::sleep_for(std::chrono::milliseconds(10));


### PR DESCRIPTION
Currently there's fuzzing is not done with msan : [https://github.com/google/oss-fuzz/blob/master/projects/cpp-httplib/project.yaml] Enabling msan will help us detect uninitialised memory reads done  by server. 
 [Refer](https://github.com/google/sanitizers/wiki/MemorySanitizer)

When the fuzz test written for server  are run with msan enabled it crashes cause of issue with openssl version 1.1.1 when used with sanitizers.  So removing openssl support from fuzz targets to enabling msan.  
The PR changes Makefile used for fuzzing placed in  `test/fuzzing` 