### PR TITLE
fix ssesvr use of deleted function

### DIFF
--- a/example/ssesvr.cc
+++ b/example/ssesvr.cc
@@ -39,8 +39,8 @@ public:
 private:
   mutex m_;
   condition_variable cv_;
-  atomic_int id_ = 0;
-  atomic_int cid_ = -1;
+  atomic_int id_{0};
+  atomic_int cid_{-1};
   string message_;
 };
 


### PR DESCRIPTION
Examples fail to compile with gcc version 10.2.0 on Ubuntu. 

ssesvr.cc:42:20: error: use of deleted function ‘std::atomic<int>::atomic(const std::atomic<int>&)’
   42 |   atomic_int id_ = 0;

This pull request fixes it.