### PR TITLE
With SSL enabled and NOMINMAX not defined, there is a conflict with '…

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7298,7 +7298,7 @@ inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
 inline ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
   if (is_writable()) {
     auto handle_size = static_cast<int>(
-        std::min<size_t>(size, std::numeric_limits<int>::max()));
+        std::min<size_t>(size, (std::numeric_limits<int>::max)()));
 
     auto ret = SSL_write(ssl_, ptr, static_cast<int>(handle_size));
     if (ret < 0) {


### PR DESCRIPTION
…max', which this fixes

See issue #1333 