### PR TITLE
Support CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@
 	* HTTPLIB_USE_BROTLI_IF_AVAILABLE (default on)
 	* HTTPLIB_REQUIRE_BROTLI (default off)
 	* HTTPLIB_COMPILE (default off)
+	* HTTPLIB_TEST (default off)
 	* BROTLI_USE_STATIC_LIBS - tells Cmake to use the static Brotli libs (only works if you have them installed).
 	* OPENSSL_USE_STATIC_LIBS - tells Cmake to use the static OpenSSL libs (only works if you have them installed).
 
@@ -88,7 +89,7 @@ option(HTTPLIB_COMPILE "If ON, uses a Python script to split the header into a c
 if(HTTPLIB_COMPILE)
 	set(HTTPLIB_IS_COMPILED TRUE)
 endif()
-
+option(HTTPLIB_TEST "Enables testing and builds tests" OFF)
 option(HTTPLIB_REQUIRE_BROTLI "Requires Brotli to be found & linked, or fails build." OFF)
 option(HTTPLIB_USE_BROTLI_IF_AVAILABLE "Uses Brotli (if available) to enable Brotli decompression support." ON)
 # Defaults to static library
@@ -278,3 +279,8 @@ install(EXPORT httplibTargets
 	NAMESPACE ${PROJECT_NAME}::
 	DESTINATION ${_TARGET_INSTALL_CMAKEDIR}
 )
+
+if(HTTPLIB_TEST)
+    include(CTest)
+    add_subdirectory(test)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,8 +9,7 @@ set(gtest_force_shared_crt ON)
 
 FetchContent_Declare(
     gtest
-    URL https://github.com/google/googletest/archive/release-1.12.1.tar.gz
-    URL_HASH SHA256=81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2
+    URL https://github.com/google/googletest/archive/main.tar.gz
 )
 FetchContent_MakeAvailable(gtest)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,94 @@
+cmake_policy(SET CMP0135 NEW)
+
+include(FetchContent)
+include(GoogleTest)
+
+set(BUILD_GMOCK OFF)
+set(INSTALL_GTEST OFF)
+set(gtest_force_shared_crt ON)
+
+FetchContent_Declare(
+    gtest
+    URL https://github.com/google/googletest/archive/release-1.12.1.tar.gz
+    URL_HASH SHA256=81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2
+)
+FetchContent_MakeAvailable(gtest)
+
+add_executable(httplib-test test.cc)
+target_compile_options(httplib-test PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+target_link_libraries(httplib-test PRIVATE httplib GTest::gtest_main)
+gtest_discover_tests(httplib-test)
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/www www
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/www2 www2
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/www3 www3
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_LIST_DIR}/ca-bundle.crt ca-bundle.crt
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_LIST_DIR}/image.jpg image.jpg
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND_ERROR_IS_FATAL ANY
+)
+
+if(HTTPLIB_IS_USING_OPENSSL)
+    find_program(OPENSSL_COMMAND
+        NAMES openssl
+        PATHS ${OPENSSL_INCLUDE_DIR}/../bin
+        REQUIRED
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} genrsa 2048
+        OUTPUT_FILE key.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} req -new -batch -config ${CMAKE_CURRENT_LIST_DIR}/test.conf -key key.pem
+        COMMAND ${OPENSSL_COMMAND} x509 -days 3650 -req -signkey key.pem
+        OUTPUT_FILE cert.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} req -x509 -config ${CMAKE_CURRENT_LIST_DIR}/test.conf -key key.pem -sha256 -days 3650 -nodes -out cert2.pem -extensions SAN
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} genrsa 2048
+        OUTPUT_FILE rootCA.key.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} req -x509 -new -batch -config ${CMAKE_CURRENT_LIST_DIR}/test.rootCA.conf -key rootCA.key.pem -days 1024
+        OUTPUT_FILE rootCA.cert.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} genrsa 2048
+        OUTPUT_FILE client.key.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} req -new -batch -config ${CMAKE_CURRENT_LIST_DIR}/test.conf -key client.key.pem
+        COMMAND ${OPENSSL_COMMAND} x509 -days 370 -req -CA rootCA.cert.pem -CAkey rootCA.key.pem -CAcreateserial
+        OUTPUT_FILE client.cert.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} genrsa -passout pass:test123! 2048
+        OUTPUT_FILE key_encrypted.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} req -new -batch -config ${CMAKE_CURRENT_LIST_DIR}/test.conf -key key_encrypted.pem
+        COMMAND ${OPENSSL_COMMAND} x509 -days 3650 -req -signkey key_encrypted.pem
+        OUTPUT_FILE cert_encrypted.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,7 +49,7 @@ if(HTTPLIB_IS_USING_OPENSSL)
         COMMAND_ERROR_IS_FATAL ANY
     )
     execute_process(
-        COMMAND ${OPENSSL_COMMAND} req -x509 -config ${CMAKE_CURRENT_LIST_DIR}/test.conf -key key.pem -sha256 -days 3650 -nodes -out cert2.pem -extensions SAN
+        COMMAND ${OPENSSL_COMMAND} req -x509 -new -config ${CMAKE_CURRENT_LIST_DIR}/test.conf -key key.pem -sha256 -days 3650 -nodes -out cert2.pem -extensions SAN
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMAND_ERROR_IS_FATAL ANY
     )


### PR DESCRIPTION
I added `test/CMakeLists.txt` because the current testing workflow is separate from the CMake build system.
Now we can do this for testing in a cross-platform way.

```sh
cmake -S . -B build -DHTTPLIB_TEST=ON
cmake --build build && cd build
ctest
```

I also tested `httplib` with `OpenSSL` as shown in `test/Makefile`.
This requires me to generate some cert files in the build directory.
Here is results on my machine (Windows 10)

![result-windows](https://user-images.githubusercontent.com/30493199/212450492-02a9f265-490d-412a-a5de-309026807913.png)

It may test with `Brotli` and `zlib` as well if libraries are installed correctly.