### PR TITLE
Fix gcc 13 warning at -O3

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4708,6 +4708,7 @@ inline bool parse_www_authenticate(const Response &res,
         auto beg = std::sregex_iterator(s.begin(), s.end(), re);
         for (auto i = beg; i != std::sregex_iterator(); ++i) {
           auto m = *i;
+          if (!m.ready()) { continue; }
           auto key = s.substr(static_cast<size_t>(m.position(1)),
                               static_cast<size_t>(m.length(1)));
           auto val = m.length(2) > 0


### PR DESCRIPTION
When compiling with gcc 13.1.1 at -O3, the following warning below is emitted.

Curiously, checking `i->ready()` before the assignment to `m` is not sufficient.

```
In file included from /usr/include/c++/13/regex:68,
                 from subprojects/cpp-httplib-0.11.2/httplib.h:218,
                 from subprojects/cpp-httplib-0.11.2/httplib.cc:1:
In member function ‘std::__cxx11::sub_match<_BiIter>::difference_type std::__cxx11::sub_match<_BiIter>::length() const [with _BiIter = __gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> >]’,
    inlined from ‘std::__cxx11::match_results<_Bi_iter, _Alloc>::difference_type std::__cxx11::match_results<_Bi_iter, _Alloc>::length(size_type) const [with _Bi_iter = __gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > > >]’ at /usr/include/c++/13/bits/regex.h:1907:37,
    inlined from ‘bool httplib::detail::parse_www_authenticate(const httplib::Response&, std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&, bool)’ at subprojects/cpp-httplib-0.11.2/httplib.cc:2529:30:
/usr/include/c++/13/bits/regex.h:942:22: warning: array subscript -3 is outside array bounds of ‘std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > > [384307168202282325]’ [-Warray-bounds=]
  942 |       { return this->matched ? std::distance(this->first, this->second) : 0; }
      |                ~~~~~~^~~~~~~
In file included from /usr/include/c++/13/x86_64-redhat-linux/bits/c++allocator.h:33,
                 from /usr/include/c++/13/bits/allocator.h:46,
                 from /usr/include/c++/13/bits/alloc_traits.h:39,
                 from /usr/include/c++/13/condition_variable:44,
                 from subprojects/cpp-httplib-0.11.2/httplib.h:205:
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > >]’,
    inlined from ‘static _Tp* std::allocator_traits<std::allocator<_Tp1> >::allocate(allocator_type&, size_type) [with _Tp = std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > >]’ at /usr/include/c++/13/bits/alloc_traits.h:482:28,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > >; _Alloc = std::allocator<std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > > >]’ at /usr/include/c++/13/bits/stl_vector.h:378:33,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_create_storage(std::size_t) [with _Tp = std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > >; _Alloc = std::allocator<std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > > >]’ at /usr/include/c++/13/bits/stl_vector.h:395:44,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::_Vector_base(std::size_t, const allocator_type&) [with _Tp = std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > >; _Alloc = std::allocator<std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > > >]’ at /usr/include/c++/13/bits/stl_vector.h:332:26,
    inlined from ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > >; _Alloc = std::allocator<std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > > >]’ at /usr/include/c++/13/bits/stl_vector.h:598:61,
    inlined from ‘std::__cxx11::match_results<_Bi_iter, _Alloc>::match_results(const std::__cxx11::match_results<_Bi_iter, _Alloc>&) [with _Bi_iter = __gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > > >]’ at /usr/include/c++/13/bits/regex.h:1815:7,
    inlined from ‘bool httplib::detail::parse_www_authenticate(const httplib::Response&, std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&, bool)’ at subprojects/cpp-httplib-0.11.2/httplib.cc:2526:21:
/usr/include/c++/13/bits/new_allocator.h:147:55: note: at offset -72 into object of size [1, 9223372036854775800] allocated by ‘operator new’
  147 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                                       ^

```
