### PR TITLE
Improve split script

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,10 +749,20 @@ res->body; // Compressed data
 Split httplib.h into .h and .cc
 -------------------------------
 
-```bash
-> python3 split.py
-> ls out
-httplib.h  httplib.cc
+```console
+$ ./split.py -h
+usage: split.py [-h] [-e EXTENSION] [-o OUT]
+
+This script splits httplib.h into .h and .cc parts.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -e EXTENSION, --extension EXTENSION
+                        extension of the implementation file (default: cc)
+  -o OUT, --out OUT     where to write the files (default: out)
+
+$ ./split.py
+Wrote out/httplib.h and out/httplib.cc
 ```
 
 NOTE

--- a/split.py
+++ b/split.py
@@ -1,32 +1,47 @@
+#!/usr/bin/env python3
+
+"""This script splits httplib.h into .h and .cc parts."""
+
+import argparse
 import os
 import sys
 
 border = '// ----------------------------------------------------------------------------'
 
-PythonVersion = sys.version_info[0];
+args_parser = argparse.ArgumentParser(description=__doc__)
+args_parser.add_argument(
+    "-e", "--extension", help="extension of the implementation file (default: cc)",
+    default="cc"
+)
+args_parser.add_argument(
+    "-o", "--out", help="where to write the files (default: out)", default="out"
+)
+args = args_parser.parse_args()
 
-with open('httplib.h') as f:
+cur_dir = os.path.dirname(sys.argv[0])
+with open(cur_dir + '/httplib.h') as f:
     lines = f.readlines()
-    inImplementation = False
-    
-    if PythonVersion < 3:
-        os.makedirs('out')
-    else:
-        os.makedirs('out', exist_ok=True)
-        
-    with open('out/httplib.h', 'w') as fh:
-        with open('out/httplib.cc', 'w') as fc:
-            fc.write('#include "httplib.h"\n')
-            fc.write('namespace httplib {\n')
-            for line in lines:
-                isBorderLine = border in line
-                if isBorderLine:
-                    inImplementation = not inImplementation
-                else:
-                    if inImplementation:
-                        fc.write(line.replace('inline ', ''))
-                        pass
-                    else:
-                        fh.write(line)
-                        pass
-            fc.write('} // namespace httplib\n')
+
+python_version = sys.version_info[0]
+if python_version < 3:
+    os.makedirs(args.out)
+else:
+    os.makedirs(args.out, exist_ok=True)
+
+in_implementation = False
+h_out = args.out + '/httplib.h'
+cc_out = args.out + '/httplib.' + args.extension
+with open(h_out, 'w') as fh, open(cc_out, 'w') as fc:
+    fc.write('#include "httplib.h"\n')
+    fc.write('namespace httplib {\n')
+    for line in lines:
+        is_border_line = border in line
+        if is_border_line:
+            in_implementation = not in_implementation
+        elif in_implementation:
+            fc.write(line.replace('inline ', ''))
+        else:
+            fh.write(line)
+    fc.write('} // namespace httplib\n')
+
+print("Wrote {} and {}".format(h_out, cc_out))


### PR DESCRIPTION
- Added shebang and made the script executable.
- Added help text.
- Added -o/--out argument for specifying output directory.
- Added -e/--extension argument for specifying file extension of the
  implementation file.
- Made the script find httplib.h next to split.py instead of the current
  working directory. This makes it possible to call the script from
  another directory.
- Simplified code structure slightly.
- Improved variable naming to follow Python conventions.