### PR TITLE
test: add missing "_Online" suffix

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -610,7 +610,7 @@ TEST(ConnectionErrorTest, InvalidPort) {
   EXPECT_EQ(Error::Connection, res.error());
 }
 
-TEST(ConnectionErrorTest, Timeout) {
+TEST(ConnectionErrorTest, Timeout_Online) {
   auto host = "google.com";
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT


### PR DESCRIPTION
This test fails reproducibly in a Debian build chroot, and they generally don't have internet access