### PR TITLE
cmake: support components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@
 
 	-------------------------------------------------------------------------------
 
-	After installation with Cmake, a find_package(httplib) is available.
-	This creates a httplib::httplib target (if found).
+	After installation with Cmake, a find_package(httplib COMPONENTS OpenSSL ZLIB Brotli) is available.
+	This creates a httplib::httplib target (if found and if listed components are supported).
 	It can be linked like so:
 
 	target_link_libraries(your_exe httplib::httplib)
@@ -235,8 +235,6 @@ configure_package_config_file("${PROJECT_NAME}Config.cmake.in"
 	INSTALL_DESTINATION "${_TARGET_INSTALL_CMAKEDIR}"
 	# Passes the includedir install path
 	PATH_VARS CMAKE_INSTALL_FULL_INCLUDEDIR
-	# There aren't any components, so don't use the macro
-	NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
 
 if(HTTPLIB_COMPILE)

--- a/httplibConfig.cmake.in
+++ b/httplibConfig.cmake.in
@@ -42,8 +42,17 @@ set_and_check(HTTPLIB_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@")
 # This is helpful if you're using Cmake's pre-compiled header feature
 set_and_check(HTTPLIB_HEADER_PATH "@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@/httplib.h")
 
-# Brings in the target library
-include("${CMAKE_CURRENT_LIST_DIR}/httplibTargets.cmake")
+# Consider each library support as a "component"
+set(httplib_OpenSSL_FOUND @HTTPLIB_IS_USING_OPENSSL@)
+set(httplib_ZLIB_FOUND @HTTPLIB_IS_USING_ZLIB@)
+set(httplib_Brotli_FOUND @HTTPLIB_IS_USING_BROTLI@)
+
+check_required_components(httplib)
+
+# Brings in the target library, but only if all required components are found
+if(NOT DEFINED httplib_FOUND OR httplib_FOUND)
+	include("${CMAKE_CURRENT_LIST_DIR}/httplibTargets.cmake")
+endif()
 
 # Ouputs a "found httplib /usr/include/httplib.h" message when using find_package(httplib)
 include(FindPackageMessage)


### PR DESCRIPTION
This will allow things like `find_package(httplib REQUIRED OpenSSL)` to reject library not supporting SSL functionalities, and prevent the creation of the `httplib::httplib` imported target when this is the case.

It's shorter than:
```
find_package(httplib REQUIRED)
if(NOT HTTPLIB_IS_USING_OPENSSL)
  message(FATAL_ERROR "...")
endif()
```
And it allows the creation of a fallback imported target (e.g. from bundled source code) with the same name than `httplib::httplib`.
