### PR TITLE
Feature: use pre_routing_handler_ for memory file system, reuse base_…

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -718,6 +718,13 @@ protected:
   time_t idle_interval_usec_ = CPPHTTPLIB_IDLE_INTERVAL_USECOND;
   size_t payload_max_length_ = CPPHTTPLIB_PAYLOAD_MAX_LENGTH;
 
+  struct MountPointEntry {
+    std::string mount_point;
+    std::string base_dir;
+    Headers headers;
+  };
+  std::vector<MountPointEntry> base_dirs_;
+
 private:
   using Handlers = std::vector<std::pair<std::regex, Handler>>;
   using HandlersForContentReader =
@@ -763,13 +770,6 @@ private:
                          ContentReceiver multipart_receiver);
 
   virtual bool process_and_close_socket(socket_t sock);
-
-  struct MountPointEntry {
-    std::string mount_point;
-    std::string base_dir;
-    Headers headers;
-  };
-  std::vector<MountPointEntry> base_dirs_;
 
   std::atomic<bool> is_running_;
   std::map<std::string, std::string> file_extension_and_mimetype_map_;


### PR DESCRIPTION
Feature: use pre_routing_handler_ for memory file system, reuse base_dirs_/set_base_dir/set_mount_point/remove_mount_point etc.
need change base_dirs_ to protected for derived class.