### PR TITLE
Add EINTR and EAGAIN judge for accept

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5484,6 +5484,8 @@ inline bool Server::listen_internal() {
           // Try to accept new connections after a short sleep.
           std::this_thread::sleep_for(std::chrono::milliseconds(1));
           continue;
+        } else if (errno == EINTR || errno == EAGAIN) {
+          continue;
         }
         if (svr_sock_ != INVALID_SOCKET) {
           detail::close_socket(svr_sock_);

--- a/test/test.cc
+++ b/test/test.cc
@@ -943,6 +943,7 @@ TEST(UrlWithSpace, Redirect_Online) {
 
 #endif
 
+#if !defined(_WIN32) && !defined(_WIN64)
 TEST(ReceiveSignals, Signal) {
   auto setupSignalHandlers = []() {
     struct sigaction act;
@@ -978,6 +979,7 @@ TEST(ReceiveSignals, Signal) {
   thread.join();
   ASSERT_FALSE(svr.is_running());
 }
+#endif
 
 TEST(RedirectToDifferentPort, Redirect) {
   Server svr1;

--- a/test/test.cc
+++ b/test/test.cc
@@ -1,4 +1,5 @@
 #include <httplib.h>
+#include <signal.h>
 
 #include <gtest/gtest.h>
 
@@ -941,6 +942,42 @@ TEST(UrlWithSpace, Redirect_Online) {
 }
 
 #endif
+
+TEST(ReceiveSignals, Signal) {
+  auto setupSignalHandlers = []() {
+    struct sigaction act;
+
+    sigemptyset(&act.sa_mask);
+    act.sa_flags = SA_SIGINFO;
+    act.sa_sigaction = [](int sig, siginfo_t *, void *) {
+      switch (sig) {
+      case SIGINT:
+      default: break;
+      }
+    };
+    ::sigaction(SIGINT, &act, nullptr);
+  };
+
+  Server svr;
+  int port = 0;
+  auto thread = std::thread([&]() {
+    setupSignalHandlers();
+    port = svr.bind_to_any_port("localhost");
+    svr.listen_after_bind();
+  });
+
+  while (!svr.is_running()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  ASSERT_TRUE(svr.is_running());
+  pthread_kill(thread.native_handle(), SIGINT);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ASSERT_TRUE(svr.is_running());
+  svr.stop();
+  thread.join();
+  ASSERT_FALSE(svr.is_running());
+}
 
 TEST(RedirectToDifferentPort, Redirect) {
   Server svr1;


### PR DESCRIPTION
This pr add EINTR and EAGAIN process for socket accept function.

When program is blocked by accept, Capturing some signals like SIGUSR2 may interrupt the accept and return error(-1), set errno to EINTR. When this happens, http service shouldn't be shutdown but should continue to call accept.

I propose this pr because I met such problem, I want to shutdown my http service by stop function when I capture signals, but this will shutdown straightly.