### PR TITLE
std::condition_variable::notify_one/all() should be called after unlocking mutex

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -580,7 +580,7 @@ private:
 
           if (pool_.shutdown_ && pool_.jobs_.empty()) { break; }
 
-          fn = pool_.jobs_.front();
+          fn = std::move(pool_.jobs_.front());
           pool_.jobs_.pop_front();
         }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <chrono>
 #include <future>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <thread>
@@ -5502,3 +5503,18 @@ TEST(SocketStream, is_writable_INET) {
   ASSERT_EQ(0, close(disconnected_svr_sock));
 }
 #endif // #ifndef _WIN32
+
+TEST(TaskQueueTest, IncreaseAtomicInteger) {
+  static constexpr unsigned int number_of_task{1000000};
+  std::atomic_uint count{0};
+  std::unique_ptr<TaskQueue> task_queue =
+      std::make_unique<ThreadPool>(CPPHTTPLIB_THREAD_POOL_COUNT);
+
+  for (unsigned int i = 0; i < number_of_task; ++i) {
+    task_queue->enqueue(
+        [&count] { count.fetch_add(1, std::memory_order_relaxed); });
+  }
+
+  EXPECT_NO_THROW(task_queue->shutdown());
+  EXPECT_EQ(number_of_task, count.load());
+}

--- a/test/test.cc
+++ b/test/test.cc
@@ -5507,8 +5507,8 @@ TEST(SocketStream, is_writable_INET) {
 TEST(TaskQueueTest, IncreaseAtomicInteger) {
   static constexpr unsigned int number_of_task{1000000};
   std::atomic_uint count{0};
-  std::unique_ptr<TaskQueue> task_queue =
-      std::make_unique<ThreadPool>(CPPHTTPLIB_THREAD_POOL_COUNT);
+  std::unique_ptr<TaskQueue> task_queue{
+      new ThreadPool{CPPHTTPLIB_THREAD_POOL_COUNT}};
 
   for (unsigned int i = 0; i < number_of_task; ++i) {
     task_queue->enqueue(


### PR DESCRIPTION
The notifying thread doesn't need to hold the lock because the notified thread may immediately block again in some implementations. (see description and example in [cppreference](https://en.cppreference.com/w/cpp/thread/condition_variable/notify_one))
There is another [caveat](https://en.cppreference.com/w/cpp/thread/condition_variable/notify_one#:~:text=Notifying%20while%20under,a%20destroyed%20object.) about notifying while holding a lock, but I think it isn't relevant to current implementation of `ThreadPool`.


I also recommend the implementation of task system which presented in [Sean Parent's talk](https://www.youtube.com/watch?v=zULU6Hhp42w).