### PR TITLE
build(meson): use C++14 with GTest >= 1.13.0

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -86,6 +86,12 @@ subdir(join_paths('www', 'dir'))
 subdir(join_paths('www2', 'dir'))
 subdir(join_paths('www3', 'dir'))
 
+# GoogleTest 1.13.0 requires C++14
+test_options = []
+if gtest_dep.version().version_compare('>=1.13.0')
+  test_options += 'cpp_std=c++14'
+endif
+
 test(
   'main',
   executable(
@@ -94,7 +100,8 @@ test(
     dependencies: [
       cpp_httplib_dep,
       gtest_dep
-    ]
+    ],
+    override_options: test_options
   ),
   depends: [
     key_pem,


### PR DESCRIPTION
GoogleTest, starting with vesion 1.13.0, requires C++14 to build. This patch enables C++14 if GoogleTest 1.13.0 or newer is detected when compiling the tests with Meson, making it possible to use new GTest versions.

You can find GoogleTest's release notes at <https://github.com/google/googletest/releases/tag/v1.13.0>.