### PR TITLE
Full Meson support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,6 @@
 project(
   'cpp-httplib',
   'cpp',
-  version: '0.9.4',
   license: 'MIT',
   default_options: [
     'buildtype=release',
@@ -15,6 +14,31 @@ project(
   ],
   meson_version: '>=0.47.0'
 )
+
+# Check just in case downstream decides to edit the source
+# and add a project version
+version = meson.project_version()
+if version == 'undefined'
+  git = find_program('git', required: false)
+  if git.found()
+    result = run_command(git, 'describe', '--tags', '--abbrev=0')
+    if result.returncode() == 0
+      version = result.stdout().strip('v\n')
+    endif
+  endif
+endif
+
+python = import('python').find_installation('python3')
+# If version is still undefined it means that the git method failed
+if version == 'undefined'
+  # Meson doesn't have regular expressions, but since it is implemented
+  # in python we can be sure we can use it to parse the file manually
+  version = run_command(
+      python, '-c', 'import re; raw_version = re.search("User\-Agent.*cpp\-httplib/([0-9]+\.?)+", open("httplib.h").read()).group(0); print(re.search("([0-9]+\\.?)+", raw_version).group(0))'
+  ).stdout().strip()
+endif
+
+message('cpp-httplib version ' + version)
 
 deps = [dependency('threads')]
 args = []
@@ -50,7 +74,6 @@ endif
 cpp_httplib_dep = dependency('', required : false)
 
 if get_option('cpp-httplib_compile')
-  python = import('python').find_installation('python3')
   httplib_ch = custom_target(
     'split',
     input: 'httplib.h',
@@ -64,6 +87,7 @@ if get_option('cpp-httplib_compile')
     sources: httplib_ch,
     dependencies: deps,
     cpp_args: args,
+    version: version,
     install: true
   )
   cpp_httplib_dep = declare_dependency(link_with: lib, sources: httplib_ch[1])
@@ -71,9 +95,11 @@ if get_option('cpp-httplib_compile')
   import('pkgconfig').generate(
     lib,
     description: 'A C++ HTTP/HTTPS server and client library',
-    url: 'https://github.com/yhirose/cpp-httplib'
+    url: 'https://github.com/yhirose/cpp-httplib',
+    version: version
   )
 else
+  install_headers('httplib.h')
   cpp_httplib_dep = declare_dependency(include_directories: include_directories('.'), dependencies: deps)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,81 @@
-project('cpp-httplib', 'cpp', license: 'MIT')
+# SPDX-FileCopyrightText: 2021 Andrea Pappacoda
+#
+# SPDX-License-Identifier: MIT
 
-cpp_httplib_dep = declare_dependency(include_directories: include_directories('.'))
+project(
+  'cpp-httplib',
+  'cpp',
+  version: '0.9.4',
+  license: 'MIT',
+  default_options: [
+    'buildtype=release',
+    'b_ndebug=if-release',
+    'b_lto=true',
+    'warning_level=3'
+  ],
+  meson_version: '>=0.47.0'
+)
+
+deps = [dependency('threads')]
+args = []
+
+openssl_dep = dependency('openssl', version: ['>=1.1.1', '<1.1.2'], required: get_option('cpp-httplib_openssl'))
+if openssl_dep.found()
+  deps += openssl_dep
+  args += '-DCPPHTTPLIB_OPENSSL_SUPPORT'
+endif
+
+zlib_dep = dependency('zlib', required: get_option('cpp-httplib_zlib'))
+if zlib_dep.found()
+  deps += zlib_dep
+  args += '-DCPPHTTPLIB_ZLIB_SUPPORT'
+endif
+
+brotli_deps = [dependency('libbrotlicommon', required: get_option('cpp-httplib_brotli'))]
+brotli_deps += dependency('libbrotlidec',    required: get_option('cpp-httplib_brotli'))
+brotli_deps += dependency('libbrotlienc',    required: get_option('cpp-httplib_brotli'))
+
+brotli_found_all = true
+foreach brotli_dep : brotli_deps
+  if not brotli_dep.found()
+    brotli_found_all = false
+  endif
+endforeach
+
+if brotli_found_all
+  deps += brotli_deps
+  args += '-DCPPHTTPLIB_BROTLI_SUPPORT'
+endif
+
+cpp_httplib_dep = dependency('', required : false)
+
+if get_option('cpp-httplib_compile')
+  python = import('python').find_installation('python3')
+  httplib_ch = custom_target(
+    'split',
+    input: 'httplib.h',
+    output: ['httplib.cc', 'httplib.h'],
+    command: [python, files('split.py'), '--out', meson.current_build_dir()],
+    install: true,
+    install_dir: [false, get_option('includedir')]
+  )
+  lib = library(
+    'cpp-httplib',
+    sources: httplib_ch,
+    dependencies: deps,
+    cpp_args: args,
+    install: true
+  )
+  cpp_httplib_dep = declare_dependency(link_with: lib, sources: httplib_ch[1])
+
+  import('pkgconfig').generate(
+    lib,
+    description: 'A C++ HTTP/HTTPS server and client library',
+    url: 'https://github.com/yhirose/cpp-httplib'
+  )
+else
+  cpp_httplib_dep = declare_dependency(include_directories: include_directories('.'), dependencies: deps)
+endif
 
 if meson.version().version_compare('>=0.54.0')
   meson.override_dependency('cpp-httplib', cpp_httplib_dep)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2021 Andrea Pappacoda
+#
+# SPDX-License-Identifier: MIT
+
+option('cpp-httplib_openssl',    type: 'feature', value: 'auto', description: 'Enable OpenSSL support')
+option('cpp-httplib_zlib',       type: 'feature', value: 'auto', description: 'Enable zlib support')
+option('cpp-httplib_brotli',     type: 'feature', value: 'auto', description: 'Enable Brotli support')
+option('cpp-httplib_compile',    type: 'boolean', value: false,  description: 'Split the header into a compilable header & source file (requires Python 3)')


### PR DESCRIPTION
cpp-httplib can be now built with Meson even in compiled library mode.

The library is built with LTO, supports OpenSSL, zlib and Brotli, and the build system also generates a pkg-config file when needed.

Compared to the CMake file this one is quite small (more than five times smaller!), and maintaining it won't be an issue :) (and I'll keep maintaining it as I promised)

Edit: Note that I set the project version to 0.9.4 even if the released version is 0.9.3 so that when you'll release again (hopefully soon, so that people can use the improved Meson support) you'll don't have to update that yourself