### PR TITLE
build(meson): mark *_encrypted_pem as test deps

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -100,6 +100,8 @@ test(
     key_pem,
     cert_pem,
     cert2_pem,
+    key_encrypted_pem,
+    cert_encrypted_pem,
     rootca_key_pem,
     rootca_cert_pem,
     client_key_pem,


### PR DESCRIPTION
Meson only runs required targets. The `key_encrypted_pem` and `cert_encrypted_pem` targets added in 020b0db090dc8e197cbedbdc4db7e3120eda5333 and 8191fd8e6c5a27e034a34084afe61f17a9420cfa weren't added to the list of targets required by the test target, so the generation of the encrypted certs was skipped, resulting in the failure of `BindServerTest.BindAndListenSeparatelySSLEncryptedKey`.