### PR TITLE
Extend built-in extension MIME mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,22 +120,48 @@ svr.set_file_extension_and_mimetype_mapping("hh", "text/x-h");
 
 The followings are built-in mappings:
 
-| Extension |     MIME Type          |
-| :-------- | :--------------------- |
-| txt       | text/plain             |
-| html, htm | text/html              |
-| css       | text/css               |
-| jpeg, jpg | image/jpg              |
-| png       | image/png              |
-| gif       | image/gif              |
-| svg       | image/svg+xml          |
-| ico       | image/x-icon           |
-| json      | application/json       |
-| pdf       | application/pdf        |
-| js, mjs   | application/javascript |
-| wasm      | application/wasm       |
-| xml       | application/xml        |
-| xhtml     | application/xhtml+xml  |
+| Extension  |          MIME Type          |
+| :--------- | :-------------------------- |
+| css        | text/css                    |
+| csv        | text/csv                    |
+| txt        | text/plain                  |
+| vtt        | text/vtt                    |
+| html, htm  | text/html                   |
+| apng       | image/apng                  |
+| avif       | image/avif                  |
+| bmp        | image/bmp                   |
+| gif        | image/gif                   |
+| png        | image/png                   |
+| svg        | image/svg+xml               |
+| webp       | image/webp                  |
+| ico        | image/x-icon                |
+| tif        | image/tiff                  |
+| tiff       | image/tiff                  |
+| jpeg, jpg  | image/jpeg                  |
+| mp4        | video/mp4                   |
+| mpeg       | video/mpeg                  |
+| webm       | video/webm                  |
+| mp3        | audio/mp3                   |
+| mpga       | audio/mpeg                  |
+| weba       | audio/webm                  |
+| wav        | audio/wave                  |
+| otf        | font/otf                    |
+| ttf        | font/ttf                    |
+| woff       | font/woff                   |
+| woff2      | font/woff2                  |
+| 7z         | application/x-7z-compressed |
+| atom       | application/atom+xml        |
+| pdf        | application/pdf             |
+| mjs, js    | application/javascript      |
+| json       | application/json            |
+| rss        | application/rss+xml         |
+| tar        | application/x-tar           |
+| xhtml, xht | application/xhtml+xml       |
+| xslt       | application/xslt+xml        |
+| xml        | application/xml             |
+| gz         | application/gzip            |
+| zip        | application/zip             |
+| wasm       | application/wasm            |
 
 NOTE: These the static file server methods are not thread safe.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The followings are built-in mappings:
 | ico       | image/x-icon           |
 | json      | application/json       |
 | pdf       | application/pdf        |
-| js        | application/javascript |
+| js, mjs   | application/javascript |
 | wasm      | application/wasm       |
 | xml       | application/xml        |
 | xhtml     | application/xhtml+xml  |

