### PR TITLE
Accept large data transfer over SSL

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7221,11 +7221,13 @@ inline bool SSLSocketStream::is_writable() const {
 }
 
 inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
+  size_t readbytes = 0;
   if (SSL_pending(ssl_) > 0) {
-    return SSL_read(ssl_, ptr, static_cast<int>(size));
+    SSL_read_ex(ssl_, ptr, size, &readbytes);
+    return static_cast<ssize_t>(readbytes);
   } else if (is_readable()) {
-    auto ret = SSL_read(ssl_, ptr, static_cast<int>(size));
-    if (ret < 0) {
+    auto ret = SSL_read_ex(ssl_, ptr, size, &readbytes);
+    if (ret == 0) {
       auto err = SSL_get_error(ssl_, ret);
       int n = 1000;
 #ifdef _WIN32
@@ -7236,26 +7238,28 @@ inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
       while (--n >= 0 && err == SSL_ERROR_WANT_READ) {
 #endif
         if (SSL_pending(ssl_) > 0) {
-          return SSL_read(ssl_, ptr, static_cast<int>(size));
+          SSL_read_ex(ssl_, ptr, size, &readbytes);
+          return static_cast<ssize_t>(readbytes);
         } else if (is_readable()) {
           std::this_thread::sleep_for(std::chrono::milliseconds(1));
-          ret = SSL_read(ssl_, ptr, static_cast<int>(size));
-          if (ret >= 0) { return ret; }
+          ret = SSL_read_ex(ssl_, ptr, size, &readbytes);
+          if (ret == 1) { return static_cast<ssize_t>(readbytes); }
           err = SSL_get_error(ssl_, ret);
         } else {
           return -1;
         }
       }
     }
-    return ret;
+    return static_cast<ssize_t>(readbytes);
   }
   return -1;
 }
 
 inline ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
   if (is_writable()) {
-    auto ret = SSL_write(ssl_, ptr, static_cast<int>(size));
-    if (ret < 0) {
+    size_t written = 0;
+    auto ret = SSL_write_ex(ssl_, ptr, size, &written);
+    if (ret == 0) {
       auto err = SSL_get_error(ssl_, ret);
       int n = 1000;
 #ifdef _WIN32
@@ -7267,15 +7271,15 @@ inline ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
 #endif
         if (is_writable()) {
           std::this_thread::sleep_for(std::chrono::milliseconds(1));
-          ret = SSL_write(ssl_, ptr, static_cast<int>(size));
-          if (ret >= 0) { return ret; }
+          ret = SSL_write_ex(ssl_, ptr, size, &written);
+          if (ret == 1) { return static_cast<ssize_t>(written); }
           err = SSL_get_error(ssl_, ret);
         } else {
           return -1;
         }
       }
     }
-    return ret;
+    return static_cast<ssize_t>(written);
   }
   return -1;
 }

