### PR TITLE
Check if stream is writable to avoid infinite loop in write_content_chunked while using SSE

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3761,7 +3761,7 @@ write_content_chunked(Stream &strm, const ContentProvider &content_provider,
 
   data_sink.is_writable = [&](void) { return ok && strm.is_writable(); };
 
-  while (data_available && !is_shutting_down()) {
+  while (data_available && !is_shutting_down() && strm.is_writable()) {
     if (!content_provider(offset, 0, data_sink)) {
       error = Error::Canceled;
       return false;

--- a/httplib.h
+++ b/httplib.h
@@ -3643,7 +3643,7 @@ inline bool write_content(Stream &strm, const ContentProvider &content_provider,
 
   data_sink.is_writable = [&](void) { return ok && strm.is_writable(); };
 
-  while (offset < end_offset && !is_shutting_down()) {
+  while (offset < end_offset && !is_shutting_down() && strm.is_writable()) {
     if (!content_provider(offset, end_offset - offset, data_sink)) {
       error = Error::Canceled;
       return false;
@@ -3689,7 +3689,7 @@ write_content_without_length(Stream &strm,
 
   data_sink.is_writable = [&](void) { return ok && strm.is_writable(); };
 
-  while (data_available && !is_shutting_down()) {
+  while (data_available && !is_shutting_down() && strm.is_writable()) {
     if (!content_provider(offset, 0, data_sink)) { return false; }
     if (!ok) { return false; }
   }


### PR DESCRIPTION
Hi @yhirose ! Here is PR which fixes issue described in #1475 

As you asked here is the copy of issue description:

I am using server-sent events and faced infinite loop. In my case infinite loop occurs when I reopen web-page/web-browser several times.
How to reproduce: run SSE example ssesvr.cc, open browser and reload page several times (5 or 6 in my case on 8-core processor). Voila, page not loading!
Infinite loop is here: https://github.com/yhirose/cpp-httplib/blob/master/httplib.h#L3764
My hotfix looks like this: while (data_available && !is_shutting_down() && strm.is_writable()) { (add && strm.is_writable()). Not sure it's absolutely correct, so no PR from me :) Also I see there are similar pieces of code, maybe they are affected too.
Please investigate the problem!
Thanks!