### PR TITLE
Add exception handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ svr.set_error_handler([](const auto& req, auto& res) {
 });
 ```
 
+### Exception handler
+
+```cpp
+svr.set_error_handler([](const auto& req, auto& res) {
+  res.status = 500;
+  res.set_content("<h1>Error 500</h1><p>Internal Server Error</p>",
+                  "text/html");
+});
+```
+
 ### Pre routing handler
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -178,12 +178,15 @@ svr.set_error_handler([](const auto& req, auto& res) {
 ```
 
 ### Exception handler
+The exception handler gets called if a user routing handler throws an error.
 
 ```cpp
-svr.set_error_handler([](const auto& req, auto& res) {
+svr.set_exception_handler([](const auto& req, auto& res, std::exception &e) {
   res.status = 500;
-  res.set_content("<h1>Error 500</h1><p>Internal Server Error</p>",
-                  "text/html");
+  auto fmt = "<h1>Error 500</h1><p>%s</p>";
+  char buf[BUFSIZ];
+  snprintf(buf, sizeof(buf), fmt, e.what());
+  res.set_content(buf, "text/html");
 });
 ```
 

--- a/httplib.h
+++ b/httplib.h
@@ -611,9 +611,6 @@ public:
   using HandlerWithContentReader = std::function<void(
       const Request &, Response &, const ContentReader &content_reader)>;
 
-  using ExceptionHandlerWithResponse =
-      std::function<HandlerResponse(const Request &, Response &, std::exception &e)>;
-
   using Expect100ContinueHandler =
       std::function<int(const Request &, Response &)>;
 
@@ -659,7 +656,6 @@ public:
   Server &set_error_handler(HandlerWithResponse handler);
   Server &set_error_handler(Handler handler);
   Server &set_exception_handler(ExceptionHandler handler);
-  Server &set_exception_handler(ExceptionHandlerWithResponse handler);
   Server &set_pre_routing_handler(HandlerWithResponse handler);
   Server &set_post_routing_handler(Handler handler);
 
@@ -770,7 +766,7 @@ private:
   HandlersForContentReader delete_handlers_for_content_reader_;
   Handlers options_handlers_;
   HandlerWithResponse error_handler_;
-  ExceptionHandlerWithResponse exception_handler_;
+  ExceptionHandler exception_handler_;
   HandlerWithResponse pre_routing_handler_;
   Handler post_routing_handler_;
   Logger logger_;
@@ -4290,16 +4286,8 @@ inline Server &Server::set_error_handler(Handler handler) {
   return *this;
 }
 
-inline Server &Server::set_exception_handler(ExceptionHandlerWithResponse handler) {
-  exception_handler_ = std::move(handler);
-  return *this;
-}
-
 inline Server &Server::set_exception_handler(ExceptionHandler handler) {
-  exception_handler_ = [handler](const Request &req, Response &res, std::exception &e) {
-    handler(req, res, e);
-    return HandlerResponse::Handled;
-  };
+  exception_handler_ = std::move(handler);
   return *this;
 }
 
@@ -5078,14 +5066,20 @@ Server::process_request(Stream &strm, bool close_connection,
   }
 
   // Rounting
-  bool routed;
+  bool routed = false;
   try {
     routed = routing(req, res, strm);
   } catch (std::exception & e) {
-    if (exception_handler_)
-      routed = exception_handler_(req, res, e) == HandlerResponse::Handled;
-    else
-      throw e;
+    if (exception_handler_) {
+      exception_handler_(req, res, e);
+      routed = true;
+    } else {
+      res.status = 500;
+      res.set_header("EXCEPTION_WHAT", e.what());
+    }
+  } catch (...) {
+    res.status = 500;
+    res.set_header("EXCEPTION_WHAT", "UNKNOWN");
   }
 
   if (routed) {

--- a/httplib.h
+++ b/httplib.h
@@ -4794,17 +4794,29 @@ inline bool Server::routing(Request &req, Response &res, Stream &strm) {
           });
 
       if (req.method == "POST") {
-        return dispatch_request_for_content_reader(
-            req, res, std::move(reader), post_handlers_for_content_reader_);
+        if (dispatch_request_for_content_reader(
+            req, res, std::move(reader),
+            post_handlers_for_content_reader_)) {
+          return true;
+        }
       } else if (req.method == "PUT") {
-        return dispatch_request_for_content_reader(
-            req, res, std::move(reader), put_handlers_for_content_reader_);
+        if (dispatch_request_for_content_reader(
+            req, res, std::move(reader),
+            put_handlers_for_content_reader_)) {
+          return true;
+        }
       } else if (req.method == "PATCH") {
-        return dispatch_request_for_content_reader(
-            req, res, std::move(reader), patch_handlers_for_content_reader_);
+        if (dispatch_request_for_content_reader(
+            req, res, std::move(reader),
+            patch_handlers_for_content_reader_)) {
+          return true;
+        }
       } else if (req.method == "DELETE") {
-        return dispatch_request_for_content_reader(
-            req, res, std::move(reader), delete_handlers_for_content_reader_);
+        if (dispatch_request_for_content_reader(
+            req, res, std::move(reader),
+            delete_handlers_for_content_reader_)) {
+          return true;
+        }
       }
     }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -3384,6 +3384,34 @@ TEST(MountTest, Unmount) {
   ASSERT_FALSE(svr.is_running());
 }
 
