### PR TITLE
Unsafe std::tolower

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -271,7 +271,7 @@ struct ci {
   bool operator()(const std::string &s1, const std::string &s2) const {
     return std::lexicographical_compare(
         s1.begin(), s1.end(), s2.begin(), s2.end(),
-        [](char c1, char c2) { return ::tolower(c1) < ::tolower(c2); });
+        [](unsigned char c1, unsigned char c2) { return ::tolower(c1) < ::tolower(c2); });
   }
 };
 


### PR DESCRIPTION
> std::tolower is undefined if the argument's value is neither representable as unsigned char nor equal to EOF

from https://en.cppreference.com/w/cpp/string/byte/tolower