### PR TITLE
build: set soversion to major.minor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if(HTTPLIB_COMPILE)
 	set_target_properties(${PROJECT_NAME}
 		PROPERTIES
 			VERSION ${${PROJECT_NAME}_VERSION}
-			SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR}
+			SOVERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}"
 	)
 else()
 	# This is for header-only.
@@ -247,13 +247,13 @@ if(HTTPLIB_COMPILE)
 	write_basic_package_version_file("${PROJECT_NAME}ConfigVersion.cmake"
 		# Example: if you find_package(httplib 0.5.4)
 		# then anything >= 0.5 and <= 1.0 is accepted
-		COMPATIBILITY SameMajorVersion
+		COMPATIBILITY SameMinorVersion
 	)
 else()
 	write_basic_package_version_file("${PROJECT_NAME}ConfigVersion.cmake"
 		# Example: if you find_package(httplib 0.5.4)
 		# then anything >= 0.5 and <= 1.0 is accepted
-		COMPATIBILITY SameMajorVersion
+		COMPATIBILITY SameMinorVersion
 		# Tells Cmake that it's a header-only lib
 		# Mildly useful for end-users :)
 		ARCH_INDEPENDENT

--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,7 @@ if get_option('cpp-httplib_compile')
     dependencies: deps,
     cpp_args: args,
     version: version,
+    soversion: version.split('.')[0] + '.' + version.split('.')[1],
     install: true
   )
   cpp_httplib_dep = declare_dependency(compile_args: args, dependencies: deps, link_with: lib, sources: httplib_ch[1])


### PR DESCRIPTION
Release 0.11 broke backwards compatibility, meaning that different cpp-httplib versions are compatible with each other only if the major and minor version numbers are the same.

This patch reflects this in the build systems.

See #1209 for some more context.

@yhirose, is it correct that cpp-httplib only maintains backwards compatibility only if both the major and the minor version components are the same? (i.e. `0.10.3` and `0.10.9` are compatible, but `0.10.9` and `0.11.0` are not)

Cc: @sum01