### PR TITLE
Support loading system certs from Keychein on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
 		$<$<PLATFORM_ID:Windows>:crypt32>
 		$<$<PLATFORM_ID:Windows>:cryptui>
 		# Needed for API from MacOS Security framework
-		$<$<PLATFORM_ID:Darwin>:"-framework CoreFoundation -framework Security">
+		$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>>:"-framework CoreFoundation -framework Security">
 		# Can't put multiple targets in a single generator expression or it bugs out.
 		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::common>
 		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
 		$<$<PLATFORM_ID:Windows>:crypt32>
 		$<$<PLATFORM_ID:Windows>:cryptui>
 		# Needed for API from MacOS Security framework
-		$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>>:"-framework CoreFoundation -framework Security">
+		"$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>>:-framework CoreFoundation -framework Security>"
 		# Can't put multiple targets in a single generator expression or it bugs out.
 		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::common>
 		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,8 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
 		$<$<PLATFORM_ID:Windows>:ws2_32>
 		$<$<PLATFORM_ID:Windows>:crypt32>
 		$<$<PLATFORM_ID:Windows>:cryptui>
+		# Needed for API from MacOS Security framework
+		$<$<PLATFORM_ID:Darwin>:"-framework CoreFoundation -framework Security">
 		# Can't put multiple targets in a single generator expression or it bugs out.
 		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::common>
 		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>

