### PR TITLE
undef poll at the end if CPPHTTPLIB_USE_POLL

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8405,8 +8405,8 @@ inline SSL_CTX *Client::ssl_context() const {
 
 } // namespace httplib
 
-#ifdef CPPHTTPLIB_USE_POLL
+#if defined(_WIN32) && defined(CPPHTTPLIB_USE_POLL)
 #undef poll
-#endif 
+#endif
 
 #endif // CPPHTTPLIB_HTTPLIB_H

--- a/httplib.h
+++ b/httplib.h
@@ -8405,4 +8405,8 @@ inline SSL_CTX *Client::ssl_context() const {
 
 } // namespace httplib
 
+#ifdef CPPHTTPLIB_USE_POLL
+#undef poll
+#endif 
+
 #endif // CPPHTTPLIB_HTTPLIB_H


### PR DESCRIPTION
The replacement of `poll` with `WSAPoll` should be reverted to avoid propagation to other source files. 