### PR TITLE
Get client process id over ip/port when server runs on UNIX socket.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2877,11 +2877,17 @@ inline void get_remote_ip_and_port(socket_t sock, std::string &ip, int &port) {
                    &addr_len)) {
 #ifndef _WIN32
     if (addr.ss_family == AF_UNIX) {
-#ifdef __linux__
+#if defined(__linux__)
         struct ucred ucred;
         socklen_t len = sizeof(ucred);
         if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &ucred, &len) == 0) {
             port = ucred.pid;
+        }
+#elif defined(SOL_LOCAL) && defined(SO_PEERPID)  // __APPLE__
+        pid_t pid;
+        socklen_t len = sizeof(pid);
+        if (getsockopt(sock, SOL_LOCAL, SO_PEERPID, &pid, &len) == 0) {
+            port = pid;
         }
 #endif
         return;

--- a/httplib.h
+++ b/httplib.h
@@ -2875,6 +2875,18 @@ inline void get_remote_ip_and_port(socket_t sock, std::string &ip, int &port) {
 
   if (!getpeername(sock, reinterpret_cast<struct sockaddr *>(&addr),
                    &addr_len)) {
+#ifndef _WIN32
+    if (addr.ss_family == AF_UNIX) {
+#ifdef __linux__
+        struct ucred ucred;
+        socklen_t len = sizeof(ucred);
+        if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &ucred, &len) == 0) {
+            port = ucred.pid;
+        }
+#endif
+        return;
+    }
+#endif
     get_remote_ip_and_port(addr, addr_len, ip, port);
   }
 }

--- a/httplib.h
+++ b/httplib.h
@@ -2602,6 +2602,9 @@ socket_t create_socket(const std::string &host, const std::string &ip, int port,
       hints.ai_addrlen = static_cast<socklen_t>(
           sizeof(addr) - sizeof(addr.sun_path) + addrlen);
 
+      fcntl(sock, F_SETFD, FD_CLOEXEC);
+      if (socket_options) { socket_options(sock); }
+
       if (!bind_or_connect(sock, hints)) {
         close_socket(sock);
         sock = INVALID_SOCKET;

--- a/test/test.cc
+++ b/test/test.cc
@@ -5344,7 +5344,8 @@ TEST_F(UnixSocketTest, pathname) {
   t.join();
 }
 
-#ifdef __linux__
+#if defined(__linux__) \
+  || /* __APPLE__ */ (defined(SOL_LOCAL) && defined(SO_PEERPID))
 TEST_F(UnixSocketTest, PeerPid) {
   httplib::Server svr;
   std::string remote_port_val;

--- a/test/test.cc
+++ b/test/test.cc
@@ -5345,6 +5345,30 @@ TEST_F(UnixSocketTest, pathname) {
 }
 
 #ifdef __linux__
+TEST_F(UnixSocketTest, PeerPid) {
+  httplib::Server svr;
+  std::string remote_port_val;
+  svr.Get(pattern_, [&](const httplib::Request &req, httplib::Response &res) {
+    res.set_content(content_, "text/plain");
+    remote_port_val = req.get_header_value("REMOTE_PORT");
+  });
+
+  std::thread t {[&] {
+    ASSERT_TRUE(svr.set_address_family(AF_UNIX).listen(pathname_, 80)); }};
+  while (!svr.is_running()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_TRUE(svr.is_running());
+
+  client_GET(pathname_);
+  EXPECT_EQ(std::to_string(getpid()), remote_port_val);
+
+  svr.stop();
+  t.join();
+}
+#endif
+
+#ifdef __linux__
 TEST_F(UnixSocketTest, abstract) {
   constexpr char svr_path[] {"\x00httplib-server.sock"};
   const std::string abstract_addr {svr_path, sizeof(svr_path) - 1};


### PR DESCRIPTION
I put client process id into `REMOTE_PORT` in http request header when server runs on UNIX socket.
The name might be awkward for process id but, I think, it's acceptable because process id can be used to address client like ip/port. As a matter of fact, process id and ip/port never coexists.

@AhnLab-OSSG