### PR TITLE
Feature/tcp cork switch on linux

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6153,9 +6153,11 @@ inline bool ClientImpl::write_request(Stream &strm, Request &req,
 
   if (!req.has_header("Accept")) { req.headers.emplace("Accept", "*/*"); }
 
+#ifndef CPPHTTPLIB_NO_DEFAULT_USER_AGENT
   if (!req.has_header("User-Agent")) {
     req.headers.emplace("User-Agent", "cpp-httplib/0.10.2");
   }
+#endif
 
   if (req.body.empty()) {
     if (req.content_provider_) {

--- a/httplib.h
+++ b/httplib.h
@@ -2574,6 +2574,13 @@ socket_t create_socket(const char *host, const char *ip, int port,
     if (fcntl(sock, F_SETFD, FD_CLOEXEC) == -1) { continue; }
 #endif
 
+#ifdef __linux__
+#ifdef CPPHTTPLIB_LINUX_TCP_CORK
+    int state = 1;
+    setsockopt(sock, IPPROTO_TCP, TCP_CORK, reinterpret_cast<char *>(&state), sizeof(state));
+#endif
+#endif
+
     if (tcp_nodelay) {
       int yes = 1;
       setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&yes),


### PR DESCRIPTION
We added the following for the client: if CPPHTTPLIB_LINUX_TCP_CORK is defined on Linux, we add the TCP_CORK flag to the socket. 
This is useful in bandwidth critical situations as the http header can be combined with the first chunk of payload in one tcp frame (see issue https://github.com/yhirose/cpp-httplib/issues/1203).

The TCP_CORK flag causes the tcp frame to be sent when the packet reaches the maximum length. Otherwise the packet will be sent after a timeout of 200ms. For this reason we have not added a manual mechanism to send the packet after the payload is finished.

We wanted to contribute this back to you and hope you like it.