### PR TITLE
Move, not copy, Logger and Handler functors

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8751,7 +8751,9 @@ inline void Client::enable_server_certificate_verification(bool enabled) {
 }
 #endif
 
-inline void Client::set_logger(Logger logger) { cli_->set_logger(logger); }
+inline void Client::set_logger(Logger logger) {
+  cli_->set_logger(std::move(logger));
+}
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 inline void Client::set_ca_cert_path(const std::string &ca_cert_file_path,

--- a/httplib.h
+++ b/httplib.h
@@ -5243,7 +5243,7 @@ inline Server &Server::set_error_handler(HandlerWithResponse handler) {
 }
 
 inline Server &Server::set_error_handler(Handler handler) {
-  error_handler_ = [handler](const Request &req, Response &res) {
+  error_handler_ = [handler = std::move(handler)](const Request &req, Response &res) {
     handler(req, res);
     return HandlerResponse::Handled;
   };
@@ -5273,7 +5273,6 @@ inline Server &Server::set_logger(Logger logger) {
 inline Server &
 Server::set_expect_100_continue_handler(Expect100ContinueHandler handler) {
   expect_100_continue_handler_ = std::move(handler);
-
   return *this;
 }
 

--- a/httplib.h
+++ b/httplib.h
@@ -223,6 +223,7 @@ using socket_t = int;
 #include <string>
 #include <sys/stat.h>
 #include <thread>
+#include <utility>
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 #ifdef _WIN32

--- a/httplib.h
+++ b/httplib.h
@@ -6801,7 +6801,6 @@ inline std::unique_ptr<Response> ClientImpl::send_with_content_provider(
       req.set_header("Transfer-Encoding", "chunked");
     } else {
       req.body.assign(body, content_length);
-      ;
     }
   }
 


### PR DESCRIPTION
Hi, and thanks a lot for the nice little library!

Here are a few minor improvements:

* Explicitly #include <utility> for use of std::move [rather than relying on indirect include]
* Move not copy Logger arg from Client to ClientImpl [will avoid copying heavy functors]
* Move not copy, set_error_handler Handler to lambda [ditto]
* Remove null statement in non-empty if/else block [I guess it was a relic from a time before the other statement was added.]

***

We might also consider whether to move `string()` arguments such as these from arguments into their destination - what do you think?

![image](https://github.com/yhirose/cpp-httplib/assets/14101058/6da39beb-080c-4d14-a59d-3c4212cf6d5a)
