### PR TITLE
Fix client.cc code, since res.error() without operator overloading…

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -804,7 +804,7 @@ enum class Error {
   Compression,
 };
 
-std::ostream& operator << (std::ostream& os, const Error& obj)
+inline std::ostream& operator << (std::ostream& os, const Error& obj)
 {
    os << static_cast<std::underlying_type<Error>::type>(obj);
    return os;

--- a/httplib.h
+++ b/httplib.h
@@ -804,6 +804,12 @@ enum class Error {
   Compression,
 };
 
+std::ostream& operator << (std::ostream& os, const Error& obj)
+{
+   os << static_cast<std::underlying_type<Error>::type>(obj);
+   return os;
+}
+
 class Result {
 public:
   Result(std::unique_ptr<Response> &&res, Error err,

--- a/test/test.cc
+++ b/test/test.cc
@@ -7,6 +7,7 @@
 #include <future>
 #include <stdexcept>
 #include <thread>
+#include <sstream>
 
 #define SERVER_CERT_FILE "./cert.pem"
 #define SERVER_CERT2_FILE "./cert2.pem"
@@ -545,6 +546,23 @@ TEST(ConnectionErrorTest, InvalidHost2) {
   auto res = cli.Get("/");
   ASSERT_TRUE(!res);
   EXPECT_EQ(Error::Connection, res.error());
+}
+
+TEST(ConnectionErrorTest, InvalidHostCheckResultErrorToString) {
+  auto host = "httpbin.org/";
+
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  SSLClient cli(host);
+#else
+  Client cli(host);
+#endif
+  cli.set_connection_timeout(std::chrono::seconds(2));
+
+  auto res = cli.Get("/");
+  ASSERT_TRUE(!res);
+  stringstream s;
+  s << "error code: " << res.error();
+  EXPECT_EQ("error code: 2", s.str());
 }
 
 TEST(ConnectionErrorTest, InvalidPort) {


### PR DESCRIPTION
I have tried the example client.cc but wasn't compiling with latest Xcode, I had to add operator overloading to make it work.