### PR TITLE
SSL access through a proxy causes SIGSEGV

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6824,7 +6824,7 @@ inline bool ClientImpl::process_request(Stream &strm, Request &req,
   if (!write_request(strm, req, close_connection, error)) { return false; }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  if (is_ssl()) {
+  if (is_ssl() && socket_.is_open()) {
     char buf[1];
     if (SSL_peek(socket_.ssl, buf, 1) == 0 &&
         SSL_get_error(socket_.ssl, 0) == SSL_ERROR_ZERO_RETURN) {


### PR DESCRIPTION
I've found that GET requests via proxy cause SIGSEGV for SSL access.

@yhirose Could you review the following and the PR?

## How to reproduce

OS: Ubuntu 22.04.2  (x86_64)

Set up Squid.

```bash
$ docker run -d --name squid-container -e TZ=JST -p 3128:3128 ubuntu/squid:5.2-22.04_beta
```

Code to reproduce.

```c++
Client cli("https://www.yahoo.com");
cli.set_proxy("localhost", 3128);
auto res = cli.Get("/");
```

## Detail

It seems that the problem is originated in the commit c7e959a9489bd37fe7d796e679e48894f272e22a at the `ClientImpl::process_request` function. I don't understand the implementation details around that code, but it is probably due to the lack of a socket open check, and this seems to fix SIGSEGV.
