### PR TITLE
Fix code err code 401 when the password is empty in base_auth.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5696,7 +5696,7 @@ inline bool ClientImpl::write_request(Stream &strm, Request &req,
     }
   }
 
-  if (!basic_auth_password_.empty()) {
+  if (!basic_auth_password_.empty() || !basic_auth_username_.empty()) {
     req.headers.insert(make_basic_authentication_header(
         basic_auth_username_, basic_auth_password_, false));
   }


### PR DESCRIPTION
Fix: When setting the base_auth with a non-empty username and an empty password  no auth is insert in the header.
The problem is similar to #650 but for the password.