### PR TITLE
Fix leaked handle in create_socket

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2728,7 +2728,10 @@ socket_t create_socket(const std::string &host, const std::string &ip, int port,
     if (sock == INVALID_SOCKET) { continue; }
 
 #ifndef _WIN32
-    if (fcntl(sock, F_SETFD, FD_CLOEXEC) == -1) { continue; }
+    if (fcntl(sock, F_SETFD, FD_CLOEXEC) == -1) {
+      close_socket(sock);
+      continue;
+    }
 #endif
 
     if (tcp_nodelay) {


### PR DESCRIPTION
Coverity Scan has flagged the following potential resource leak in `cpp-httplib`, which is bundled in [Zeal](https://github.com/zealdocs/zeal). It is the only "high impact" issue. There are other lower priority potential problems, which I may try to fix later.

![image](https://user-images.githubusercontent.com/714940/230758862-fbc43a45-87ae-455f-b688-5c8f83e5c1e1.png)
