### PR TITLE
fix compiling on some old Arm compilers

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2348,7 +2348,7 @@ find_content_type(const std::string &path,
   auto it = user_data.find(ext);
   if (it != user_data.end()) { return it->second.c_str(); }
 
-  using udl::operator""_;
+  using udl::operator "" _;
 
   switch (str2tag(ext)) {
   default: return nullptr;


### PR DESCRIPTION
That should fix compiling on some old Arm compilers. For example it crashed for me on gcc version 4.8.3 20140320 for Arm with error: `missing space between '""' and suffix identifier`