--- a/httplib.h
+++ b/httplib.h
@@ -7928,7 +7928,7 @@ inline bool SSLClient::load_certs() {
         ret = false;
       }
     } else {
-      bool loaded = false;
+      auto loaded = false;
 #ifdef _WIN32
       loaded =
           detail::load_system_certs_on_windows(SSL_CTX_get_cert_store(ctx_));

--- a/httplib.h
+++ b/httplib.h
@@ -4426,7 +4426,7 @@ inline bool retrieve_certs_from_keychain(CFObjectPtr<CFArrayRef> &certs) {
   CFTypeRef values[] = {kSecClassCertificate, kSecMatchLimitAll,
                         kCFBooleanTrue};
 
-  CFObjectPtr<const __CFDictionary> query(
+  CFObjectPtr<CFDictionaryRef> query(
       CFDictionaryCreate(nullptr, reinterpret_cast<const void **>(keys), values,
                          sizeof(keys) / sizeof(keys[0]),
                          &kCFTypeDictionaryKeyCallBacks,

--- a/httplib.h
+++ b/httplib.h
@@ -4414,8 +4414,7 @@ inline bool load_system_certs_on_windows(X509_STORE *store) {
 
   return true;
 }
-#endif
-#ifdef __APPLE__
+#elif defined(__APPLE__)
 using CFObjectDeleter = std::function<void(CFTypeRef)>;
 template <typename T> using CFObjectPtr = std::unique_ptr<T, CFObjectDeleter>;
 
@@ -7904,8 +7903,7 @@ inline bool SSLClient::load_certs() {
       SSL_CTX_set_default_verify_paths(ctx_);
 #ifdef _WIN32
       detail::load_system_certs_on_windows(SSL_CTX_get_cert_store(ctx_));
-#endif
-#ifdef __APPLE__
+#elif defined(__APPLE__)
       detail::load_system_certs_on_apple(SSL_CTX_get_cert_store(ctx_));
 #endif
     }

--- a/httplib.h
+++ b/httplib.h
@@ -7898,12 +7898,14 @@ inline bool SSLClient::load_certs() {
         ret = false;
       }
     } else {
-      SSL_CTX_set_default_verify_paths(ctx_);
+      bool loaded = false;
 #ifdef _WIN32
-      detail::load_system_certs_on_windows(SSL_CTX_get_cert_store(ctx_));
+      loaded =
+          detail::load_system_certs_on_windows(SSL_CTX_get_cert_store(ctx_));
 #elif defined(__APPLE__)
-      detail::load_system_certs_on_apple(SSL_CTX_get_cert_store(ctx_));
+      loaded = detail::load_system_certs_on_apple(SSL_CTX_get_cert_store(ctx_));
 #endif
+      if (!loaded) { SSL_CTX_set_default_verify_paths(ctx_); }
     }
   });
 

--- a/httplib.h
+++ b/httplib.h
@@ -239,12 +239,10 @@ using socket_t = int;
 #pragma comment(lib, "crypt32.lib")
 #pragma comment(lib, "cryptui.lib")
 #endif
-#endif //_WIN32
-
-#ifdef __APPLE__
+#elif defined(__APPLE__) // _WIN32
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>
-#endif
+#endif // __APPLE__
 
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -4415,8 +4413,8 @@ inline bool load_system_certs_on_windows(X509_STORE *store) {
   return true;
 }
 #elif defined(__APPLE__)
-using CFObjectDeleter = std::function<void(CFTypeRef)>;
-template <typename T> using CFObjectPtr = std::unique_ptr<T, CFObjectDeleter>;
+template <typename T>
+using CFObjectPtr = std::unique_ptr<T, void (*)(CFTypeRef)>;
 
 inline bool load_system_certs_on_apple(X509_STORE *store) {
   CFStringRef keys[] = {kSecClass, kSecMatchLimit, kSecReturnRef};

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,9 @@ openssl_dep = dependency('openssl', version: '>=1.1.1', required: get_option('cp
 if openssl_dep.found()
   deps += openssl_dep
   args += '-DCPPHTTPLIB_OPENSSL_SUPPORT'
+  if host_machine.system() == 'darwin'
+    deps += dependency('appleframeworks', modules: ['CoreFoundation', 'Security'])
+  endif
 endif
 
 zlib_dep = dependency('zlib', required: get_option('cpp-httplib_zlib'))
@@ -56,10 +59,6 @@ endforeach
 if brotli_found_all
   deps += brotli_deps
   args += '-DCPPHTTPLIB_BROTLI_SUPPORT'
-endif
-
-if host_machine.system() == 'darwin'
-  deps += dependency('appleframeworks', modules: ['CoreFoundation', 'Security'])
 endif
 
 cpp_httplib_dep = dependency('', required: false)

--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,10 @@ if brotli_found_all
   args += '-DCPPHTTPLIB_BROTLI_SUPPORT'
 endif
 
+if host_machine.system() == 'darwin'
+  deps += dependency('appleframeworks', modules: ['CoreFoundation', 'Security'])
+endif
+
 cpp_httplib_dep = dependency('', required: false)
 
 if get_option('cpp-httplib_compile')

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,7 +11,7 @@ OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I$(OPENSSL_DIR)/include -L$(OPEN
 ifneq ($(OS), Windows_NT)
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S), Darwin)
-    	OPENSSL_SUPPORT += -framework CoreFoundation -framework Security
+		OPENSSL_SUPPORT += -framework CoreFoundation -framework Security
 	endif
 endif
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,8 +11,8 @@ OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I$(OPENSSL_DIR)/include -L$(OPEN
 ifneq ($(OS), Windows_NT)
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S), Darwin)
-        OPENSSL_SUPPORT += -framework CoreFoundation -framework Security
-    endif
+    	OPENSSL_SUPPORT += -framework CoreFoundation -framework Security
+	endif
 endif
 
 ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,6 +8,13 @@ OPENSSL_DIR = $(PREFIX)/opt/openssl@1.1
 #OPENSSL_DIR = $(PREFIX)/opt/openssl@3
 OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I$(OPENSSL_DIR)/include -L$(OPENSSL_DIR)/lib -lssl -lcrypto
 
+ifneq ($(OS), Windows_NT)
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S), Darwin)
+        OPENSSL_SUPPORT += -framework CoreFoundation -framework Security
+    endif
+endif
+
 ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz
 
 BROTLI_DIR = $(PREFIX)/opt/brotli


### PR DESCRIPTION
Added support for loading certificates from the Keychain on MacOS, similar to Windows.
I have tested it in my project and it works. 

I am not sure how to properly add the necessary MacOS SDK frameworks to cmake and make, I will be glad to comments.