### PR TITLE
clang-tidy suggested fixes

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -722,7 +722,7 @@ private:
       std::vector<std::pair<std::regex, HandlerWithContentReader>>;
 
   socket_t create_server_socket(const char *host, int port, int socket_flags,
-                                const SocketOptions& socket_options) const;
+                                const SocketOptions &socket_options) const;
   int bind_internal(const char *host, int port, int socket_flags);
   bool listen_internal();
 
@@ -752,7 +752,7 @@ private:
   bool read_content(Stream &strm, Request &req, Response &res);
   bool
   read_content_with_content_receiver(Stream &strm, Request &req, Response &res,
-                                     const ContentReceiver& receiver,
+                                     const ContentReceiver &receiver,
                                      MultipartContentHeader multipart_header,
                                      ContentReceiver multipart_receiver);
   bool read_content_core(Stream &strm, Request &req, Response &res,
@@ -868,20 +868,20 @@ public:
   Result Get(const char *path, const Headers &headers);
   Result Get(const char *path, Progress progress);
   Result Get(const char *path, const Headers &headers, Progress progress);
-  Result Get(const char *path, const ContentReceiver& content_receiver);
+  Result Get(const char *path, const ContentReceiver &content_receiver);
   Result Get(const char *path, const Headers &headers,
-             const ContentReceiver& content_receiver);
-  Result Get(const char *path, const ContentReceiver& content_receiver,
+             const ContentReceiver &content_receiver);
+  Result Get(const char *path, const ContentReceiver &content_receiver,
              Progress progress);
   Result Get(const char *path, const Headers &headers,
-             const ContentReceiver& content_receiver, Progress progress);
+             const ContentReceiver &content_receiver, Progress progress);
   Result Get(const char *path, ResponseHandler response_handler,
-             const ContentReceiver& content_receiver);
+             const ContentReceiver &content_receiver);
   Result Get(const char *path, const Headers &headers,
              ResponseHandler response_handler,
-             const ContentReceiver& content_receiver);
+             const ContentReceiver &content_receiver);
   Result Get(const char *path, ResponseHandler response_handler,
-             const ContentReceiver& content_receiver, Progress progress);
+             const ContentReceiver &content_receiver, Progress progress);
   Result Get(const char *path, const Headers &headers,
              ResponseHandler response_handler,
              const ContentReceiver &content_receiver, Progress progress);
@@ -889,7 +889,8 @@ public:
   Result Get(const char *path, const Params &params, const Headers &headers,
              Progress progress = nullptr);
   Result Get(const char *path, const Params &params, const Headers &headers,
-             const ContentReceiver& content_receiver, const Progress& progress = nullptr);
+             const ContentReceiver &content_receiver,
+             const Progress &progress = nullptr);
   Result Get(const char *path, const Params &params, const Headers &headers,
              const ResponseHandler &response_handler,
              const ContentReceiver &content_receiver,
@@ -1207,31 +1208,33 @@ public:
   Result Get(const char *path, const Headers &headers);
   Result Get(const char *path, Progress progress);
   Result Get(const char *path, const Headers &headers, Progress progress);
-  Result Get(const char *path, const ContentReceiver& content_receiver);
+  Result Get(const char *path, const ContentReceiver &content_receiver);
   Result Get(const char *path, const Headers &headers,
-             const ContentReceiver& content_receiver);
-  Result Get(const char *path, const ContentReceiver& content_receiver,
+             const ContentReceiver &content_receiver);
+  Result Get(const char *path, const ContentReceiver &content_receiver,
              Progress progress);
   Result Get(const char *path, const Headers &headers,
-             const ContentReceiver& content_receiver, Progress progress);
+             const ContentReceiver &content_receiver, Progress progress);
   Result Get(const char *path, ResponseHandler response_handler,
-             const ContentReceiver& content_receiver);
+             const ContentReceiver &content_receiver);
   Result Get(const char *path, const Headers &headers,
              ResponseHandler response_handler,
-             const ContentReceiver& content_receiver);
+             const ContentReceiver &content_receiver);
   Result Get(const char *path, const Headers &headers,
-             ResponseHandler response_handler, const ContentReceiver& content_receiver,
-             Progress progress);
+             ResponseHandler response_handler,
+             const ContentReceiver &content_receiver, Progress progress);
   Result Get(const char *path, ResponseHandler response_handler,
-             const ContentReceiver& content_receiver, Progress progress);
+             const ContentReceiver &content_receiver, Progress progress);
 
   Result Get(const char *path, const Params &params, const Headers &headers,
              Progress progress = nullptr);
   Result Get(const char *path, const Params &params, const Headers &headers,
-             const ContentReceiver& content_receiver, const Progress& progress = nullptr);
+             const ContentReceiver &content_receiver,
+             const Progress &progress = nullptr);
   Result Get(const char *path, const Params &params, const Headers &headers,
-             const ResponseHandler& response_handler, const ContentReceiver& content_receiver,
-             const Progress& progress = nullptr);
+             const ResponseHandler &response_handler,
+             const ContentReceiver &content_receiver,
+             const Progress &progress = nullptr);
 
   Result Head(const char *path);
   Result Head(const char *path, const Headers &headers);
