### PR TITLE
avoid lockup in `ThreadPool::shutdown()` on legacy host

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -560,9 +560,8 @@ public:
     {
       std::unique_lock<std::mutex> lock(mutex_);
       shutdown_ = true;
+      cond_.notify_all();
     }
-
-    cond_.notify_all();
 
     // Join...
     for (auto &t : threads_) {


### PR DESCRIPTION
It is found on CentOS 7.0.1406 which is very early version of CentOS 7.
It's not happened on CentOS 8 or Ubuntu 22.04. So, I think, it's affected libc or libpthread which is both 2.17 on CentOS 7.0.1406.

I found the lockup from my own test suite with repeating test for stability. Before this patch, it occurs within 1000 times. After apply this patch it was fine even under 1M times of repeating.

@AhnLab-OSSG