### PR TITLE
Result: allow default constructor

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -878,6 +878,7 @@ std::ostream &operator<<(std::ostream &os, const Error &obj);
 
 class Result {
 public:
+  Result() = default;
   Result(std::unique_ptr<Response> &&res, Error err,
          Headers &&request_headers = Headers{})
       : res_(std::move(res)), err_(err),
@@ -906,7 +907,7 @@ public:
 
 private:
   std::unique_ptr<Response> res_;
-  Error err_;
+  Error err_ = Error::Unknown;
   Headers request_headers_;
 };
 


### PR DESCRIPTION
Allow default constructor for `Result`, to support use cases such as the following:
````
       [...]
       httplib::Client client(host);
       httplib::Result result; // needed here

        if (method == "GET") {
                result = client.Get(path);

        } else if (method == "POST") {
                result = client.Post(path, headers, body,
                                "application/json");
         }

         if (!result) {
             std::cout << "Error";
             return -1;
         }

         // use result
         [...]
````