### PR TITLE
Don't define INVALID_SOCKET if it has been defined already

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -178,7 +178,9 @@ using socket_t = SOCKET;
 #include <unistd.h>
 
 using socket_t = int;
+#ifndef INVALID_SOCKET
 #define INVALID_SOCKET (-1)
+#endif
 #endif //_WIN32
 
 #include <algorithm>


### PR DESCRIPTION
If including pcap.h from libpcap before httplib.h, INVALID_SOCKET has already been defined.
Therefore, I added an ifndef.