--- a/httplib.h
+++ b/httplib.h
@@ -7223,63 +7223,54 @@ inline bool SSLSocketStream::is_writable() const {
 inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
   size_t readbytes = 0;
   if (SSL_pending(ssl_) > 0) {
-    SSL_read_ex(ssl_, ptr, size, &readbytes);
-    return static_cast<ssize_t>(readbytes);
-  } else if (is_readable()) {
     auto ret = SSL_read_ex(ssl_, ptr, size, &readbytes);
-    if (ret == 0) {
-      auto err = SSL_get_error(ssl_, ret);
-      int n = 1000;
+    return (ret == 1 ? static_cast<ssize_t>(readbytes) : -1);
+  }
+  if (!is_readable()) { return -1; }
+
+  auto ret = SSL_read_ex(ssl_, ptr, size, &readbytes);
+  if (ret == 1) { return static_cast<ssize_t>(readbytes); }
+  auto err = SSL_get_error(ssl_, ret);
+  int n = 1000;
 #ifdef _WIN32
-      while (--n >= 0 && (err == SSL_ERROR_WANT_READ ||
-                          (err == SSL_ERROR_SYSCALL &&
-                           WSAGetLastError() == WSAETIMEDOUT))) {
+  while (--n >= 0 &&
+         (err == SSL_ERROR_WANT_READ ||
+          (err == SSL_ERROR_SYSCALL && WSAGetLastError() == WSAETIMEDOUT))) {
 #else
-      while (--n >= 0 && err == SSL_ERROR_WANT_READ) {
+  while (--n >= 0 && err == SSL_ERROR_WANT_READ) {
 #endif
-        if (SSL_pending(ssl_) > 0) {
-          SSL_read_ex(ssl_, ptr, size, &readbytes);
-          return static_cast<ssize_t>(readbytes);
-        } else if (is_readable()) {
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
-          ret = SSL_read_ex(ssl_, ptr, size, &readbytes);
-          if (ret == 1) { return static_cast<ssize_t>(readbytes); }
-          err = SSL_get_error(ssl_, ret);
-        } else {
-          return -1;
-        }
-      }
+    if (SSL_pending(ssl_) > 0) {
+      ret = SSL_read_ex(ssl_, ptr, size, &readbytes);
+      return (ret == 1 ? static_cast<ssize_t>(readbytes) : -1);
     }
-    return static_cast<ssize_t>(readbytes);
+    if (!is_readable()) { return -1; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    ret = SSL_read_ex(ssl_, ptr, size, &readbytes);
+    if (ret == 1) { return static_cast<ssize_t>(readbytes); }
+    err = SSL_get_error(ssl_, ret);
   }
   return -1;
 }
 
 inline ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
-  if (is_writable()) {
-    size_t written = 0;
-    auto ret = SSL_write_ex(ssl_, ptr, size, &written);
-    if (ret == 0) {
-      auto err = SSL_get_error(ssl_, ret);
-      int n = 1000;
+  if (!is_writable()) { return -1; }
+  size_t written = 0;
+  auto ret = SSL_write_ex(ssl_, ptr, size, &written);
+  if (ret == 1) { return static_cast<ssize_t>(written); }
+  auto err = SSL_get_error(ssl_, ret);
+  int n = 1000;
 #ifdef _WIN32
-      while (--n >= 0 && (err == SSL_ERROR_WANT_WRITE ||
-                          (err == SSL_ERROR_SYSCALL &&
-                           WSAGetLastError() == WSAETIMEDOUT))) {
+  while (--n >= 0 &&
+         (err == SSL_ERROR_WANT_WRITE ||
+          (err == SSL_ERROR_SYSCALL && WSAGetLastError() == WSAETIMEDOUT))) {
 #else
-      while (--n >= 0 && err == SSL_ERROR_WANT_WRITE) {
+  while (--n >= 0 && err == SSL_ERROR_WANT_WRITE) {
 #endif
-        if (is_writable()) {
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
-          ret = SSL_write_ex(ssl_, ptr, size, &written);
-          if (ret == 1) { return static_cast<ssize_t>(written); }
-          err = SSL_get_error(ssl_, ret);
-        } else {
-          return -1;
-        }
-      }
-    }
-    return static_cast<ssize_t>(written);
+    if (!is_writable()) { return -1; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    ret = SSL_write_ex(ssl_, ptr, size, &written);
+    if (ret == 1) { return static_cast<ssize_t>(written); }
+    err = SSL_get_error(ssl_, ret);
   }
   return -1;
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -4661,7 +4661,8 @@ TEST(SSLClientServerTest, CustomizeServerSSLCtx) {
   t.join();
 }
 
-TEST(SSLClientServerTest, LargeDataTransfer) {
+// Disabled due to the out-of-memory problem on GitHub Actions Workflows
+TEST(SSLClientServerTest, DISABLED_LargeDataTransfer) {
 
   // prepare large data
   std::random_device seed_gen;

--- a/test/test.cc
+++ b/test/test.cc
@@ -4676,8 +4676,7 @@ TEST(SSLClientServerTest, LargeDataTransfer) {
 
   svr.Post("/binary", [&](const Request &req, Response &res) {
     EXPECT_EQ(large_size_byte, req.body.size());
-    EXPECT_TRUE(std::memcmp(binary.data(), req.body.data(), large_size_byte) ==
-                0);
+    EXPECT_EQ(0, std::memcmp(binary.data(), req.body.data(), large_size_byte));
     res.set_content(req.body, "application/octet-stream");
   });
 
@@ -4697,8 +4696,7 @@ TEST(SSLClientServerTest, LargeDataTransfer) {
   // compare
   EXPECT_EQ(200, res->status);
   EXPECT_EQ(large_size_byte, res->body.size());
-  EXPECT_TRUE(std::memcmp(binary.data(), res->body.data(), large_size_byte) ==
-              0);
+  EXPECT_EQ(0, std::memcmp(binary.data(), res->body.data(), large_size_byte));
 
   // cleanup
   svr.stop();

--- a/test/test.cc
+++ b/test/test.cc
@@ -4660,6 +4660,48 @@ TEST(SSLClientServerTest, CustomizeServerSSLCtx) {
 
   t.join();
 }
+
+TEST(SSLClientServerTest, LargeDataTransfer) {
+
+  // prepare large data
+  std::random_device seed_gen;
+  std::mt19937 random(seed_gen());
+  constexpr auto large_size_byte = 2147483648UL + 1048576UL; // 2GiB + 1MiB
+  std::vector<std::uint32_t> binary(large_size_byte / sizeof(std::uint32_t));
+  std::generate(binary.begin(), binary.end(), [&random]() { return random(); });
+
+  // server
+  SSLServer svr(SERVER_CERT_FILE, SERVER_PRIVATE_KEY_FILE);
+  ASSERT_TRUE(svr.is_valid());
+
+  svr.Post("/binary", [&](const Request &req, Response &res) {
+    EXPECT_EQ(large_size_byte, req.body.size());
+    EXPECT_TRUE(std::memcmp(binary.data(), req.body.data(), large_size_byte) ==
+                0);
+    res.set_content(req.body, "application/octet-stream");
+  });
+
+  auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
+  while (!svr.is_running()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  SSLClient cli("localhost", PORT);
+  cli.enable_server_certificate_verification(false);
+  cli.set_read_timeout(std::chrono::seconds(100));
+  cli.set_write_timeout(std::chrono::seconds(100));
+  auto res = cli.Post("/binary", reinterpret_cast<char *>(binary.data()),
+                      large_size_byte, "application/octet-stream");
+
+  EXPECT_EQ(200, res->status);
+  EXPECT_EQ(large_size_byte, res->body.size());
+  EXPECT_TRUE(std::memcmp(binary.data(), res->body.data(), large_size_byte) ==
+              0);
+
+  svr.stop();
+  listen_thread.join();
+  ASSERT_FALSE(svr.is_running());
+}
 #endif
 
 #ifdef _WIN32
@@ -4897,4 +4939,3 @@ TEST(MultipartFormDataTest, LargeData) {
   t.join();
 }
 #endif
-

--- a/test/test.cc
+++ b/test/test.cc
@@ -4686,6 +4686,7 @@ TEST(SSLClientServerTest, LargeDataTransfer) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
+  // client POST
   SSLClient cli("localhost", PORT);
   cli.enable_server_certificate_verification(false);
   cli.set_read_timeout(std::chrono::seconds(100));
@@ -4693,11 +4694,13 @@ TEST(SSLClientServerTest, LargeDataTransfer) {
   auto res = cli.Post("/binary", reinterpret_cast<char *>(binary.data()),
                       large_size_byte, "application/octet-stream");
 
+  // compare
   EXPECT_EQ(200, res->status);
   EXPECT_EQ(large_size_byte, res->body.size());
   EXPECT_TRUE(std::memcmp(binary.data(), res->body.data(), large_size_byte) ==
               0);
 
+  // cleanup
   svr.stop();
   listen_thread.join();
   ASSERT_FALSE(svr.is_running());
@@ -4939,3 +4942,4 @@ TEST(MultipartFormDataTest, LargeData) {
   t.join();
 }
 #endif
+


### PR DESCRIPTION
I found that the HTTP client cannot send the large request body when SSL is enabled.

In `SSL_write` and `SSL_read` the `size_t` type is cast to `int` hence the threshold is 2GiB.
This pull request fixes this problem by replacing them with `SSL_*_ex` functions and accepts large data transfers over SSL.

The changes are as follows:

- [x] Replace `SSL_write` with `SSL_write_ex`
- [x] Replace `SSL_read` with `SSL_read_ex`
- [x] Add a test for large data transfer over SSL

@yhirose Could you review this PR?