### PR TITLE
cmake: fix find_dependency

### DIFF
--- a/httplibConfig.cmake.in
+++ b/httplibConfig.cmake.in
@@ -12,19 +12,19 @@ set(HTTPLIB_VERSION @PROJECT_VERSION@)
 include(CMakeFindDependencyMacro)
 
 # We add find_dependency calls here to not make the end-user have to call them.
-find_dependency(Threads REQUIRED)
+find_dependency(Threads)
 if(@HTTPLIB_IS_USING_OPENSSL@)
 	# OpenSSL COMPONENTS were added in Cmake v3.11
 	if(CMAKE_VERSION VERSION_LESS "3.11")
-		find_dependency(OpenSSL @_HTTPLIB_OPENSSL_MIN_VER@ REQUIRED)
+		find_dependency(OpenSSL @_HTTPLIB_OPENSSL_MIN_VER@)
 	else()
 		# Once the COMPONENTS were added, they were made optional when not specified.
 		# Since we use both, we need to search for both.
-		find_dependency(OpenSSL @_HTTPLIB_OPENSSL_MIN_VER@ COMPONENTS Crypto SSL REQUIRED)
+		find_dependency(OpenSSL @_HTTPLIB_OPENSSL_MIN_VER@ COMPONENTS Crypto SSL)
 	endif()
 endif()
 if(@HTTPLIB_IS_USING_ZLIB@)
-	find_dependency(ZLIB REQUIRED)
+	find_dependency(ZLIB)
 endif()
 
 if(@HTTPLIB_IS_USING_BROTLI@)
@@ -32,7 +32,7 @@ if(@HTTPLIB_IS_USING_BROTLI@)
 	# Note that the FindBrotli.cmake file is installed in the same dir as this file.
 	list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 	set(BROTLI_USE_STATIC_LIBS @BROTLI_USE_STATIC_LIBS@)
-	find_dependency(Brotli COMPONENTS common encoder decoder REQUIRED)
+	find_dependency(Brotli COMPONENTS common encoder decoder)
 endif()
 
 # Mildly useful for end-users


### PR DESCRIPTION
`QUIET`/`REQUIRED` are not recommended in `find_dependency` because they will be added by CMake based on the keyword used in `find_package(httplib ...)`.

For example currently `find_package(httplib QUIET COMPONENTS OpenSSL)` will produce a fatal error if OpenSSL is not found instead of failing silently (httplib is not a required dependency in this case).