### PR TITLE
fix incorrect checking of Content-Type in Server::read_content

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5188,7 +5188,7 @@ inline bool Server::read_content(Stream &strm, Request &req, Response &res) {
             return true;
           })) {
     const auto &content_type = req.get_header_value("Content-Type");
-    if (!content_type.find("application/x-www-form-urlencoded")) {
+    if (content_type.find("application/x-www-form-urlencoded") == std::string::npos) {
       if (req.body.size() > CPPHTTPLIB_REQUEST_URI_MAX_LENGTH) {
         res.status = 413; // NOTE: should be 414?
         return false;


### PR DESCRIPTION
fixes #1288.

This was obviously just an oversight and wasn't supposed to act like that.

`std::string::find` will return the *position* (index) of the value, if found, which will be `0` (implicit false) if the Content-Type is exactly "application/x-www-form-urlencoded". This PR fixes this by correctly checking for `std::string::npos`, which is the "not found" of `std::string::find()`.