### PR TITLE
Server http digest authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,12 @@ auto res = cli.Get("/", [](uint64_t len, uint64_t total) {
 ![progress](https://user-images.githubusercontent.com/236374/33138910-495c4ecc-cf86-11e7-8693-2fc6d09615c4.gif)
 
 ### Authentication
-
+#### Server
+```cpp
+// Server digest Authentication
+svr.set_digest_auth("user", "pass", "realm");
+```
+#### Client
 ```cpp
 // Basic Authentication
 cli.set_basic_auth("user", "pass");
@@ -614,7 +619,6 @@ cli.set_bearer_token_auth("token");
 NOTE: OpenSSL is required for Digest Authentication.
 
 ### Proxy server support
-
 ```cpp
 cli.set_proxy("host", port);
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -10,7 +10,7 @@ ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz
 BROTLI_DIR = /usr/local/opt/brotli
 # BROTLI_SUPPORT = -DCPPHTTPLIB_BROTLI_SUPPORT -I$(BROTLI_DIR)/include -L$(BROTLI_DIR)/lib -lbrotlicommon-static -lbrotlienc-static -lbrotlidec-static
 
-all: server client hello simplecli simplesvr upload redirect ssesvr ssecli benchmark
+all: server client hello simplecli simplesvr upload redirect ssesvr ssecli benchmark digestsvr
 
 server : server.cc ../httplib.h Makefile
 	$(CXX) -o server $(CXXFLAGS) server.cc $(OPENSSL_SUPPORT) $(ZLIB_SUPPORT) $(BROTLI_SUPPORT)
@@ -41,6 +41,9 @@ ssecli : ssecli.cc ../httplib.h Makefile
 
 benchmark : benchmark.cc ../httplib.h Makefile
 	$(CXX) -o benchmark $(CXXFLAGS) benchmark.cc $(OPENSSL_SUPPORT) $(ZLIB_SUPPORT) $(BROTLI_SUPPORT)
+
+digestsvr : digestsvr.cc ../httplib.h Makefile
+	$(CXX) -o digestsvr $(CXXFLAGS) digestsvr.cc $(OPENSSL_SUPPORT) $(ZLIB_SUPPORT) $(BROTLI_SUPPORT)
 
 pem:
 	openssl genrsa 2048 > key.pem

--- a/example/digestsvr.cc
+++ b/example/digestsvr.cc
@@ -1,0 +1,14 @@
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include <httplib.h>
+using namespace httplib;
+
+int main(void) {
+  Server svr;
+  svr.set_digest_auth("user", "pass", "test-digest");
+
+  svr.Get("/hi", [](const Request & /*req*/, Response &res) {
+    res.set_content("Authenticated!", "text/plain");
+  });
+
+  svr.listen("localhost", 8080);
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,10 +4,10 @@ CXXFLAGS = -g -std=c++11 -DGTEST_USE_OWN_TR1_TUPLE -I.. -I. -Wall -Wextra -Wtype
 OPENSSL_DIR = /usr/local/opt/openssl@1.1
 OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I$(OPENSSL_DIR)/include -L$(OPENSSL_DIR)/lib -lssl -lcrypto
 
-ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz
+#ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz
 
 BROTLI_DIR = /usr/local/opt/brotli
-BROTLI_SUPPORT = -DCPPHTTPLIB_BROTLI_SUPPORT -I$(BROTLI_DIR)/include -L$(BROTLI_DIR)/lib -lbrotlicommon -lbrotlienc -lbrotlidec
+#BROTLI_SUPPORT = -DCPPHTTPLIB_BROTLI_SUPPORT -I$(BROTLI_DIR)/include -L$(BROTLI_DIR)/lib -lbrotlicommon -lbrotlienc -lbrotlidec
 
 all : test
 	./test


### PR DESCRIPTION
Added HTTP digest authentication feature to Server. The feature is able to authenticate the HTTP digest responses in "MD5" or "MD5-sess" algorithm mode. For now only the "auth" authentication mode is supported. The issue was already discussed but never implemented here: https://github.com/yhirose/cpp-httplib/issues/375

I took nonce calculation as:
H(time-stamp ":" realm <":" private-key>)

Authentication is available for only one username and password. 