### PR TITLE
ssize_t redefinition on Windows - int/int64 vs long/long long

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -130,9 +130,9 @@
 #pragma comment(lib, "ws2_32.lib")
 
 #ifdef _WIN64
-using ssize_t = __int64;
+using ssize_t = long long;
 #else
-using ssize_t = int;
+using ssize_t = long;
 #endif
 #endif // _MSC_VER
 

--- a/httplib.h
+++ b/httplib.h
@@ -130,7 +130,7 @@
 #pragma comment(lib, "ws2_32.lib")
 
 #ifdef _WIN64
-using ssize_t = long long;
+using ssize_t = __int64;
 #else
 using ssize_t = long;
 #endif


### PR DESCRIPTION
Per issue #1336 