### PR TITLE
Add optional private key password to SSLServer ctor

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -65,6 +65,8 @@ cert.pem:
 	openssl req -x509 -new -batch -config test.rootCA.conf -key rootCA.key.pem -days 1024 > rootCA.cert.pem
 	openssl genrsa 2048 > client.key.pem
 	openssl req -new -batch -config test.conf -key client.key.pem | openssl x509 -days 370 -req -CA rootCA.cert.pem -CAkey rootCA.key.pem -CAcreateserial > client.cert.pem
+	openssl genrsa -passout pass:test123! 2048 > key_encrypted.pem
+	openssl req -new -batch -config test.conf -key key_encrypted.pem | openssl x509 -days 3650 -req -signkey key_encrypted.pem > cert_encrypted.pem
 	#c_rehash .
 
 clean:

--- a/test/meson.build
+++ b/test/meson.build
@@ -33,6 +33,13 @@ cert2_pem = custom_target(
   command: [openssl, 'req', '-x509', '-config', test_conf, '-key', '@INPUT@', '-sha256', '-days', '3650', '-nodes', '-out', '@OUTPUT@', '-extensions', 'SAN']
 )
 
+cert_encrypted_pem = custom_target(
+  'cert_encrypted_pem',
+  input: key_encrypted_pem,
+  output: 'cert_encrypted.pem',
+  command: [openssl, 'req', '-x509', '-config', test_conf, '-key', '@INPUT@', '-sha256', '-days', '3650', '-nodes', '-out', '@OUTPUT@', '-extensions', 'SAN']
+)
+
 rootca_key_pem = custom_target(
   'rootca_key_pem',
   output: 'rootCA.key.pem',

--- a/test/test.cc
+++ b/test/test.cc
@@ -18,6 +18,9 @@
 #define CLIENT_CA_CERT_DIR "."
 #define CLIENT_CERT_FILE "./client.cert.pem"
 #define CLIENT_PRIVATE_KEY_FILE "./client.key.pem"
+#define SERVER_ENCRYPTED_CERT_FILE "./cert_encrypted.pem"
+#define SERVER_ENCRYPTED_PRIVATE_KEY_FILE "./key_encrypted.pem"
+#define SERVER_ENCRYPTED_PRIVATE_KEY_PASS "test123!"
 
 using namespace std;
 using namespace httplib;
@@ -1187,6 +1190,17 @@ TEST(BindServerTest, BindAndListenSeparately) {
 TEST(BindServerTest, BindAndListenSeparatelySSL) {
   SSLServer svr(SERVER_CERT_FILE, SERVER_PRIVATE_KEY_FILE, CLIENT_CA_CERT_FILE,
                 CLIENT_CA_CERT_DIR);
+  int port = svr.bind_to_any_port("0.0.0.0");
+  ASSERT_TRUE(svr.is_valid());
+  ASSERT_TRUE(port > 0);
+  svr.stop();
+}
+#endif
+
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+TEST(BindServerTest, BindAndListenSeparatelySSLEncryptedKey) {
+  SSLServer svr(SERVER_ENCRYPTED_CERT_FILE, SERVER_ENCRYPTED_PRIVATE_KEY_FILE, nullptr,
+                nullptr, SERVER_ENCRYPTED_PRIVATE_KEY_PASS);
   int port = svr.bind_to_any_port("0.0.0.0");
   ASSERT_TRUE(svr.is_valid());
   ASSERT_TRUE(port > 0);


### PR DESCRIPTION
This parameter bypasses the prompt at runtime when using an encrypted private key:
```
Enter PEM pass phrase:
```

Let me know if you think it might be worth adding this and I can add required unit tests.