### PR TITLE
Fix readme set_chunked_content_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ svr.Get("/stream", [&](const Request &req, Response &res) {
 ```cpp
 svr.Get("/chunked", [&](const Request& req, Response& res) {
   res.set_chunked_content_provider(
+    "text/plain",
     [](size_t offset, DataSink &sink) {
       sink.write("123", 3);
       sink.write("345", 3);


### PR DESCRIPTION
`Response::set_chunked_content_provider` has two formal parameters, not one.