### PR TITLE
Fix explicit constructor warning

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5275,7 +5275,7 @@ inline PathParamsMatcher::PathParamsMatcher(const std::string &pattern) {
 }
 
 inline bool PathParamsMatcher::match(Request &request) const {
-  request.matches = {};
+  request.matches = std::smatch();
   request.path_params.clear();
   request.path_params.reserve(param_names_.size());
 


### PR DESCRIPTION
This fixes the `converting to ... from initializer list would use explicit constructor` warning introduced in #1608 and reported in #1613 .