### PR TITLE
Do not use `buf.size()` on a uninitialized array.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1490,9 +1490,9 @@ inline ssize_t Stream::write_format(const char *fmt, const Args &...args) {
   std::array<char, bufsiz> buf;
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
-  auto sn = _snprintf_s(buf.data(), bufsiz - 1, buf.size() - 1, fmt, args...);
+  auto sn = _snprintf_s(buf.data(), bufsiz - 1, bufsiz - 1, fmt, args...);
 #else
-  auto sn = snprintf(buf.data(), buf.size() - 1, fmt, args...);
+  auto sn = snprintf(buf.data(), bufsiz - 1, fmt, args...);
 #endif
   if (sn <= 0) { return sn; }
 
@@ -5675,7 +5675,7 @@ inline bool ClientImpl::read_response_line(Stream &strm, const Request &req,
                                            Response &res) {
   std::array<char, 2048> buf;
 
-  detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
+  detail::stream_line_reader line_reader(strm, buf.data(), 2048);
 
   if (!line_reader.getline()) { return false; }
 


### PR DESCRIPTION
Recent version of gcc raise a warning `maybe-uninitialized` when using
`size()` method on a uninitialized array.
This prevent us to use httplib in a project compiled with `-Werror`.


This fixes the same problem than #980 but in a better way.
I concentrate myself on the place where gcc raised a warning, not everywhere in the code where we could replace `buf.size()` by a constant.