### PR TITLE
Give DataSink a "sendfile" method which  performs zero-copy on Linux

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -338,6 +338,7 @@ public:
 #ifdef __linux__
     int fd;
     if ((fd = open(path.c_str(), O_RDONLY)) < 0) {
+      std::cerr << "Failed to open file" << std::endl;
       return false;
     }
 
@@ -346,6 +347,7 @@ public:
       ssize_t bytes_written = ::sendfile(socket_, fd, &file_offset, length);
       if (bytes_written < 0) {
         close(fd);
+	std::cerr << "Failed to call sendfile with errno=" << errno << ":" << strerror(errno) << std::endl;
         return false;
       }
       total_bytes_written += bytes_written;

--- a/httplib.h
+++ b/httplib.h
@@ -331,11 +331,11 @@ public:
   DataSink &operator=(DataSink &&) = delete;
 
   bool sendfile(const std::string& path, ssize_t file_offset, size_t length) {
-#ifdef __linux__
     if (!socket_ || !offset_) {
       return false;
     }
 
+#ifdef __linux__
     int fd;
     if ((fd = open(path.c_str(), O_RDONLY)) < 0) {
       return false;
@@ -364,8 +364,6 @@ public:
   }
 
   bool sendfile(const std::string& path) {
-    (void) socket_;
-    (void) offset_;
     // Use std::filesystem::file_size instead once we support C++17
     std::ifstream fs(path, std::ios_base::binary);
     fs.seekg(0, std::ios_base::end);


### PR DESCRIPTION
On Linux, this performs zero-copy to send a file from disk to socket.
On other platforms, this is simply a helper function to send a file.

More information about sendfile:
* manpage: https://man7.org/linux/man-pages/man2/sendfile.2.html
* Nice article: https://medium.com/swlh/linux-zero-copy-using-sendfile-75d2eb56b39b
From the benchmark I did on my side, I noticed the same improvements as the one described in this article

I wish I could implement this for the static file server too, since this is where I assume this will be used the most, but this is more complicated to do.

But having it in content provider sounds like a good first step.

If the change look good to you, I will update the README.md to add examples on how to use this (based on the unit tests).