+TEST(ExceptionTest, ThrowExceptionInHandler) {
+  Server svr;
+
+  svr.Get("/hi", [&](const Request & /*req*/, Response & /*res*/) {
+    throw std::runtime_error("exception...");
+    // res.set_content("Hello World!", "text/plain");
+  });
+
+  auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
+  while (!svr.is_running()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  // Give GET time to get a few messages.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  Client cli("localhost", PORT);
+
+  auto res = cli.Get("/hi");
+  ASSERT_TRUE(res);
+  EXPECT_EQ(500, res->status);
+  ASSERT_FALSE(res->has_header("EXCEPTION_WHAT"));
+
+  svr.stop();
+  listen_thread.join();
+  ASSERT_FALSE(svr.is_running());
+}
+
 TEST(KeepAliveTest, ReadTimeout) {
   Server svr;
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <future>
 #include <thread>
+#include <stdexcept>
 
 #define SERVER_CERT_FILE "./cert.pem"
 #define SERVER_CERT2_FILE "./cert2.pem"
@@ -968,6 +969,41 @@ TEST(ErrorHandlerTest, ContentLength) {
     auto res = cli.Get("/hi");
     ASSERT_TRUE(res);
     EXPECT_EQ(200, res->status);
+    EXPECT_EQ("text/html", res->get_header_value("Content-Type"));
+    EXPECT_EQ("26", res->get_header_value("Content-Length"));
+    EXPECT_EQ("abcdefghijklmnopqrstuvwxyz", res->body);
+  }
+
+  svr.stop();
+  thread.join();
+  ASSERT_FALSE(svr.is_running());
+}
+
+TEST(ExceptionHandlerTest, ContentLength) {
+  Server svr;
+
+  svr.set_exception_handler([](const Request & /*req*/, Response &res, std::exception & e) {
+    res.status = 500;
+    res.set_content("abcdefghijklmnopqrstuvwxyz",
+                    "text/html"); // <= Content-Length still 13
+  });
+
+  svr.Get("/hi", [](const Request & /*req*/, Response &res) {
+    res.set_content("Hello World!\n", "text/plain");
+    throw std::runtime_error("abc");
+  });
+
+  auto thread = std::thread([&]() { svr.listen(HOST, PORT); });
+
+  // Give GET time to get a few messages.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  {
+    Client cli(HOST, PORT);
+
+    auto res = cli.Get("/hi");
+    ASSERT_TRUE(res);
+    EXPECT_EQ(500, res->status);
     EXPECT_EQ("text/html", res->get_header_value("Content-Type"));
     EXPECT_EQ("26", res->get_header_value("Content-Length"));
     EXPECT_EQ("abcdefghijklmnopqrstuvwxyz", res->body);
@@ -3342,34 +3378,6 @@ TEST(MountTest, Unmount) {
   res = cli.Get("/mount2/dir/test.html");
   ASSERT_TRUE(res);
   EXPECT_EQ(404, res->status);
-
-  svr.stop();
-  listen_thread.join();
-  ASSERT_FALSE(svr.is_running());
-}
-
-TEST(ExceptionTest, ThrowExceptionInHandler) {
-  Server svr;
-
-  svr.Get("/hi", [&](const Request & /*req*/, Response & /*res*/) {
-    throw std::runtime_error("exception...");
-    // res.set_content("Hello World!", "text/plain");
-  });
-
-  auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
-  while (!svr.is_running()) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  }
-
-  // Give GET time to get a few messages.
-  std::this_thread::sleep_for(std::chrono::seconds(1));
-
-  Client cli("localhost", PORT);
-
-  auto res = cli.Get("/hi");
-  ASSERT_TRUE(res);
-  EXPECT_EQ(500, res->status);
-  ASSERT_FALSE(res->has_header("EXCEPTION_WHAT"));
 
   svr.stop();
   listen_thread.join();

--- a/test/test.cc
+++ b/test/test.cc
@@ -982,7 +982,7 @@ TEST(ErrorHandlerTest, ContentLength) {
 TEST(ExceptionHandlerTest, ContentLength) {
   Server svr;
 
-  svr.set_exception_handler([](const Request & /*req*/, Response &res, std::exception & e) {
+  svr.set_exception_handler([](const Request & /*req*/, Response &res, std::exception & /*e*/) {
     res.status = 500;
     res.set_content("abcdefghijklmnopqrstuvwxyz",
                     "text/html"); // <= Content-Length still 13


### PR DESCRIPTION
This pull request adds the option to handle C++ exceptions caused by user handlers when routing. This allows users to react to exceptions globally by logging them and restarting safely. This may be used over try/catch's within the handlers to avoid repetition in error messages: an API might return the same error message for every failed interaction, so just reacting to all exception instead of reaction to individual exception saves code and reduces binary size.