### PR TITLE
Add header-only Meson support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,7 @@
+project('httplib', 'cpp', license: 'MIT')
+
+httplib_dep = declare_dependency(include_directories: include_directories('.'))
+
+if meson.version().version_compare('>=0.54.0')
+  meson.override_dependency('httplib', httplib_dep)
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
-project('httplib', 'cpp', license: 'MIT')
+project('cpp-httplib', 'cpp', license: 'MIT')
 
-httplib_dep = declare_dependency(include_directories: include_directories('.'))
+cpp_httplib_dep = declare_dependency(include_directories: include_directories('.'))
 
 if meson.version().version_compare('>=0.54.0')
-  meson.override_dependency('httplib', httplib_dep)
+  meson.override_dependency('cpp-httplib', cpp_httplib_dep)
 endif


### PR DESCRIPTION
This allows users to call `dependency('httplib')` and have the include directory automatically configured. 

This doesn't add any advanced functionality (as you can see by the diff) so there's nothing to maintain (unless you move `httplib.h` in a separate directory; in that case `include_directories('.')` should be changed to `include_directories('newdir')`). In fact, it only makes users' life simpler :)