--- a/httplib.h
+++ b/httplib.h
@@ -2206,6 +2206,7 @@ find_content_type(const std::string &path,
     case "txt"_: return "text/plain";
     case "ttf"_: return "font/ttf";
     case "webp"_: return "image/webp";
+    case "xht"_:
     case "xhtml"_: return "application/xhtml+xml";
     case "xslt"_: return "application/xslt+xml";
     case "xml"_: return "application/xml";

--- a/httplib.h
+++ b/httplib.h
@@ -2165,7 +2165,7 @@ find_content_type(const std::string &path,
     return "application/json";
   } else if (ext == "pdf") {
     return "application/pdf";
-  } else if (ext == "js" || ext == "mjs") {
+  } else if (ext == "js") {
     return "application/javascript";
   } else if (ext == "wasm") {
     return "application/wasm";

--- a/httplib.h
+++ b/httplib.h
@@ -2177,13 +2177,11 @@ find_content_type(const std::string &path,
     case "png"_: return "image/png";	
     case "svg"_: return "image/svg+xml";
     case "webp"_: return "image/webp";
-    case "bmp"_: return "image/bmp";
     case "ico"_: return "image/x-icon";
     case "tif"_: return "image/tiff";
     case "tiff"_: return "image/tiff";
     case "htm"_:
     case "html"_: return "text/html";
-    case "ico"_: return "image/x-icon";
     case "woff"_: return "font/woff";
     case "woff2"_: return "font/woff2";
     case "js"_:
@@ -2197,15 +2195,11 @@ find_content_type(const std::string &path,
     case "mpeg"_: return "video/mpeg";
     case "weba"_: return "audio/webm";
     case "webm"_: return "video/webm";
-    case "png"_: return "image/png";
     case "otf"_: return "font/otf";
     case "ttf"_: return "font/ttf";
     case "rss"_: return "application/rss+xml";
-    case "svg"_: return "image/svg+xml";
     case "tar"_: return "application/x-tar";
     case "txt"_: return "text/plain";
-    case "ttf"_: return "font/ttf";
-    case "webp"_: return "image/webp";
     case "xht"_:
     case "xhtml"_: return "application/xhtml+xml";
     case "xslt"_: return "application/xslt+xml";

--- a/httplib.h
+++ b/httplib.h
@@ -2148,9 +2148,9 @@ inline unsigned int str2tag(const std::string &s) {
 
 namespace udl {
 
-inline constexpr unsigned int operator"" _(const char *s, size_t l) {
-  return str2tag_core(s, l, 0);
-}
+  inline constexpr unsigned int operator"" _(const char *s, size_t l) {
+    return str2tag_core(s, l, 0);
+  }
 
 } // namespace udl
 
@@ -2162,28 +2162,60 @@ find_content_type(const std::string &path,
   auto it = user_data.find(ext);
   if (it != user_data.end()) { return it->second.c_str(); }
 
-  using namespace udl;
+  using udl::operator""_;
 
   switch (str2tag(ext)) {
-  case "txt"_: return "text/plain";
-  case "html"_:
-  case "htm"_: return "text/html";
-  case "css"_: return "text/css";
-  case "jpeg"_:
-  case "jpg"_: return "image/jpg";
-  case "vtt"_: return "text/vtt";
-  case "png"_: return "image/png";
-  case "gif"_: return "image/gif";
-  case "svg"_: return "image/svg+xml";
-  case "ico"_: return "image/x-icon";
-  case "json"_: return "application/json";
-  case "pdf"_: return "application/pdf";
-  case "js"_: return "application/javascript";
-  case "wasm"_: return "application/wasm";
-  case "xml"_: return "application/xml";
-  case "xhtml"_: return "application/xhtml+xml";
-  case "mp4"_: return "video/mp4";
-  default: return nullptr;
+    default: return nullptr;
+    case "pdf"_: return "application/pdf";
+    case "atom"_: return "application/atom+xml";
+    case "bmp"_: return "image/bmp";
+    case "css"_ : return "text/css";
+    case "csv"_: return "text/csv";
+    case "apng"_: return "image/apng";
+    case "avif"_: return "image/avif";
+    case "gif"_: return "image/gif";
+    case "png"_: return "image/png";	
+    case "svg"_: return "image/svg+xml";
+    case "webp"_: return "image/webp";
+    case "bmp"_: return "image/bmp";
+    case "ico"_: return "image/x-icon";
+    case "tif"_: return "image/tiff";
+    case "tiff"_: return "image/tiff";
+    case "htm"_:
+    case "html"_: return "text/html";
+    case "ico"_: return "image/x-icon";
+    case "woff"_: return "font/woff";
+    case "woff2"_: return "font/woff2";
+    case "js"_:
+    case "mjs"_: return "application/javascript";
+    case "json"_: return "application/json";
+    case "jpg"_:
+    case "jpeg"_: return "image/jpeg";
+    case "mp3"_: return "audio/mp3";
+    case "mpga"_: return "audio/mpeg";
+    case "mp4"_: return "video/mp4";
+    case "mpeg"_: return "video/mpeg";
+    case "weba"_: return "audio/webm";
+    case "webm"_: return "video/webm";
+    case "png"_: return "image/png";
+    case "otf"_: return "font/otf";
+    case "ttf"_: return "font/ttf";
+    case "rss"_: return "application/rss+xml";
+    case "svg"_: return "image/svg+xml";
+    case "tar"_: return "application/x-tar";
+    case "txt"_: return "text/plain";
+    case "ttf"_: return "font/ttf";
+    case "webp"_: return "image/webp";
+    case "xhtml"_: return "application/xhtml+xml";
+    case "xslt"_: return "application/xslt+xml";
+    case "xml"_: return "application/xml";
+    case "yaml"_:	 return "text/yaml";
+    case "gz"_: return "application/gzip";
+    case "zip"_: return "application/zip";
+    case "vtt"_: return "text/vtt";
+    case "wasm"_: return "application/wasm";
+    case "wav"_: return "audio/wave";
+    case "7z"_: return "application/x-7z-compressed";
   }
 }
 

--- a/httplib.h
+++ b/httplib.h
@@ -2165,7 +2165,7 @@ find_content_type(const std::string &path,
     return "application/json";
   } else if (ext == "pdf") {
     return "application/pdf";
-  } else if (ext == "js") {
+  } else if (ext == "js" || ext == "mjs") {
     return "application/javascript";
   } else if (ext == "wasm") {
     return "application/wasm";

--- a/httplib.h
+++ b/httplib.h
@@ -2166,13 +2166,16 @@ find_content_type(const std::string &path,
 
   switch (str2tag(ext)) {
     default: return nullptr;
-    case "pdf"_: return "application/pdf";
-    case "atom"_: return "application/atom+xml";
-    case "bmp"_: return "image/bmp";
-    case "css"_ : return "text/css";
+    case "css"_: return "text/css";
     case "csv"_: return "text/csv";
+    case "txt"_: return "text/plain";
+    case "vtt"_: return "text/vtt";
+    case "htm"_:
+    case "html"_: return "text/html";
+
     case "apng"_: return "image/apng";
     case "avif"_: return "image/avif";
+    case "bmp"_: return "image/bmp";
     case "gif"_: return "image/gif";
     case "png"_: return "image/png";	
     case "svg"_: return "image/svg+xml";
@@ -2180,37 +2183,38 @@ find_content_type(const std::string &path,
     case "ico"_: return "image/x-icon";
     case "tif"_: return "image/tiff";
     case "tiff"_: return "image/tiff";
-    case "htm"_:
-    case "html"_: return "text/html";
+    case "jpg"_:
+    case "jpeg"_: return "image/jpeg";
+
+    case "mp4"_: return "video/mp4";
+    case "mpeg"_: return "video/mpeg";
+    case "webm"_: return "video/webm";
+
+    case "mp3"_: return "audio/mp3";
+    case "mpga"_: return "audio/mpeg";
+    case "weba"_: return "audio/webm";
+    case "wav"_: return "audio/wave";
+
+    case "otf"_: return "font/otf";
+    case "ttf"_: return "font/ttf";
     case "woff"_: return "font/woff";
     case "woff2"_: return "font/woff2";
+
+    case "7z"_: return "application/x-7z-compressed";
+    case "atom"_: return "application/atom+xml";
+    case "pdf"_: return "application/pdf";
     case "js"_:
     case "mjs"_: return "application/javascript";
     case "json"_: return "application/json";
-    case "jpg"_:
-    case "jpeg"_: return "image/jpeg";
-    case "mp3"_: return "audio/mp3";
-    case "mpga"_: return "audio/mpeg";
-    case "mp4"_: return "video/mp4";
-    case "mpeg"_: return "video/mpeg";
-    case "weba"_: return "audio/webm";
-    case "webm"_: return "video/webm";
-    case "otf"_: return "font/otf";
-    case "ttf"_: return "font/ttf";
     case "rss"_: return "application/rss+xml";
     case "tar"_: return "application/x-tar";
-    case "txt"_: return "text/plain";
     case "xht"_:
     case "xhtml"_: return "application/xhtml+xml";
     case "xslt"_: return "application/xslt+xml";
     case "xml"_: return "application/xml";
-    case "yaml"_:	 return "text/yaml";
     case "gz"_: return "application/gzip";
     case "zip"_: return "application/zip";
-    case "vtt"_: return "text/vtt";
     case "wasm"_: return "application/wasm";
-    case "wav"_: return "audio/wave";
-    case "7z"_: return "application/x-7z-compressed";
   }
 }
 


### PR DESCRIPTION
The extension ".mjs" has been a common file extension used for JavaScript files for roughly the last six years.
It popped up after EcmaScript 2015 made a breaking change by added modules to the languages.

This PR doesn't add any *actual* code, and literally changes less than a line of text.

If you would rather that users set this as a custom header on their own, please feel free to simply reject this PR.

Related, but if I may ask, what should be a default, and what should be a built-in?
Why is, say, `.mp4` a built-in, but `.mp3`, not?

I could update the built-in list to contain around ~50 of the most common extensions that someone might use.