### PR TITLE
Accept URLs with a trailing slash

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6983,7 +6983,7 @@ inline Client::Client(const char *scheme_host_port)
 inline Client::Client(const char *scheme_host_port,
                       const std::string &client_cert_path,
                       const std::string &client_key_path) {
-  const static std::regex re(R"(^(?:([a-z]+)://)?([^:/?#]+)(?::(\d+))?)");
+  const static std::regex re(R"(^(?:([a-z]+)://)?([^:/?#]+)(?::(\d+))?/?)");
 
   std::cmatch m;
   if (std::regex_match(scheme_host_port, m, re)) {


### PR DESCRIPTION
According to [RFC 3986 §6.2.3](https://tools.ietf.org/html/rfc3986), we can use a trailing slash within URL that has an empty path:

> For example,
>    because the "http" scheme makes use of an authority component, has a
>    default port of "80", and defines an empty path to be equivalent to
>    "/", the following four URIs are equivalent:
> 
>       http://example.com
>       http://example.com/
>       http://example.com:/
>       http://example.com:80/

The regular expression used for URL matching doesn't accept a trailing slash. As result, we get an error like "Connection error", because our HTTP client was initialized with bad parameters.