### PR TITLE
resolve http server can't send file large than 2GB (Fix #1290)

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4691,7 +4691,7 @@ inline ssize_t SocketStream::read(char *ptr, size_t size) {
 inline ssize_t SocketStream::write(const char *ptr, size_t size) {
   if (!is_writable()) { return -1; }
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_WIN64)
   size =
       (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
 #endif

--- a/test/test.cc
+++ b/test/test.cc
@@ -4742,6 +4742,39 @@ TEST(SendAPI, SimpleInterface_Online) {
   EXPECT_EQ(301, res->status);
 }
 
+#ifdef _WIN64
+TEST(ServerLargeContentTest, SendLargeContent) {
+  // allocate content size larger than 2GB in memory
+  const size_t content_size = 2LL * 1024LL * 1024LL * 1024LL + 1LL;
+  char *content = (char *)malloc(content_size);
+  ASSERT_TRUE(content);
+
+  Server svr;
+  svr.Get("/foo", [=](const httplib::Request &req, httplib::Response &resp) {
+    resp.set_content(content, content_size, "application/octet-stream");
+  });
+
+  auto listen_thread = std::thread([&svr]() { svr.listen(HOST, PORT); });
+  while (!svr.is_running()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  // Give GET time to get a few messages.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  Client cli(HOST, PORT);
+  auto res = cli.Get("/foo");
+  ASSERT_TRUE(res);
+  EXPECT_EQ(200, res->status);
+  EXPECT_EQ(content_size, res->body.length());
+
+  free(content);
+  svr.stop();
+  listen_thread.join();
+  ASSERT_FALSE(svr.is_running());
+}
+#endif
+
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 TEST(YahooRedirectTest2, SimpleInterface_Online) {
   Client cli("http://yahoo.com");

--- a/test/test.cc
+++ b/test/test.cc
@@ -4742,8 +4742,9 @@ TEST(SendAPI, SimpleInterface_Online) {
   EXPECT_EQ(301, res->status);
 }
 
+// Disabled due to out-of-memory problem on GitHub Actions
 #ifdef _WIN64
-TEST(ServerLargeContentTest, SendLargeContent) {
+TEST(ServerLargeContentTest, DISABLED_SendLargeContent) {
   // allocate content size larger than 2GB in memory
   const size_t content_size = 2LL * 1024LL * 1024LL * 1024LL + 1LL;
   char *content = (char *)malloc(content_size);

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -116,6 +116,7 @@
       <AdditionalUsingDirectories>
       </AdditionalUsingDirectories>
       <SDLCheck>true</SDLCheck>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -158,6 +159,7 @@
       <AdditionalUsingDirectories>
       </AdditionalUsingDirectories>
       <SDLCheck>true</SDLCheck>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
resolve problem: http server can't send file large than 2GB. 
add unit test for http server send file large than 2GB.  
add /bigobj compile option to msvc x64. 