### PR TITLE
Fix "Location" header url corrupted by percent-unescaping in redirect…

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3353,7 +3353,10 @@ inline bool parse_header(const char *beg, const char *end, T fn) {
   }
 
   if (p < end) {
-    fn(std::string(beg, key_end), decode_url(std::string(p, end), false));
+    std::string key(beg, key_end);
+    std::string rawValue(p, end);
+    std::string value = key=="Location"?std::move(rawValue):decode_url(rawValue, false);
+    fn(std::move(key), std::move(value));
     return true;
   }
 

--- a/httplib.h
+++ b/httplib.h
@@ -2854,8 +2854,7 @@ inline socket_t create_client_socket(
 }
 
 inline bool get_ip_and_port(const struct sockaddr_storage &addr,
-                            socklen_t addr_len, std::string &ip,
-                            int &port) {
+                            socklen_t addr_len, std::string &ip, int &port) {
   if (addr.ss_family == AF_INET) {
     port = ntohs(reinterpret_cast<const struct sockaddr_in *>(&addr)->sin_port);
   } else if (addr.ss_family == AF_INET6) {
@@ -3355,7 +3354,8 @@ inline bool parse_header(const char *beg, const char *end, T fn) {
   if (p < end) {
     std::string key(beg, key_end);
     std::string rawValue(p, end);
-    std::string value = key=="Location"?std::move(rawValue):decode_url(rawValue, false);
+    std::string value =
+        key == "Location" ? std::move(rawValue) : decode_url(rawValue, false);
     fn(std::move(key), std::move(value));
     return true;
   }
@@ -4539,8 +4539,8 @@ inline void hosted_at(const std::string &hostname,
         *reinterpret_cast<struct sockaddr_storage *>(rp->ai_addr);
     std::string ip;
     int dummy = -1;
-    if (detail::get_ip_and_port(addr, sizeof(struct sockaddr_storage),
-                                ip, dummy)) {
+    if (detail::get_ip_and_port(addr, sizeof(struct sockaddr_storage), ip,
+                                dummy)) {
       addrs.push_back(ip);
     }
   }
@@ -7446,7 +7446,7 @@ inline void SSLSocketStream::get_remote_ip_and_port(std::string &ip,
 }
 
 inline void SSLSocketStream::get_local_ip_and_port(std::string &ip,
-                                                    int &port) const {
+                                                   int &port) const {
   detail::get_local_ip_and_port(sock_, ip, port);
 }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -5598,29 +5598,40 @@ TEST(TaskQueueTest, IncreaseAtomicInteger) {
   EXPECT_EQ(number_of_task, count.load());
 }
 
-TEST(ParseHeader, LocationValueDecoding)
-{
-  static const std::string URL("https://stitcher2.acast.com/livestitches/4d4cc4fe72c9452bd0b0992a5c89e434.mp3?aid=63a4721c69c77e001126ad39&chid=a8879bdf-de58-4537-8dab-a3bb13948786&ci=oFpQlSRp3GFDZwrcZw5e3SEuFWtGfBXjcj6-mtxC8TJYKWNWTP3KWg%3D%3D&pf=rss&sv=sphinx%401.134.1&uid=6ec01abdba610f88f88e42ff560ecdef&Expires=1672109987714&Key-Pair-Id=K38CTQXUSD0VVB&Signature=TQXsBs7XluU~YRtPTcYe1EtVuvnkf542tbp1p7KUnvn24rm-tQjO8dYgLSbXlJCBwsiPtbnJc-YjLbGlaVLKDzzfABj2lCldE-KoeUSdnEQPWXdPK6FK5BR7kuN-CuY1MfQ-0sDa4MTGAErHZZB1p3~jiiZbbP7fYd9ttBfXwlZgjv5BtHOL4KQs7QY7q-~ZP5tXoGhtufPMruWRYOptrves991ax5lgKPwTvzhXSL6CEKpHWoAMi88shXnBBC~f2iOropB-yzcj5K-uaK6LPcObfHh9Akgl~uIAqbLka2Nrq-HQ-7QrMIUmFcA2nTEaAF66dGRj7AGtEkS2m2hB4A__");
+TEST(ParseHeader, LocationValueDecoding) {
+  static const std::string URL(
+      "https://stitcher2.acast.com/livestitches/"
+      "4d4cc4fe72c9452bd0b0992a5c89e434.mp3?aid=63a4721c69c77e001126ad39&chid="
+      "a8879bdf-de58-4537-8dab-a3bb13948786&ci="
+      "oFpQlSRp3GFDZwrcZw5e3SEuFWtGfBXjcj6-mtxC8TJYKWNWTP3KWg%3D%3D&pf=rss&sv="
+      "sphinx%401.134.1&uid=6ec01abdba610f88f88e42ff560ecdef&Expires="
+      "1672109987714&Key-Pair-Id=K38CTQXUSD0VVB&Signature=TQXsBs7XluU~"
+      "YRtPTcYe1EtVuvnkf542tbp1p7KUnvn24rm-tQjO8dYgLSbXlJCBwsiPtbnJc-"
+      "YjLbGlaVLKDzzfABj2lCldE-KoeUSdnEQPWXdPK6FK5BR7kuN-CuY1MfQ-"
+      "0sDa4MTGAErHZZB1p3~jiiZbbP7fYd9ttBfXwlZgjv5BtHOL4KQs7QY7q-~"
+      "ZP5tXoGhtufPMruWRYOptrves991ax5lgKPwTvzhXSL6CEKpHWoAMi88shXnBBC~"
+      "f2iOropB-yzcj5K-uaK6LPcObfHh9Akgl~uIAqbLka2Nrq-HQ-"
+      "7QrMIUmFcA2nTEaAF66dGRj7AGtEkS2m2hB4A__");
   static const std::string Location("Location");
-  static const std::string testLocation(Location+":"+URL);
+  static const std::string testLocation(Location + ":" + URL);
 
-  //test Location URL is preserved
-  httplib::detail::parse_header(testLocation.data(), testLocation.data()+testLocation.size(),
-               [&](std::string const& key, std::string const& value)
-  {
-    EXPECT_EQ(key, Location);
-    EXPECT_EQ(value, URL);
-    EXPECT_NE(value, httplib::detail::decode_url(URL, false));
-  });
+  // test Location URL is preserved
+  httplib::detail::parse_header(
+      testLocation.data(), testLocation.data() + testLocation.size(),
+      [&](std::string const &key, std::string const &value) {
+        EXPECT_EQ(key, Location);
+        EXPECT_EQ(value, URL);
+        EXPECT_NE(value, httplib::detail::decode_url(URL, false));
+      });
 
-  //test non-Location URL is decoded
+  // test non-Location URL is decoded
   static const std::string Other("Other");
-  static const std::string testOther(Other+":"+URL);
-  httplib::detail::parse_header(testOther.data(), testOther.data()+testOther.size(),
-               [&](std::string const& key, std::string const& value)
-  {
-    EXPECT_EQ(key, Other);
-    EXPECT_EQ(value, httplib::detail::decode_url(URL, false));
-    EXPECT_NE(value, URL);
-  });
+  static const std::string testOther(Other + ":" + URL);
+  httplib::detail::parse_header(
+      testOther.data(), testOther.data() + testOther.size(),
+      [&](std::string const &key, std::string const &value) {
+        EXPECT_EQ(key, Other);
+        EXPECT_EQ(value, httplib::detail::decode_url(URL, false));
+        EXPECT_NE(value, URL);
+      });
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -5597,3 +5597,30 @@ TEST(TaskQueueTest, IncreaseAtomicInteger) {
   EXPECT_NO_THROW(task_queue->shutdown());
   EXPECT_EQ(number_of_task, count.load());
 }
+
+TEST(ParseHeader, LocationValueDecoding)
+{
+  static const std::string URL("https://stitcher2.acast.com/livestitches/4d4cc4fe72c9452bd0b0992a5c89e434.mp3?aid=63a4721c69c77e001126ad39&chid=a8879bdf-de58-4537-8dab-a3bb13948786&ci=oFpQlSRp3GFDZwrcZw5e3SEuFWtGfBXjcj6-mtxC8TJYKWNWTP3KWg%3D%3D&pf=rss&sv=sphinx%401.134.1&uid=6ec01abdba610f88f88e42ff560ecdef&Expires=1672109987714&Key-Pair-Id=K38CTQXUSD0VVB&Signature=TQXsBs7XluU~YRtPTcYe1EtVuvnkf542tbp1p7KUnvn24rm-tQjO8dYgLSbXlJCBwsiPtbnJc-YjLbGlaVLKDzzfABj2lCldE-KoeUSdnEQPWXdPK6FK5BR7kuN-CuY1MfQ-0sDa4MTGAErHZZB1p3~jiiZbbP7fYd9ttBfXwlZgjv5BtHOL4KQs7QY7q-~ZP5tXoGhtufPMruWRYOptrves991ax5lgKPwTvzhXSL6CEKpHWoAMi88shXnBBC~f2iOropB-yzcj5K-uaK6LPcObfHh9Akgl~uIAqbLka2Nrq-HQ-7QrMIUmFcA2nTEaAF66dGRj7AGtEkS2m2hB4A__");
+  static const std::string Location("Location");
+  static const std::string testLocation(Location+":"+URL);
+
+  //test Location URL is preserved
+  httplib::detail::parse_header(testLocation.data(), testLocation.data()+testLocation.size(),
+               [&](std::string const& key, std::string const& value)
+  {
+    EXPECT_EQ(key, Location);
+    EXPECT_EQ(value, URL);
+    EXPECT_NE(value, httplib::detail::decode_url(URL, false));
+  });
+
+  //test non-Location URL is decoded
+  static const std::string Other("Other");
+  static const std::string testOther(Other+":"+URL);
+  httplib::detail::parse_header(testOther.data(), testOther.data()+testOther.size(),
+               [&](std::string const& key, std::string const& value)
+  {
+    EXPECT_EQ(key, Other);
+    EXPECT_EQ(value, httplib::detail::decode_url(URL, false));
+    EXPECT_NE(value, URL);
+  });
+}


### PR DESCRIPTION
Redirected GET request like `https://sphinx.acast.com/p/acast/s/a-bientot-de-te-revoir/e/63a4721c69c77e001126ad39/media.mp3`
are failing and while it looks like an agent setup problem it is actually the processing of the `Location` response header.

httplib is percent-un-escaping every response header with `decode_url` in `parse_header`, giving this address
`https://stitcher2.acast.com/livestitches/4d4cc4fe72c9452bd0b0992a5c89e434.mp3?aid=63a4721c69c77e001126ad39&chid=a8879bdf-de58-4537-8dab-a3bb13948786&ci=oFpQlSRp3GFDZwrcZw5e3SEuFWtGfBXjcj6-mtxC8TJYKWNWTP3KWg==&pf=rss&sv=sphinx@1.134.1&uid=6ec01abdba610f88f88e42ff560ecdef&Expires=1672100680731&Key-Pair-Id=K38CTQXUSD0VVB&Signature=XoIMT7YfpbpOerJXwA4JVT-zat8V2flxU5AKtwr8LEGegGAu6hNSgeyLgq7gQmpv6pv6im2hKSyfUUqQmBEW8MCFLUYiUXuSVEcuVZ3BAT8u0gzcSdTFC1wOGhZTAExH15vei9-UAOVMj7Mq-jP-8hd-H~Atrj2YKI9krbWoslScK4yepWvpzwvBWP8-58NPIy6FaSfMHWwODigNCrJudiR0DPrr6x-HVSiwB~q5aTNVvlABQqGxNkpWtnAie8TuYKEvmioTlEL1aFj8RxMWke7yRc4uOchJtak5COoej4x780f0mepp-eh0OGtsB1izB7hGsyob0c8DwCYoVGTsRg__` in the `Location` result header and the redirected request fails.

However Firefox (for instance) successfully redirects to
`https://stitcher2.acast.com/livestitches/4d4cc4fe72c9452bd0b0992a5c89e434.mp3?aid=63a4721c69c77e001126ad39&chid=a8879bdf-de58-4537-8dab-a3bb13948786&ci=oFpQlSRp3GFDZwrcZw5e3SEuFWtGfBXjcj6-mtxC8TJYKWNWTP3KWg%3D%3D&pf=rss&sv=sphinx%401.134.1&uid=6ec01abdba610f88f88e42ff560ecdef&Expires=1672109987714&Key-Pair-Id=K38CTQXUSD0VVB&Signature=TQXsBs7XluU~YRtPTcYe1EtVuvnkf542tbp1p7KUnvn24rm-tQjO8dYgLSbXlJCBwsiPtbnJc-YjLbGlaVLKDzzfABj2lCldE-KoeUSdnEQPWXdPK6FK5BR7kuN-CuY1MfQ-0sDa4MTGAErHZZB1p3~jiiZbbP7fYd9ttBfXwlZgjv5BtHOL4KQs7QY7q-~ZP5tXoGhtufPMruWRYOptrves991ax5lgKPwTvzhXSL6CEKpHWoAMi88shXnBBC~f2iOropB-yzcj5K-uaK6LPcObfHh9Akgl~uIAqbLka2Nrq-HQ-7QrMIUmFcA2nTEaAF66dGRj7AGtEkS2m2hB4A__`, with escaped parts here `%3D%3D&pf=rss&sv=sphinx%40`

This fix skips decoding for `Location` (case sensitive) only, it may be too restrictive.