### PR TITLE
build(meson): allow using OpenSSL 3.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,7 +33,7 @@ message('cpp-httplib version ' + version)
 deps = [dependency('threads')]
 args = []
 
-openssl_dep = dependency('openssl', version: ['>=1.1.1', '<1.1.2'], required: get_option('cpp-httplib_openssl'))
+openssl_dep = dependency('openssl', version: '>=1.1.1', required: get_option('cpp-httplib_openssl'))
 if openssl_dep.found()
   deps += openssl_dep
   args += '-DCPPHTTPLIB_OPENSSL_SUPPORT'


### PR DESCRIPTION
Following 0857eba17b9d3ef90d45950f9853b7579d6a7f29 cpp-httplib is fully compatible with OpenSSL versions newer than 1.1.1