### PR TITLE
add support for requests with both MultipartFormDataItems and Content Providers

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6690,7 +6690,7 @@ inline bool ClientImpl::process_request(Stream &strm, Request &req,
   return true;
 }
 
-ContentProviderWithoutLength ClientImpl::get_multipart_content_provider(
+inline ContentProviderWithoutLength ClientImpl::get_multipart_content_provider(
     const std::string &boundary, const MultipartFormDataItems &items,
     const MultipartFormDataProviderItems &provider_items) {
   size_t cur_item = 0, cur_start = 0;

--- a/httplib.h
+++ b/httplib.h
@@ -6925,7 +6925,7 @@ inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
 
   size_t curItem = 0, curStart = 0;
   ContentProviderWithoutLength content_provider = [&](size_t offset, DataSink& sink) {
-    if (!offset) {
+    if (!offset && items.size()) {
       sink.os << detail::serialize_multipart_formdata(items, boundary, false);
       return true;
     }

--- a/httplib.h
+++ b/httplib.h
@@ -6899,8 +6899,8 @@ inline Result ClientImpl::Post(const std::string &path,
 
 inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
                                const MultipartFormDataItems &items) {
-  std::string boundary = detail::make_multipart_data_boundary();
-  std::string content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+  const auto &boundary = detail::make_multipart_data_boundary();
+  const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
   const auto &body = detail::serialize_multipart_formdata(items, boundary);
   return Post(path, headers, body, content_type.c_str());
 }
@@ -6912,7 +6912,7 @@ inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
     return Result{nullptr, Error::UnsupportedMultipartBoundaryChars};
   }
 
-  std::string content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+  const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
   const auto &body = detail::serialize_multipart_formdata(items, boundary);
   return Post(path, headers, body, content_type.c_str());
 }
@@ -6920,8 +6920,8 @@ inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
 inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
                                const MultipartFormDataItems &items,
                                const MultipartFormDataProviderItems &pItems) { 
-  std::string boundary = detail::make_multipart_data_boundary();
-  std::string content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+  const auto &boundary = detail::make_multipart_data_boundary();
+  const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
 
   size_t curItem = 0, curStart = 0;
   ContentProviderWithoutLength content_provider = [&](size_t offset, DataSink& sink) {
@@ -6931,8 +6931,10 @@ inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
     }
     else if (curItem < pItems.size()) {
       if (!curStart) {
+        const auto& begin = detail::serialize_multipart_formdata_item_begin(pItems[curItem], boundary);
+        offset += begin.size(); 
         curStart = offset;
-        sink.os << detail::serialize_multipart_formdata_item_begin(pItems[curItem], boundary);
+        sink.os << begin; 
       }
 
       DataSink curSink;
@@ -7037,8 +7039,8 @@ inline Result ClientImpl::Put(const std::string &path,
 
 inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
                               const MultipartFormDataItems &items) {
-  std::string boundary = detail::make_multipart_data_boundary();
-  std::string content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+  const auto &boundary = detail::make_multipart_data_boundary();
+  const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
   const auto &body = detail::serialize_multipart_formdata(items, boundary);
   return Put(path, headers, body, content_type);
 }
@@ -7050,7 +7052,7 @@ inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
     return Result{nullptr, Error::UnsupportedMultipartBoundaryChars};
   }
 
-  std::string content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+  const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
   const auto &body = detail::serialize_multipart_formdata(items, boundary);
   return Put(path, headers, body, content_type);
 }


### PR DESCRIPTION
I had a situation where I needed to send a POST request with some multipart parameters, some of which needed to be fed by content providers (chunked transfer) rather than just a string.  I implemented just that.

I tried to get it working with the most idiomatic code for this library but there are still a few combinations missing, e.g. right now it only works with ContentProviderWithoutLength not just ContentProvider.  Maybe it would be a better idea to just use ContentProvider and then users can use the ContentProviderAdapter?  Only problem is this adapter class doesn't seem to be accessible outside httplib.