### PR TITLE
build(meson): always install a pkg-config file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,12 +19,13 @@ project(
 # Check just in case downstream decides to edit the source
 # and add a project version
 version = meson.project_version()
-python = import('python').find_installation('python3')
+python3 = find_program('python3')
 if version == 'undefined'
   # Meson doesn't have regular expressions, but since it is implemented
   # in python we can be sure we can use it to parse the file manually
   version = run_command(
-      python, '-c', 'import re; raw_version = re.search("User\-Agent.*cpp\-httplib/([0-9]+\.?)+", open("httplib.h").read()).group(0); print(re.search("([0-9]+\\.?)+", raw_version).group(0))'
+      python3, '-c', 'import re; raw_version = re.search("User\-Agent.*cpp\-httplib/([0-9]+\.?)+", open("httplib.h").read()).group(0); print(re.search("([0-9]+\\.?)+", raw_version).group(0))',
+      check: true
   ).stdout().strip()
 endif
 
@@ -68,7 +69,7 @@ if get_option('cpp-httplib_compile')
     'split',
     input: 'httplib.h',
     output: ['httplib.cc', 'httplib.h'],
-    command: [python, files('split.py'), '--out', meson.current_build_dir()],
+    command: [python3, files('split.py'), '--out', meson.current_build_dir()],
     install: true,
     install_dir: [false, get_option('includedir')]
   )
@@ -92,6 +93,14 @@ if get_option('cpp-httplib_compile')
 else
   install_headers('httplib.h')
   cpp_httplib_dep = declare_dependency(compile_args: args, dependencies: deps, include_directories: include_directories('.'))
+
+  import('pkgconfig').generate(
+    name: 'cpp-httplib',
+    description: 'A C++ HTTP/HTTPS server and client library',
+    install_dir: join_paths(get_option('datadir'), 'pkgconfig'),
+    url: 'https://github.com/yhirose/cpp-httplib',
+    version: version
+  )
 endif
 
 if meson.version().version_compare('>=0.54.0')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,5 +5,5 @@
 option('cpp-httplib_openssl', type: 'feature', value: 'auto', description: 'Enable OpenSSL support')
 option('cpp-httplib_zlib',    type: 'feature', value: 'auto', description: 'Enable zlib support')
 option('cpp-httplib_brotli',  type: 'feature', value: 'auto', description: 'Enable Brotli support')
-option('cpp-httplib_compile', type: 'boolean', value: false,  description: 'Split the header into a compilable header & source file (requires Python 3)')
+option('cpp-httplib_compile', type: 'boolean', value: false,  description: 'Split the header into a compilable header & source file')
 option('cpp-httplib_test',    type: 'boolean', value: false,  description: 'Build tests')


### PR DESCRIPTION
A pkg-config file was previously installed only if cpp-httplib was being built as a compiled library.

Since architecture-independent .pc files can exist in /usr/share/pkgconfig, it can be useful to install one even when installing the header-only version (for example, it could be used by third party projects to easily find out if cpp-httplib is installed and its version, using something like Meson's `dependency()` or CMake's `pkg_check_modules()`).

This is accomplished using the `dataonly` kwarg of Meson's pkg-config generator, introduced in version 0.54.0. This means that I had to bump the minimum required version, but since that has been released in March 2020 and is available in Debian 11 I believe it's fine to require it.

The change makes the Meson build behave a bit more like the CMake one, as it also always installs a CMake Config file, but here the pkg-config file gets installed to the correct architecture-independent directory (`datadir` represents /usr/share on Linux and simiar systems).

Lastly, I made some minor cleanups, partially thanks to the version bump