@@ -1707,7 +1710,7 @@ bool process_client_socket(socket_t sock, time_t read_timeout_sec,
 
 socket_t create_client_socket(
     const char *host, const char *ip, int port, int address_family,
-    bool tcp_nodelay, const SocketOptions& socket_options,
+    bool tcp_nodelay, const SocketOptions &socket_options,
     time_t connection_timeout_sec, time_t connection_timeout_usec,
     time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
     time_t write_timeout_usec, const std::string &intf, Error &error);
@@ -2699,7 +2702,7 @@ inline std::string if2ip(int address_family, const std::string &ifn) {
 
 inline socket_t create_client_socket(
     const char *host, const char *ip, int port, int address_family,
-    bool tcp_nodelay, const SocketOptions& socket_options,
+    bool tcp_nodelay, const SocketOptions &socket_options,
     time_t connection_timeout_sec, time_t connection_timeout_usec,
     time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
     time_t write_timeout_usec, const std::string &intf, Error &error) {
@@ -3374,7 +3377,9 @@ inline bool read_content_chunked(Stream &strm,
 
     if (!line_reader.getline()) { return false; }
 
-    if (static_cast<int>(strcmp(line_reader.ptr(), "\r\n") != 0) != 0) { break; }
+    if (static_cast<int>(strcmp(line_reader.ptr(), "\r\n") != 0) != 0) {
+      break;
+    }
 
     if (!line_reader.getline()) { return false; }
   }
@@ -5210,7 +5215,7 @@ inline bool Server::read_content(Stream &strm, Request &req, Response &res) {
 }
 
 inline bool Server::read_content_with_content_receiver(
-    Stream &strm, Request &req, Response &res, const ContentReceiver& receiver,
+    Stream &strm, Request &req, Response &res, const ContentReceiver &receiver,
     MultipartContentHeader multipart_header,
     ContentReceiver multipart_receiver) {
   return read_content_core(strm, req, res, receiver,
@@ -5306,11 +5311,10 @@ inline bool Server::handle_file_request(const Request &req, Response &res,
 
 inline socket_t
 Server::create_server_socket(const char *host, int port, int socket_flags,
-                             const SocketOptions& socket_options) const {
+                             const SocketOptions &socket_options) const {
   return detail::create_socket(
       host, "", port, address_family_, socket_flags, tcp_nodelay_,
-      socket_options,
-      [](socket_t sock, struct addrinfo &ai) -> bool {
+      socket_options, [](socket_t sock, struct addrinfo &ai) -> bool {
         if (::bind(sock, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen)) !=
             0) {
           return false;
@@ -5440,9 +5444,9 @@ inline bool Server::routing(Request &req, Response &res, Stream &strm) {
     // Content reader handler
     {
       ContentReader reader(
-          [&](const ContentReceiver& receiver) {
-            return read_content_with_content_receiver(
-                strm, req, res, receiver, nullptr, nullptr);
+          [&](const ContentReceiver &receiver) {
+            return read_content_with_content_receiver(strm, req, res, receiver,
+                                                      nullptr, nullptr);
           },
           [&](MultipartContentHeader header, ContentReceiver receiver) {
             return read_content_with_content_receiver(strm, req, res, nullptr,
@@ -5452,26 +5456,22 @@ inline bool Server::routing(Request &req, Response &res, Stream &strm) {
 
       if (req.method == "POST") {
         if (dispatch_request_for_content_reader(
-                req, res, reader,
-                post_handlers_for_content_reader_)) {
+                req, res, reader, post_handlers_for_content_reader_)) {
           return true;
         }
       } else if (req.method == "PUT") {
         if (dispatch_request_for_content_reader(
-                req, res, reader,
-                put_handlers_for_content_reader_)) {
+                req, res, reader, put_handlers_for_content_reader_)) {
           return true;
         }
       } else if (req.method == "PATCH") {
         if (dispatch_request_for_content_reader(
-                req, res, reader,
-                patch_handlers_for_content_reader_)) {
+                req, res, reader, patch_handlers_for_content_reader_)) {
           return true;
         }
       } else if (req.method == "DELETE") {
         if (dispatch_request_for_content_reader(
-                req, res, reader,
-                delete_handlers_for_content_reader_)) {
+                req, res, reader, delete_handlers_for_content_reader_)) {
           return true;
         }
       }
@@ -6496,9 +6496,9 @@ inline bool ClientImpl::process_request(Stream &strm, Request &req,
 inline bool
 ClientImpl::process_socket(const Socket &socket,
                            std::function<bool(Stream &strm)> callback) {
-  return detail::process_client_socket(
-      socket.sock, read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-      write_timeout_usec_, callback);
+  return detail::process_client_socket(socket.sock, read_timeout_sec_,
+                                       read_timeout_usec_, write_timeout_sec_,
+                                       write_timeout_usec_, callback);
 }
 
 inline bool ClientImpl::is_ssl() const { return false; }
@@ -6527,49 +6527,47 @@ inline Result ClientImpl::Get(const char *path, const Headers &headers,
 }
 
 inline Result ClientImpl::Get(const char *path,
-                              const ContentReceiver& content_receiver) {
+                              const ContentReceiver &content_receiver) {
   return Get(path, Headers(), nullptr, content_receiver, nullptr);
 }
 
 inline Result ClientImpl::Get(const char *path,
-                              const ContentReceiver& content_receiver,
+                              const ContentReceiver &content_receiver,
                               Progress progress) {
-  return Get(path, Headers(), nullptr, content_receiver,
-             std::move(progress));
+  return Get(path, Headers(), nullptr, content_receiver, std::move(progress));
 }
 
 inline Result ClientImpl::Get(const char *path, const Headers &headers,
-                              const ContentReceiver& content_receiver) {
+                              const ContentReceiver &content_receiver) {
   return Get(path, headers, nullptr, content_receiver, nullptr);
 }
 
 inline Result ClientImpl::Get(const char *path, const Headers &headers,
-                              const ContentReceiver& content_receiver,
+                              const ContentReceiver &content_receiver,
                               Progress progress) {
-  return Get(path, headers, nullptr, content_receiver,
-             std::move(progress));
+  return Get(path, headers, nullptr, content_receiver, std::move(progress));
 }
 
 inline Result ClientImpl::Get(const char *path,
                               ResponseHandler response_handler,
-                              const ContentReceiver& content_receiver) {
-  return Get(path, Headers(), std::move(response_handler),
-             content_receiver, nullptr);
+                              const ContentReceiver &content_receiver) {
+  return Get(path, Headers(), std::move(response_handler), content_receiver,
+             nullptr);
 }
 
 inline Result ClientImpl::Get(const char *path, const Headers &headers,
                               ResponseHandler response_handler,
-                              const ContentReceiver& content_receiver) {
-  return Get(path, headers, std::move(response_handler),
-             content_receiver, nullptr);
+                              const ContentReceiver &content_receiver) {
+  return Get(path, headers, std::move(response_handler), content_receiver,
+             nullptr);
 }
 
 inline Result ClientImpl::Get(const char *path,
                               ResponseHandler response_handler,
-                              const ContentReceiver& content_receiver,
+                              const ContentReceiver &content_receiver,
                               Progress progress) {
-  return Get(path, Headers(), std::move(response_handler),
-             content_receiver, std::move(progress));
+  return Get(path, Headers(), std::move(response_handler), content_receiver,
+             std::move(progress));
 }
 
 inline Result ClientImpl::Get(const char *path, const Headers &headers,
@@ -6601,10 +6599,9 @@ inline Result ClientImpl::Get(const char *path, const Params &params,
 
 inline Result ClientImpl::Get(const char *path, const Params &params,
                               const Headers &headers,
-                              const ContentReceiver& content_receiver,
-                              const Progress& progress) {
-  return Get(path, params, headers, nullptr, content_receiver,
-             progress);
+                              const ContentReceiver &content_receiver,
+                              const Progress &progress) {
+  return Get(path, params, headers, nullptr, content_receiver, progress);
 }
 
 inline Result ClientImpl::Get(const char *path, const Params &params,
@@ -7874,43 +7871,46 @@ inline Result Client::Get(const char *path, const Headers &headers,
                           Progress progress) {
   return cli_->Get(path, headers, std::move(progress));
 }
-inline Result Client::Get(const char *path, const ContentReceiver& content_receiver) {
+inline Result Client::Get(const char *path,
+                          const ContentReceiver &content_receiver) {
   return cli_->Get(path, content_receiver);
 }
 inline Result Client::Get(const char *path, const Headers &headers,
-                          const ContentReceiver& content_receiver) {
+                          const ContentReceiver &content_receiver) {
   return cli_->Get(path, headers, content_receiver);
 }
-inline Result Client::Get(const char *path, const ContentReceiver& content_receiver,
+inline Result Client::Get(const char *path,
+                          const ContentReceiver &content_receiver,
                           Progress progress) {
   return cli_->Get(path, content_receiver, std::move(progress));
 }
 inline Result Client::Get(const char *path, const Headers &headers,
-                          const ContentReceiver& content_receiver, Progress progress) {
-  return cli_->Get(path, headers, content_receiver,
+                          const ContentReceiver &content_receiver,
+                          Progress progress) {
+  return cli_->Get(path, headers, content_receiver, std::move(progress));
+}
+inline Result Client::Get(const char *path, ResponseHandler response_handler,
+                          const ContentReceiver &content_receiver) {
+  return cli_->Get(path, std::move(response_handler), content_receiver);
+}
+inline Result Client::Get(const char *path, const Headers &headers,
+                          ResponseHandler response_handler,
+                          const ContentReceiver &content_receiver) {
+  return cli_->Get(path, headers, std::move(response_handler),
+                   content_receiver);
+}
+inline Result Client::Get(const char *path, ResponseHandler response_handler,
+                          const ContentReceiver &content_receiver,
+                          Progress progress) {
+  return cli_->Get(path, std::move(response_handler), content_receiver,
                    std::move(progress));
 }
-inline Result Client::Get(const char *path, ResponseHandler response_handler,
-                          const ContentReceiver& content_receiver) {
-  return cli_->Get(path, std::move(response_handler),
-                   content_receiver);
-}
 inline Result Client::Get(const char *path, const Headers &headers,
                           ResponseHandler response_handler,
-                          const ContentReceiver& content_receiver) {
-  return cli_->Get(path, headers, std::move(response_handler),
-                   content_receiver);
-}
-inline Result Client::Get(const char *path, ResponseHandler response_handler,
-                          const ContentReceiver& content_receiver, Progress progress) {
-  return cli_->Get(path, std::move(response_handler),
-                   content_receiver, std::move(progress));
-}
-inline Result Client::Get(const char *path, const Headers &headers,
-                          ResponseHandler response_handler,
-                          const ContentReceiver& content_receiver, Progress progress) {
-  return cli_->Get(path, headers, std::move(response_handler),
-                   content_receiver, std::move(progress));
+                          const ContentReceiver &content_receiver,
+                          Progress progress) {
+  return cli_->Get(path, headers, std::move(response_handler), content_receiver,
+                   std::move(progress));
 }
 inline Result Client::Get(const char *path, const Params &params,
                           const Headers &headers, Progress progress) {
@@ -7918,16 +7918,17 @@ inline Result Client::Get(const char *path, const Params &params,
 }
 inline Result Client::Get(const char *path, const Params &params,
                           const Headers &headers,
-                          const ContentReceiver& content_receiver, const Progress& progress) {
-  return cli_->Get(path, params, headers, content_receiver,
-                   progress);
+                          const ContentReceiver &content_receiver,
+                          const Progress &progress) {
+  return cli_->Get(path, params, headers, content_receiver, progress);
 }
 inline Result Client::Get(const char *path, const Params &params,
                           const Headers &headers,
-                          const ResponseHandler& response_handler,
-                          const ContentReceiver& content_receiver, const Progress& progress) {
-  return cli_->Get(path, params, headers, response_handler,
-                   content_receiver, progress);
+                          const ResponseHandler &response_handler,
+                          const ContentReceiver &content_receiver,
+                          const Progress &progress) {
+  return cli_->Get(path, params, headers, response_handler, content_receiver,
+                   progress);
 }
 
 inline Result Client::Head(const char *path) { return cli_->Head(path); }

--- a/httplib.h
+++ b/httplib.h
@@ -2529,7 +2529,6 @@ socket_t create_socket(const char *host, const char *ip, int port,
   struct addrinfo hints {};
   struct addrinfo *result = nullptr;
 
-  memset(&hints, 0, sizeof(struct addrinfo));
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_protocol = 0;
 
@@ -2635,7 +2634,6 @@ inline bool bind_ip_address(socket_t sock, const char *host) {
   struct addrinfo hints {};
   struct addrinfo *result = nullptr;
 
-  memset(&hints, 0, sizeof(struct addrinfo));
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_protocol = 0;
@@ -4399,7 +4397,6 @@ inline void hosted_at(const char *hostname, std::vector<std::string> &addrs) {
   struct addrinfo hints {};
   struct addrinfo *result = nullptr;
 
-  memset(&hints, 0, sizeof(struct addrinfo));
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_protocol = 0;

--- a/httplib.h
+++ b/httplib.h
@@ -1872,7 +1872,7 @@ private:
 namespace detail {
 
 inline bool is_hex(char c, int &v) {
-  if (0x20 <= c && (isdigit(c) != 0)) {
+  if (0x20 <= c && std::isdigit(c)) {
     v = c - '0';
     return true;
   } else if ('A' <= c && c <= 'F') {
@@ -2031,7 +2031,7 @@ inline std::string encode_query_param(const std::string &value) {
   escaped << std::hex;
 
   for (auto c : value) {
-    if ((std::isalnum(static_cast<uint8_t>(c)) != 0) || c == '-' || c == '_' ||
+    if (std::isalnum(c) || c == '-' || c == '_' ||
         c == '.' || c == '!' || c == '~' || c == '*' || c == '\'' || c == '(' ||
         c == ')') {
       escaped << c;
@@ -3375,7 +3375,7 @@ inline bool read_content_chunked(Stream &strm,
 
     if (!line_reader.getline()) { return false; }
 
-    if (static_cast<int>(strcmp(line_reader.ptr(), "\r\n") != 0) != 0) {
+    if (std::strcmp(line_reader.ptr(), "\r\n")) {
       break;
     }
 
@@ -3385,7 +3385,7 @@ inline bool read_content_chunked(Stream &strm,
   if (chunk_len == 0) {
     // Reader terminator after chunks
     if (!line_reader.getline() ||
-        (static_cast<int>(strcmp(line_reader.ptr(), "\r\n") != 0) != 0)) {
+        (std::strcmp(line_reader.ptr(), "\r\n"))) {
       return false;
     }
   }
@@ -6710,7 +6710,7 @@ inline Result ClientImpl::Post(const char *path, const Headers &headers,
                                const MultipartFormDataItems &items,
                                const std::string &boundary) {
   for (char c : boundary) {
-    if ((std::isalnum(c) == 0) && c != '-' && c != '_') {
+    if (!std::isalnum(c) && c != '-' && c != '_') {
       return Result{nullptr, Error::UnsupportedMultipartBoundaryChars};
     }
   }

--- a/httplib.h
+++ b/httplib.h
@@ -7726,8 +7726,8 @@ SSLClient::verify_host_with_subject_alt_name(X509 *server_cert) const {
         case GEN_DNS: dsn_matched = check_host_name(name, name_len); break;
 
         case GEN_IPADD:
-          if ((memcmp(&addr6, name, addr_len) == 0) ||
-              (memcmp(&addr, name, addr_len) == 0)) {
+          if ((!memcmp(&addr6, name, addr_len)) ||
+              (!memcmp(&addr, name, addr_len))) {
             ip_mached = true;
           }
           break;
@@ -7777,7 +7777,7 @@ inline bool SSLClient::check_host_name(const char *pattern,
     auto &p = *itr;
     if (p != h && p != "*") {
       auto partial_match = (!p.empty() && p[p.size() - 1] == '*' &&
-                            (p.compare(0, p.size() - 1, h) == 0));
+                            (!p.compare(0, p.size() - 1, h)));
       if (!partial_match) { return false; }
     }
     ++itr;

--- a/httplib.h
+++ b/httplib.h
@@ -1497,10 +1497,9 @@ inline T get_header_value(const Headers & /*headers*/, const char * /*key*/,
                           size_t /*id*/ = 0, uint64_t /*def*/ = 0) {}
 
 template <>
-inline uint64_t get_header_value<uint64_t>(const Headers & /*unused*/ headers,
-                                           const char * /*unused*/ key,
-                                           size_t /*unused*/ id,
-                                           uint64_t /*unused*/ def) {
+inline uint64_t get_header_value<uint64_t>(const Headers &headers,
+                                           const char *key, size_t id,
+                                           uint64_t def) {
   auto rng = headers.equal_range(key);
   auto it = rng.first;
   std::advance(it, static_cast<ssize_t>(id));
@@ -2031,9 +2030,8 @@ inline std::string encode_query_param(const std::string &value) {
   escaped << std::hex;
 
   for (auto c : value) {
-    if (std::isalnum(c) || c == '-' || c == '_' ||
-        c == '.' || c == '!' || c == '~' || c == '*' || c == '\'' || c == '(' ||
-        c == ')') {
+    if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '!' ||
+        c == '~' || c == '*' || c == '\'' || c == '(' || c == ')') {
       escaped << c;
     } else {
       escaped << std::uppercase;
@@ -3375,17 +3373,14 @@ inline bool read_content_chunked(Stream &strm,
 
     if (!line_reader.getline()) { return false; }
 
-    if (std::strcmp(line_reader.ptr(), "\r\n")) {
-      break;
-    }
+    if (std::strcmp(line_reader.ptr(), "\r\n")) { break; }
 
     if (!line_reader.getline()) { return false; }
   }
 
   if (chunk_len == 0) {
     // Reader terminator after chunks
-    if (!line_reader.getline() ||
-        (std::strcmp(line_reader.ptr(), "\r\n"))) {
+    if (!line_reader.getline() || (std::strcmp(line_reader.ptr(), "\r\n"))) {
       return false;
     }
   }

--- a/httplib.h
+++ b/httplib.h
@@ -5967,7 +5967,7 @@ inline bool ClientImpl::send(Request &req, Response &res, Error &error) {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
       // TODO: refactoring
       if (is_ssl()) {
-        auto &scli = dynamic_cast<SSLClient &>(*this);
+        auto &scli = static_cast<SSLClient &>(*this);
         if (!proxy_host_.empty() && proxy_port_ != -1) {
           bool success = false;
           if (!scli.connect_with_proxy(socket_, res, success, error)) {
@@ -8214,7 +8214,7 @@ inline void Client::set_ca_cert_path(const char *ca_cert_file_path,
 
 inline void Client::set_ca_cert_store(X509_STORE *ca_cert_store) {
   if (is_ssl_) {
-    dynamic_cast<SSLClient &>(*cli_).set_ca_cert_store(ca_cert_store);
+    static_cast<SSLClient &>(*cli_).set_ca_cert_store(ca_cert_store);
   } else {
     cli_->set_ca_cert_store(ca_cert_store);
   }
@@ -8222,13 +8222,13 @@ inline void Client::set_ca_cert_store(X509_STORE *ca_cert_store) {
 
 inline long Client::get_openssl_verify_result() const {
   if (is_ssl_) {
-    return dynamic_cast<SSLClient &>(*cli_).get_openssl_verify_result();
+    return static_cast<SSLClient &>(*cli_).get_openssl_verify_result();
   }
   return -1; // NOTE: -1 doesn't match any of X509_V_ERR_???
 }
 
 inline SSL_CTX *Client::ssl_context() const {
-  if (is_ssl_) { return dynamic_cast<SSLClient &>(*cli_).ssl_context(); }
+  if (is_ssl_) { return static_cast<SSLClient &>(*cli_).ssl_context(); }
   return nullptr;
 }
 #endif


### PR DESCRIPTION
This PR applies neat corrections at source and small hand-made solutions. Some of these changes are great for performance, such as avoiding unnecessary copies, others are just for code readability, but each of these changes have been manually revised. I also confirm that the changes pass the test suite

Main changes:
- Multiple parameters declared as const references in function signatures to avoid unnecessary copies
- Where possible member functions have been made static
- Avoid implicit conversions
- Removed default destructors where possible