### PR TITLE
check return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ int main(void)
   httplib::Client cli("localhost", 1234);
 
   if (auto res = cli.Get("/hi")) {
-    if (res->status == 200) {
+    if (res && res->status == 200) {
       std::cout << res->body << std::endl;
     }
   } else {


### PR DESCRIPTION
The original example can be misleading as the return value of client Get/Post method can be nullptr, we should check it before access "res", otherwise a segfault may occure #677 