### PR TITLE
Windows CMake directory install fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,15 +221,8 @@ target_compile_definitions(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
 	$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:CPPHTTPLIB_OPENSSL_SUPPORT>
 )
 
-# Cmake's find_package search path is different based on the system
-# See https://cmake.org/cmake/help/latest/command/find_package.html for the list
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-	set(_TARGET_INSTALL_CMAKEDIR "${CMAKE_INSTALL_PREFIX}/cmake")
-else()
-	# On Non-Windows, it should be /usr/lib/cmake/<name>/<name>Config.cmake
-	# NOTE: This may or may not work for macOS...
-	set(_TARGET_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-endif()
+# CMake configuration files installation directory
+set(_TARGET_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
 include(CMakePackageConfigHelpers)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ target_compile_definitions(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
 # Cmake's find_package search path is different based on the system
 # See https://cmake.org/cmake/help/latest/command/find_package.html for the list
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-	set(_TARGET_INSTALL_CMAKEDIR "${CMAKE_INSTALL_PREFIX}/cmake/${PROJECT_NAME}")
+	set(_TARGET_INSTALL_CMAKEDIR "${CMAKE_INSTALL_PREFIX}/cmake")
 else()
 	# On Non-Windows, it should be /usr/lib/cmake/<name>/<name>Config.cmake
 	# NOTE: This may or may not work for macOS...


### PR DESCRIPTION
Hi @yhirose @sum01 

Thanks for your initial work on https://github.com/yhirose/cpp-httplib/pull/470

There is a comment which seems to be the rational behind the different CMake installation directory, but I don't think it is relevant (issue: https://github.com/yhirose/cpp-httplib/issues/287)

I therefore assume that this initial split in installation directory was done "from spec", not from practical issue bubbling up - but it's not (was not) correct.

Proposed are two commits. 
1. First one fixes the original behavior - it was close, but that means of searching for CMake config files was only introduced in CMake version 3.25, predating the date of original PR. See: https://cmake.org/cmake/help/latest/command/find_package.html#id3
2. Simplification, which removes the differentiation altogether, and settles for `lib/cmake/[project]/` path - I've integrated many CMake dependencies to date in various projects (one bigger being https://github.com/luxonis/depthai-core) and have never seen this installation path used by any dependency on Windows. Never had issues before.

Issue popped up during integration of the library using Hunter package manager.
