### PR TITLE
Don't overwrite the last redirected location

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3920,7 +3920,8 @@ inline bool redirect(T &cli, Request &req, Response &res,
   if (ret) {
     req = new_req;
     res = new_res;
-    res.location = location;
+
+    if (res.location.empty()) res.location = location;
   }
   return ret;
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -929,7 +929,7 @@ TEST(YahooRedirectTest, Redirect_Online) {
   res = cli.Get("/");
   ASSERT_TRUE(res);
   EXPECT_EQ(200, res->status);
-  EXPECT_EQ("https://yahoo.com/", res->location);
+  EXPECT_EQ("https://www.yahoo.com/", res->location);
 }
 
 TEST(HttpsToHttpRedirectTest, Redirect_Online) {
@@ -5237,7 +5237,7 @@ TEST(YahooRedirectTest2, SimpleInterface_Online) {
   res = cli.Get("/");
   ASSERT_TRUE(res);
   EXPECT_EQ(200, res->status);
-  EXPECT_EQ("https://yahoo.com/", res->location);
+  EXPECT_EQ("https://www.yahoo.com/", res->location);
 }
 
 TEST(YahooRedirectTest3, SimpleInterface_Online) {


### PR DESCRIPTION
Since redirection is handled recursively, multiple redirects result an invalid location which is the first redirected location. `res.location` is overwritten recursively.

Some test cases did not check the last location `https://www.yahoo.com`. They usually succeed even if they check the wrong location `https://yahoo.com/`. But sometimes they fail because `http://yahoo.com` redirects `http://www.yahoo.com`.
```
http://yahoo.com -> https://yahoo.com    -> https://www.yahoo.com
http://yahoo.com -> http://www.yahoo.com -> https://www.yahoo.com
```