### PR TITLE
Add keep_alive_timeout guide on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ svr.set_expect_100_continue_handler([](const Request &req, Response &res) {
 
 ```cpp
 svr.set_keep_alive_max_count(2); // Default is 5
+svr.set_keep_alive_timeout(10);  // Default is 5
 ```
 
 ### Timeout


### PR DESCRIPTION
This PR contains simple suggestions as follows:

* Add one-line guide for `set_keep_alive_timeout` on README.