### PR TITLE
build(meson): don't require python3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,6 @@ project(
 # Check just in case downstream decides to edit the source
 # and add a project version
 version = meson.project_version()
-python3 = find_program('python3')
 if version == 'undefined'
   cxx = meson.get_compiler('cpp')
   version = cxx.get_define('CPPHTTPLIB_VERSION',
@@ -27,8 +26,6 @@ if version == 'undefined'
     include_directories: include_directories('.')).strip('"')
   assert(version != '', 'failed to get version from httplib.h')
 endif
-
-message('cpp-httplib version ' + version)
 
 deps = [dependency('threads')]
 args = []
@@ -64,6 +61,8 @@ endif
 cpp_httplib_dep = dependency('', required: false)
 
 if get_option('cpp-httplib_compile')
+  python3 = find_program('python3')
+
   httplib_ch = custom_target(
     'split',
     input: 'httplib.h',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,5 +5,5 @@
 option('cpp-httplib_openssl', type: 'feature', value: 'auto', description: 'Enable OpenSSL support')
 option('cpp-httplib_zlib',    type: 'feature', value: 'auto', description: 'Enable zlib support')
 option('cpp-httplib_brotli',  type: 'feature', value: 'auto', description: 'Enable Brotli support')
-option('cpp-httplib_compile', type: 'boolean', value: false,  description: 'Split the header into a compilable header & source file')
+option('cpp-httplib_compile', type: 'boolean', value: false,  description: 'Split the header into a compilable header & source file (requires python3)')
 option('cpp-httplib_test',    type: 'boolean', value: false,  description: 'Build tests')


### PR DESCRIPTION
Thanks to abf3a67dd070e138c0f1a20b913abf003193cb79 the use of python3 isn't required anymore to configure the build, so I moved the `find_program('python3')` inside the "if compile" block.

This makes it possible to configure cpp-httplib on systems where python isn't available with tools like [muon](https://sr.ht/~lattis/muon/)