### PR TITLE
Remove redundant call to close_socket

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2244,7 +2244,6 @@ inline socket_t create_client_socket(
           if (is_connection_error() ||
               !wait_until_socket_is_ready(sock, connection_timeout_sec,
                                           connection_timeout_usec)) {
-            close_socket(sock);
             error = Error::Connection;
             return false;
           }


### PR DESCRIPTION
The "bind_or_connect" lambda passed by "create_client_socket" calls "close_socket" on some errors.  After the lambda returns false up to the loop in "create_socket" it will also call "close_socket" which will either fail with EBADF or in a multi-threaded program may close a descriptor opened in parallel (which can cause other network sockets of files to be mysteriously closed and possibly replaced with some other descriptor).  The call to "close_socket" in the lambda is not needed, so this removes it.