### PR TITLE
Fix multipart Content-Type headers with both boundary and charset parameters

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1823,6 +1823,8 @@ std::string params_to_query_str(const Params &params);
 
 void parse_query_text(const std::string &s, Params &params);
 
+bool parse_multipart_boundary(const std::string &content_type, std::string &boundary);
+
 bool parse_range_header(const std::string &s, Ranges &ranges);
 
 int close_socket(socket_t sock);

--- a/httplib.h
+++ b/httplib.h
@@ -3888,10 +3888,12 @@ inline void parse_query_text(const std::string &s, Params &params) {
 
 inline bool parse_multipart_boundary(const std::string &content_type,
                                      std::string &boundary) {
-  auto pos = content_type.find("boundary=");
+  auto boundary_keyword = "boundary=";
+  auto pos = content_type.find(boundary_keyword);
   if (pos == std::string::npos) { return false; }
   auto end = content_type.find(';', pos);
-  boundary = content_type.substr(pos + 9, end - pos - 9);
+  auto beg = pos + strlen(boundary_keyword);
+  boundary = content_type.substr(beg, end - beg);
   if (boundary.length() >= 2 && boundary.front() == '"' &&
       boundary.back() == '"') {
     boundary = boundary.substr(1, boundary.size() - 2);

--- a/httplib.h
+++ b/httplib.h
@@ -3890,7 +3890,8 @@ inline bool parse_multipart_boundary(const std::string &content_type,
                                      std::string &boundary) {
   auto pos = content_type.find("boundary=");
   if (pos == std::string::npos) { return false; }
-  boundary = content_type.substr(pos + 9);
+  auto end = content_type.find(';', pos);
+  boundary = content_type.substr(pos + 9, end - pos - 9);
   if (boundary.length() >= 2 && boundary.front() == '"' &&
       boundary.back() == '"') {
     boundary = boundary.substr(1, boundary.size() - 2);

--- a/test/test.cc
+++ b/test/test.cc
@@ -169,6 +169,39 @@ TEST(ParamsToQueryTest, ConvertParamsToQuery) {
   EXPECT_EQ(detail::params_to_query_str(dic), "key1=val1&key2=val2&key3=val3");
 }
 
+TEST(ParseMultipartBoundaryTest, DefaultValue) {
+  string content_type = "multipart/form-data; boundary=something";
+  string boundary;
+  auto ret = detail::parse_multipart_boundary(content_type, boundary);
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(boundary, "something");
+}
+
+TEST(ParseMultipartBoundaryTest, ValueWithQuote) {
+  string content_type = "multipart/form-data; boundary=\"gc0pJq0M:08jU534c0p\"";
+  string boundary;
+  auto ret = detail::parse_multipart_boundary(content_type, boundary);
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(boundary, "gc0pJq0M:08jU534c0p");
+}
+
+TEST(ParseMultipartBoundaryTest, ValueWithCharset) {
+  string content_type = "multipart/mixed; boundary=THIS_STRING_SEPARATES;charset=UTF-8";
+  string boundary;
+  auto ret = detail::parse_multipart_boundary(content_type, boundary);
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(boundary, "THIS_STRING_SEPARATES");
+}
+
+TEST(ParseMultipartBoundaryTest, ValueWithQuotesAndCharset) {
+  string content_type =
+      "multipart/mixed; boundary=\"cpp-httplib-multipart-data\"; charset=UTF-8";
+  string boundary;
+  auto ret = detail::parse_multipart_boundary(content_type, boundary);
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(boundary, "cpp-httplib-multipart-data");
+}
+
 TEST(GetHeaderValueTest, DefaultValue) {
   Headers headers = {{"Dummy", "Dummy"}};
   auto val = detail::get_header_value(headers, "Content-Type", 0, "text/plain");


### PR DESCRIPTION
This PR is for Issue #1515.

If the webserver returns a multipart response and include both boundary and charset parameters in the Content-Type header, then only the boundary needs to be read by `parse_multipart_boundary()`. I am not sure that including boundary + charset is something that follows the standard, but when querying an _openresty_ server, we get this case.
I tried my best to read the RFC standards and do something that works in the general case. According to section [5.1.1](https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1) of the RFC2046, the boundary cannot contain a semicolon, so I just search for the first semicolon after the "boundary=" keyword and cut the substring at this position. I added four tests to check that it works.
