### PR TITLE
Initialize sockaddr_un to fix valgrind uninitialised byte message

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2668,7 +2668,7 @@ socket_t create_socket(const std::string &host, const std::string &ip, int port,
 
     auto sock = socket(hints.ai_family, hints.ai_socktype, hints.ai_protocol);
     if (sock != INVALID_SOCKET) {
-      sockaddr_un addr;
+      sockaddr_un addr {};
       addr.sun_family = AF_UNIX;
       std::copy(host.begin(), host.end(), addr.sun_path);
 


### PR DESCRIPTION
### Description
Fixes an uninitialized memory warning in the `create_socket` function of the `httplib` library that caused warning when running with Valgrind a UNIX socket server.

### Changes Made
- Initialize the `addr` variable in the `create_socket` function of the `httplib` library before using it in the `bind()` function call.

### Testing
No warning check, functionality ok.


### Warning message
```
valgrind --tool=memcheck --leak-check=full ./wazuh_modules/content_manager/testtool/content_manager_test_tool
==1210596== Memcheck, a memory error detector
==1210596== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1210596== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==1210596== Command: ./wazuh_modules/content_manager/testtool/content_manager_test_tool
==1210596== 
==1210596== Thread 26:
==1210596== Syscall param socketcall.bind(my_addr.sun_path) points to uninitialised byte(s)
==1210596==    at 0x4E4066B: bind (syscall-template.S:120)
==1210596==    by 0x49E0646: httplib::Server::create_server_socket(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int, std::function<void (int)>) const::{lambda(int, addrinfo&)#1}::operator()(int, addrinfo&) const (httplib.h:5695)
==1210596==    by 0x49E1203: int httplib::detail::create_socket<httplib::Server::create_server_socket(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int, std::function<void (int)>) const::{lambda(int, addrinfo&)#1}>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int, int, bool, std::function<void (int)>, httplib::Server::create_server_socket(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int, std::function<void (int)>) const::{lambda(int, addrinfo&)#1}) (httplib.h:2679)
==1210596==    by 0x49E0717: httplib::Server::create_server_socket(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int, std::function<void (int)>) const (httplib.h:5691)
==1210596==    by 0x49E0834: httplib::Server::bind_internal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int) (httplib.h:5707)
==1210596==    by 0x49E04A3: httplib::Server::bind_to_port(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int) (httplib.h:5326)
==1210596==    by 0x49E04E9: httplib::Server::listen(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int) (httplib.h:5337)
==1210596==    by 0x49DF596: OnDemandManager::startServer()::{lambda()#1}::operator()() const (onDemandManager.cpp:44)
==1210596==    by 0x49E02C3: void std::__invoke_impl<void, OnDemandManager::startServer()::{lambda()#1}>(std::__invoke_other, OnDemandManager::startServer()::{lambda()#1}&&) (invoke.h:61)
==1210596==    by 0x49E0286: std::__invoke_result<OnDemandManager::startServer()::{lambda()#1}>::type std::__invoke<OnDemandManager::startServer()::{lambda()#1}>(OnDemandManager::startServer()::{lambda()#1}&&) (invoke.h:96)
==1210596==    by 0x49E0233: void std::thread::_Invoker<std::tuple<OnDemandManager::startServer()::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (std_thread.h:253)
==1210596==    by 0x49E0207: std::thread::_Invoker<std::tuple<OnDemandManager::startServer()::{lambda()#1}> >::operator()() (std_thread.h:260)
==1210596==  Address 0x11c46aa5 is on thread 26's stack
==1210596==  in frame #2, created by int httplib::detail::create_socket<httplib::Server::create_server_socket(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int, std::function<void (int)>) const::{lambda(int, addrinfo&)#1}>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int, int, bool, std::function<void (int)>, httplib::Server::create_server_socket(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int, std::function<void (int)>) const::{lambda(int, addrinfo&)#1}) (httplib.h:2637)
==1210596== 
==1210596== 
==1210596== HEAP SUMMARY:
==1210596==     in use at exit: 0 bytes in 0 blocks
==1210596==   total heap usage: 150 allocs, 150 frees, 95,655 bytes allocated
==1210596== 
==1210596== All heap blocks were freed -- no leaks are possible
==1210596== 
==1210596== Use --track-origins=yes to see where uninitialised values come from
==1210596== For lists of detected and suppressed errors, rerun with: -s
==1210596== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
