### PR TITLE
Fix compile error with MINGW-64 GCC-12.1.0

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -166,7 +166,6 @@ using socket_t = SOCKET;
 #else // not _WIN32
 
 #include <arpa/inet.h>
-#include <cstring>
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <netdb.h>
@@ -190,6 +189,7 @@ using socket_t = int;
 #endif
 #endif //_WIN32
 
+#include <cstring>
 #include <algorithm>
 #include <array>
 #include <atomic>


### PR DESCRIPTION
This change should fix a compile error that happens when using GCC v12.1.0 on Windows x64 (MINGW-64 via MSYS2):

../src/httplib.h: In constructor 'httplib::detail::gzip_decompressor::gzip_decompressor()':
../src/httplib.h:3064:8: error: 'memset' is not a member of 'std'; did you mean 'wmemset'?
3064 | std::memset(&strm_, 0, sizeof(strm_));
| ^~~~~~
| wmemset

The header  ´<cstring>´ should be included for Windows too.
