### PR TITLE
Fix type mismatch

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7620,7 +7620,8 @@ inline X509_STORE *ClientImpl::create_ca_cert_store(const char *ca_cert,
 
   auto cts = X509_STORE_new();
   if (cts) {
-    for (size_t first = 0, last = sk_X509_INFO_num(inf); first < last; ++first) {
+    for (size_t first = 0, last = sk_X509_INFO_num(inf); first < last;
+         ++first) {
       auto itmp = sk_X509_INFO_value(inf, first);
       if (!itmp) { continue; }
 

--- a/httplib.h
+++ b/httplib.h
@@ -7620,7 +7620,7 @@ inline X509_STORE *ClientImpl::create_ca_cert_store(const char *ca_cert,
 
   auto cts = X509_STORE_new();
   if (cts) {
-    for (auto first = 0, last = sk_X509_INFO_num(inf); first < last; ++first) {
+    for (size_t first = 0, last = sk_X509_INFO_num(inf); first < last; ++first) {
       auto itmp = sk_X509_INFO_value(inf, first);
       if (!itmp) { continue; }
 


### PR DESCRIPTION
g++12 reports the following problem:

httplib.h:7623:10: error: inconsistent deduction for ‘auto’: ‘int’ and then ‘long unsigned int’
 7623 |     for (auto first = 0, last = sk_X509_INFO_num(inf); first < last; ++first) {
      |          ^~~~