### PR TITLE
CPPHTTPLIB_NO_DEFAULT_USER_AGENT skips default user agent

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6153,9 +6153,11 @@ inline bool ClientImpl::write_request(Stream &strm, Request &req,
 
   if (!req.has_header("Accept")) { req.headers.emplace("Accept", "*/*"); }
 
+#ifndef CPPHTTPLIB_NO_DEFAULT_USER_AGENT
   if (!req.has_header("User-Agent")) {
     req.headers.emplace("User-Agent", "cpp-httplib/0.10.2");
   }
+#endif
 
   if (req.body.empty()) {
     if (req.content_provider_) {


### PR DESCRIPTION
For bandwidth critical environments, it can be desirable to send no User-Agent header.
This modification causes cpp-httplib not to write the default User-Agent if CPPHTTPLIB_NO_DEFAULT_USER_AGENT is defined.