### PR TITLE
Fix lifetime issues when test fails

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -63,6 +63,15 @@ private:
   std::thread thread_;
 };
 
+template <typename Server> class RAIIWrapper {
+public:
+  RAIIWrapper(Server &server) : server_{server} {}
+  ~RAIIWrapper() { server_.stop(); }
+
+private:
+  Server &server_;
+};
+
 MultipartFormData &get_file_value(MultipartFormDataItems &files,
                                   const char *key) {
   auto it = std::find_if(

--- a/test/test.cc
+++ b/test/test.cc
@@ -37,6 +37,32 @@ const std::string JSON_DATA = "{\"hello\":\"world\"}";
 
 const string LARGE_DATA = string(1024 * 1024 * 100, '@'); // 100MB
 
+class JoiningThread {
+public:
+  JoiningThread() noexcept = default;
+  JoiningThread(const JoiningThread &) = delete;
+  JoiningThread(JoiningThread &&) noexcept = default;
+  JoiningThread &operator=(const JoiningThread &) = delete;
+  JoiningThread &operator=(JoiningThread &&) noexcept = default;
+
+  template <class Function, class... Args>
+  explicit JoiningThread(Function &&f, Args &&...args)
+      : thread_{std::forward<Function>(f), std::forward<Args>(args)...} {}
+
+  ~JoiningThread() {
+    if (thread_.joinable()) thread_.join();
+  }
+
+  bool joinable() const noexcept { return thread_.joinable(); }
+  void join() { thread_.join(); }
+  std::thread::native_handle_type native_handle() {
+    return thread_.native_handle();
+  }
+
+private:
+  std::thread thread_;
+};
+
 MultipartFormData &get_file_value(MultipartFormDataItems &files,
                                   const char *key) {
   auto it = std::find_if(


### PR DESCRIPTION
Many test cases have a lifetime issue. It is okay on test success, but something is missed on test failure. For example, following code calls `std::terminate()` because it tries to return at `ASSERT_TRUE()` without joining the listening thread.

```cpp
Server svr;
auto listen_thread = std::thread([&svr]{ svr.listen("127.0.0.1", 1234); });

Client cli("127.0.0.1", 1234);
auto res = cli.Get("/hi");
ASSERT_TRUE(res);

// Not called on failure
svr.stop();
listen_thread.join();
```

To prevent this, I implemented `JoiningThread` and `RAIIWrapper`. `JoiningThread` is basically [`std::jthread`](https://en.cppreference.com/w/cpp/thread/jthread) without [`std::stop_token`](https://en.cppreference.com/w/cpp/thread/stop_token) feature and `RAIIWrapper` calls `Server::stop()` at its destruction. We can now correct the order of destruction using these helpers.

```cpp
Server svr;
JoiningThread listen_thread;
RAIIWrapper<Server> svr_wrapper{svr};

listen_thread = JoiningThread([&svr]{ svr.listen("127.0.0.1", 1234); });

Client cli("127.0.0.1", 1234);
auto res = cli.Get("/hi");
ASSERT_TRUE(res);

// These are redundant now
svr.stop();
listen_thread.join();
```