### PR TITLE
build(meson): feature args in pkg-config file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -96,6 +96,7 @@ if get_option('cpp-httplib_compile')
   import('pkgconfig').generate(
     lib,
     description: 'A C++ HTTP/HTTPS server and client library',
+    extra_cflags: args,
     url: 'https://github.com/yhirose/cpp-httplib',
     version: version
   )


### PR DESCRIPTION
Follow-up for #1090. The args are now also added to the pkg-config file.