### PR TITLE
Split the header only if needed

### DIFF
--- a/split.py
+++ b/split.py
@@ -26,6 +26,7 @@ source_name = '/' + lib_name + '.' + args.extension
 in_file = cur_dir + header_name
 # get the output file
 h_out = args.out + header_name
+cc_out = args.out + source_name
 
 # if the modification time of the out file is after the in file,
 # don't split (as it is already finished)
@@ -34,9 +35,8 @@ if os.path.exists(h_out):
     out_time = os.path.getmtime(h_out)
     if in_time < out_time:
         print("{} and {} are up to date".format(h_out, cc_out))
-        return
-
-
+        exit
+        
 with open(in_file) as f:
     lines = f.readlines()
 

--- a/split.py
+++ b/split.py
@@ -19,7 +19,25 @@ args_parser.add_argument(
 args = args_parser.parse_args()
 
 cur_dir = os.path.dirname(sys.argv[0])
-with open(cur_dir + '/httplib.h') as f:
+lib_name = 'httplib'
+header_name = '/' + lib_name + '.h'
+source_name = '/' + lib_name + '.' + args.extension
+# get the input file
+in_file = cur_dir + header_name
+# get the output file
+h_out = args.out + header_name
+
+# if the modification time of the out file is after the in file,
+# don't split (as it is already finished)
+if os.path.exists(h_out):
+    in_time = os.path.getmtime(in_file)
+    out_time = os.path.getmtime(h_out)
+    if in_time < out_time:
+        print("{} and {} are up to date".format(h_out, cc_out))
+        return
+
+
+with open(in_file) as f:
     lines = f.readlines()
 
 python_version = sys.version_info[0]
@@ -29,8 +47,7 @@ else:
     os.makedirs(args.out, exist_ok=True)
 
 in_implementation = False
-h_out = args.out + '/httplib.h'
-cc_out = args.out + '/httplib.' + args.extension
+cc_out = args.out + source_name
 with open(h_out, 'w') as fh, open(cc_out, 'w') as fc:
     fc.write('#include "httplib.h"\n')
     fc.write('namespace httplib {\n')

--- a/split.py
+++ b/split.py
@@ -30,35 +30,38 @@ cc_out = args.out + source_name
 
 # if the modification time of the out file is after the in file,
 # don't split (as it is already finished)
+do_split = True
+
 if os.path.exists(h_out):
     in_time = os.path.getmtime(in_file)
     out_time = os.path.getmtime(h_out)
-    if in_time < out_time:
-        print("{} and {} are up to date".format(h_out, cc_out))
-        exit
-        
-with open(in_file) as f:
-    lines = f.readlines()
+    do_split = in_time > out_time:
 
-python_version = sys.version_info[0]
-if python_version < 3:
-    os.makedirs(args.out)
+if do_split:
+    with open(in_file) as f:
+        lines = f.readlines()
+
+    python_version = sys.version_info[0]
+    if python_version < 3:
+        os.makedirs(args.out)
+    else:
+        os.makedirs(args.out, exist_ok=True)
+
+    in_implementation = False
+    cc_out = args.out + source_name
+    with open(h_out, 'w') as fh, open(cc_out, 'w') as fc:
+        fc.write('#include "httplib.h"\n')
+        fc.write('namespace httplib {\n')
+        for line in lines:
+            is_border_line = border in line
+            if is_border_line:
+                in_implementation = not in_implementation
+            elif in_implementation:
+                fc.write(line.replace('inline ', ''))
+            else:
+                fh.write(line)
+        fc.write('} // namespace httplib\n')
+
+    print("Wrote {} and {}".format(h_out, cc_out))
 else:
-    os.makedirs(args.out, exist_ok=True)
-
-in_implementation = False
-cc_out = args.out + source_name
-with open(h_out, 'w') as fh, open(cc_out, 'w') as fc:
-    fc.write('#include "httplib.h"\n')
-    fc.write('namespace httplib {\n')
-    for line in lines:
-        is_border_line = border in line
-        if is_border_line:
-            in_implementation = not in_implementation
-        elif in_implementation:
-            fc.write(line.replace('inline ', ''))
-        else:
-            fh.write(line)
-    fc.write('} // namespace httplib\n')
-
-print("Wrote {} and {}".format(h_out, cc_out))
+    print("{} and {} are up to date".format(h_out, cc_out))

--- a/split.py
+++ b/split.py
@@ -35,7 +35,7 @@ do_split = True
 if os.path.exists(h_out):
     in_time = os.path.getmtime(in_file)
     out_time = os.path.getmtime(h_out)
-    do_split = in_time > out_time:
+    do_split = in_time > out_time
 
 if do_split:
     with open(in_file) as f:


### PR DESCRIPTION
We include this project with cmake into ours. On every cmake configuration it splits the header  into its 2 parts. This change invalidstes a lot of targets resulting in unecessary rebuilds.
This pull request changes the split.py to only split if the header is newer than the split files.