### PR TITLE
Ignore gcc `maybe-uninitialized` warning.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4098,11 +4098,14 @@ inline ssize_t Stream::write_format(const char *fmt, const Args &...args) {
   const auto bufsiz = 2048;
   std::array<char, bufsiz> buf;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #if defined(_MSC_VER) && _MSC_VER < 1900
   auto sn = _snprintf_s(buf.data(), bufsiz - 1, buf.size() - 1, fmt, args...);
 #else
   auto sn = snprintf(buf.data(), buf.size() - 1, fmt, args...);
 #endif
+#pragma GCC diagnostic pop
   if (sn <= 0) { return sn; }
 
   auto n = static_cast<size_t>(sn);
@@ -5133,7 +5136,10 @@ Server::process_request(Stream &strm, bool close_connection,
                         const std::function<void(Request &)> &setup_request) {
   std::array<char, 2048> buf{};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
+#pragma GCC diagnostic pop
 
   // Connection has been closed on client
   if (!line_reader.getline()) { return false; }
@@ -5378,8 +5384,10 @@ inline void ClientImpl::close_socket(Socket &socket) {
 inline bool ClientImpl::read_response_line(Stream &strm, const Request &req,
                                            Response &res) {
   std::array<char, 2048> buf;
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
+#pragma GCC diagnostic pop
 
   if (!line_reader.getline()) { return false; }
 


### PR DESCRIPTION
Recent version of gcc (fedora 34, gcc 11.1.1) warn about the use `buf` where it may be
uninitialized.
But we are using `buf` to initialize it so it should be ok to use it.

I'm not sure this is the right way to fix it.
The other solution I see would be to initialize the buffer with 0 which would be somehow counterproductive here.
I let you decide :)