### PR TITLE
[PR] Special function to encode query params

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -203,6 +203,7 @@ using socket_t = int;
 #include <string>
 #include <sys/stat.h>
 #include <thread>
+#include <iomanip>
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 #include <openssl/err.h>
@@ -214,7 +215,6 @@ using socket_t = int;
 #include <openssl/applink.c>
 #endif
 
-#include <iomanip>
 #include <iostream>
 #include <sstream>
 

--- a/httplib.h
+++ b/httplib.h
@@ -1463,7 +1463,16 @@ inline std::string encode_query_param(const std::string &value){
   escaped << std::hex;
 
   for (char const &c: value) {
-    if (std::isalnum(c) || c == '-' || c == '_' || c == '.'||  c == '~') {
+    if (std::isalnum(c) ||
+        c == '-'  ||
+        c == '_'  ||
+        c == '.'  ||
+        c == '!'  ||
+        c == '~'  ||
+        c == '*'  ||
+        c == '\'' ||
+        c == '('  ||
+        c == ')') {
       escaped << c;
     } else {
       escaped << std::uppercase;

--- a/httplib.h
+++ b/httplib.h
@@ -1457,6 +1457,24 @@ inline bool is_valid_path(const std::string &path) {
   return true;
 }
 
+inline std::string encode_query_param(const std::string &value){
+  std::ostringstream escaped;
+  escaped.fill('0');
+  escaped << std::hex;
+
+  for (char const &c: value) {
+    if (std::isalnum(c) || c == '-' || c == '_' || c == '.'||  c == '~') {
+      escaped << c;
+    } else {
+      escaped << std::uppercase;
+      escaped << '%' << std::setw(2) << static_cast<int>(static_cast<unsigned char>(c));
+      escaped << std::nouppercase;
+    }
+  }
+
+  return escaped.str();
+}
+
 inline std::string encode_url(const std::string &s) {
   std::string result;
 
@@ -3002,7 +3020,7 @@ inline std::string params_to_query_str(const Params &params) {
     if (it != params.begin()) { query += "&"; }
     query += it->first;
     query += "=";
-    query += encode_url(it->second);
+    query += encode_query_param(it->second);
   }
   return query;
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -46,6 +46,18 @@ TEST(StartupTest, WSAStartup) {
 }
 #endif
 
+TEST(EncodeQueryParamTest, ParseUnescapedChararactersTest){
+  string unescapedCharacters = "-_.!~*'()";
+
+  EXPECT_EQ(detail::encode_query_param(unescapedCharacters), "-_.!~*'()");
+}
+
+TEST(EncodeQueryParamTest, ParseReservedCharactersTest){
+  string reservedCharacters = ";,/?:@&=+$";
+
+  EXPECT_EQ(detail::encode_query_param(reservedCharacters), "%3B%2C%2F%3F%3A%40%26%3D%2B%24");
+}
+
 TEST(TrimTests, TrimStringTests) {
   EXPECT_EQ("abc", detail::trim_copy("abc"));
   EXPECT_EQ("abc", detail::trim_copy("  abc  "));


### PR DESCRIPTION
#800 


Here my new PR which contains tests and added new unescaped characters ( `-_.!~*'()` )