### PR TITLE
Build examples using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@
 	* HTTPLIB_REQUIRE_BROTLI (default off)
 	* HTTPLIB_COMPILE (default off)
 	* HTTPLIB_INSTALL (default on)
+	* HTTPLIB_EXAMPLE (default off)
 	* HTTPLIB_TEST (default off)
 	* BROTLI_USE_STATIC_LIBS - tells Cmake to use the static Brotli libs (only works if you have them installed).
 	* OPENSSL_USE_STATIC_LIBS - tells Cmake to use the static OpenSSL libs (only works if you have them installed).
@@ -98,6 +99,7 @@ option(HTTPLIB_INSTALL "Enables the installation target" ON)
 if(HTTPLIB_COMPILE)
 	set(HTTPLIB_IS_COMPILED TRUE)
 endif()
+option(HTTPLIB_EXAMPLE "Builds examples" OFF)
 option(HTTPLIB_TEST "Enables testing and builds tests" OFF)
 option(HTTPLIB_REQUIRE_BROTLI "Requires Brotli to be found & linked, or fails build." OFF)
 option(HTTPLIB_USE_BROTLI_IF_AVAILABLE "Uses Brotli (if available) to enable Brotli decompression support." ON)
@@ -296,6 +298,10 @@ if(HTTPLIB_INSTALL)
 		NAMESPACE ${PROJECT_NAME}::
 		DESTINATION ${_TARGET_INSTALL_CMAKEDIR}
 	)
+endif()
+
+if(HTTPLIB_EXAMPLE)
+    add_subdirectory(example)
 endif()
 
 if(HTTPLIB_TEST)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,42 @@
+set(HTTPLIB_EXAMPLES
+    benchmark
+    client
+    hello
+    redirect
+    server
+    simplecli
+    simplesvr
+    ssecli
+    ssesvr
+    upload
+)
+
+foreach(example IN LISTS HTTPLIB_EXAMPLES)
+    add_executable(httplib-${example} ${example}.cc)
+    target_link_libraries(httplib-${example} PRIVATE httplib)
+endforeach()
+
+if(HTTPLIB_IS_USING_OPENSSL)
+    file(
+        COPY ca-bundle.crt
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    find_program(OPENSSL_COMMAND
+        NAMES openssl
+        PATHS ${OPENSSL_INCLUDE_DIR}/../bin
+        REQUIRED
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} genrsa 2048
+        OUTPUT_FILE key.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND ${OPENSSL_COMMAND} req -new -batch -key key.pem
+        COMMAND ${OPENSSL_COMMAND} x509 -days 3650 -req -signkey key.pem
+        OUTPUT_FILE cert.pem
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+endif()


### PR DESCRIPTION
`example/CMakeLists.txt` is added for building examples with CMake. We can simply build them using `HTTPLIB_EXAMPLE` option.