### PR TITLE
meson: fix regression that broke extracting version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,12 +21,11 @@ project(
 version = meson.project_version()
 python3 = find_program('python3')
 if version == 'undefined'
-  # Meson doesn't have regular expressions, but since it is implemented
-  # in python we can be sure we can use it to parse the file manually
-  version3 = run_command(
-      python3, '-c', 'import re, sys; raw_version = re.search("#define CPPHTTPLIB_VERSION \"([0-9]+\.?)+\"", open(sys.argv[1]).read()).group(0); print(re.search("([0-9]+\\.?)+", raw_version).group(0))', files('httplib.h'),
-      check: true
-  ).stdout().strip()
+  cxx = meson.get_compiler('cpp')
+  version = cxx.get_define('CPPHTTPLIB_VERSION',
+    prefix: '#include <httplib.h>',
+    include_directories: include_directories('.')).strip('"')
+  assert(version != '', 'failed to get version from httplib.h')
 endif
 
 message('cpp-httplib version ' + version)

--- a/meson.build
+++ b/meson.build
@@ -23,8 +23,8 @@ python3 = find_program('python3')
 if version == 'undefined'
   # Meson doesn't have regular expressions, but since it is implemented
   # in python we can be sure we can use it to parse the file manually
-  version = run_command(
-      python3, '-c', 'import re; raw_version = re.search("User\-Agent.*cpp\-httplib/([0-9]+\.?)+", open("httplib.h").read()).group(0); print(re.search("([0-9]+\\.?)+", raw_version).group(0))',
+  version3 = run_command(
+      python3, '-c', 'import re, sys; raw_version = re.search("#define CPPHTTPLIB_VERSION \"([0-9]+\.?)+\"", open(sys.argv[1]).read()).group(0); print(re.search("([0-9]+\\.?)+", raw_version).group(0))', files('httplib.h'),
       check: true
   ).stdout().strip()
 endif


### PR DESCRIPTION
In commit 33f67386fec8040a36a26b2038b39dd8dcf2814d the code that heuristically parsed the version broke due to the version being moved around into a more easily accessible define.

Also fix using this as a subproject since commit 8ecdb1197967dea050fd38a8e9b5020e02320b31. 