### PR TITLE
Threadpool: don't allow enqueueing after shutdown.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -559,6 +559,10 @@ public:
   void enqueue(std::function<void()> fn) override {
     {
       std::unique_lock<std::mutex> lock(mutex_);
+
+      // Don't allow enqueueing after shutdown
+      if (shutdown_) { return; }
+
       jobs_.push_back(std::move(fn));
     }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -5880,3 +5880,19 @@ TEST(TaskQueueTest, IncreaseAtomicInteger) {
   EXPECT_NO_THROW(task_queue->shutdown());
   EXPECT_EQ(number_of_task, count.load());
 }
+
+TEST(TaskQueueTest, NoEnqueueingAfterShutdown) {
+  std::unique_ptr<TaskQueue> task_queue{ new ThreadPool{CPPHTTPLIB_THREAD_POOL_COUNT} };
+  std::atomic_uint count{0};
+
+  for (unsigned int i = 0; i < 10000; i++) {
+    if (i != 0) {
+      task_queue->enqueue(
+        [&count] { count.fetch_add(1, std::memory_order_relaxed); });
+    } else {
+      task_queue->shutdown();
+    }
+  }
+
+  EXPECT_EQ(0, count.load());
+}


### PR DESCRIPTION
A threadpool should ignore all the enqueueing tasks after its shutdown rather than pushing them into the `job_` list.