### PR TITLE
Use std::exception_ptr

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -616,7 +616,7 @@ public:
   using Handler = std::function<void(const Request &, Response &)>;
 
   using ExceptionHandler =
-      std::function<void(const Request &, Response &, std::exception &e)>;
+      std::function<void(const Request &, Response &, std::exception_ptr &ep)>;
 
   enum class HandlerResponse {
     Handled,
@@ -5733,7 +5733,8 @@ Server::process_request(Stream &strm, bool close_connection,
     routed = routing(req, res, strm);
   } catch (std::exception &e) {
     if (exception_handler_) {
-      exception_handler_(req, res, e);
+      auto ep = std::current_exception();
+      exception_handler_(req, res, ep);
       routed = true;
     } else {
       res.status = 500;

--- a/test/test.cc
+++ b/test/test.cc
@@ -1249,8 +1249,13 @@ TEST(ExceptionHandlerTest, ContentLength) {
   Server svr;
 
   svr.set_exception_handler([](const Request & /*req*/, Response &res,
-                               std::exception &e) {
-    EXPECT_EQ("abc", std::string(e.what()));
+                               std::exception_ptr ep) {
+    EXPECT_FALSE(ep == nullptr);
+    try{
+      std::rethrow_exception(ep);
+    }catch(std::exception& e){
+      EXPECT_EQ("abc", std::string(e.what()));
+    }
     res.status = 500;
     res.set_content("abcdefghijklmnopqrstuvwxyz",
                     "text/html"); // <= Content-Length still 13 at this point


### PR DESCRIPTION
See #1318.
By passing an exception to the user with std::exception_ptr, library users will be able to handle the exception using a custom exception class.

Example:
```c++
class UserException : public std::runtime_error{
  void method1(){
    // Print stack traces, etc.
  }
};


class AnotherLibraryDefinedException : public std::runtime_error{
  void method2(){
    // In some cases, the library may raise an exception of its own type.
  }
};

void main(){
  httplib svr;

  svr.Get("/", [=](const httplib::Request& /*req*/, httplib::Response& res) {
    throw UserException();
    // or
    throw AnotherLibraryDefinedException();
  });

  svr.set_exception_handler([]const Request &, Response &, std::exception_ptr &ep{
    // In the current implementation, all exception types are std :: exception, so calling method1 or method2 is not easy    
    try{
      std::rethrow_exception(ep);
    }catch(UserException& e){
      e.method1();
    }catch(AnotherLibraryDefinedException& e){
      e.method2();
    }
    // 
  });

}

```