### PR TITLE
Fix set_content_provider example in README.md. Fixes #1161.

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Without content length:
 svr.Get("/stream", [&](const Request &req, Response &res) {
   res.set_content_provider(
     "text/plain", // Content type
-    [&](size_t offset, size_t length, DataSink &sink) {
+    [&](size_t offset, DataSink &sink) {
       if (/* there is still data */) {
         std::vector<char> data;
         // prepare data...


### PR DESCRIPTION
The example didn't passed an integer to `set_content_provider` meaning it calls this function:
https://github.com/yhirose/cpp-httplib/blob/412ab5f0634a1e1db43ccff57c82797f9469497c/httplib.h#L472-L473
which takes as an argument a `ContentProviderWithoutLength` function which correspond to:
https://github.com/yhirose/cpp-httplib/blob/412ab5f0634a1e1db43ccff57c82797f9469497c/httplib.h#L356-L357

This corresponds to this unit test:
https://github.com/yhirose/cpp-httplib/blob/412ab5f0634a1e1db43ccff57c82797f9469497c/test/test.cc#L3652-L3656

which doesn't match the example:
https://github.com/yhirose/cpp-httplib/blob/412ab5f0634a1e1db43ccff57c82797f9469497c/README.md#L306