### PR TITLE
Fix #1590

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6643,8 +6643,7 @@ inline bool ClientImpl::send_(Request &req, Response &res, Error &error) {
     }
 
     if (socket_should_be_closed_when_request_is_done_ || close_connection ||
-        !ret || res.get_header_value("Connection") == "close" ||
-        (res.version == "HTTP/1.0" && res.reason != "Connection established")) {
+        !ret) {
       shutdown_ssl(socket_, true);
       shutdown_socket(socket_);
       close_socket(socket_);
@@ -6697,6 +6696,24 @@ inline bool ClientImpl::handle_request(Stream &strm, Request &req,
   }
 
   if (!ret) { return false; }
+
+  if (res.get_header_value("Connection") == "close" ||
+      (res.version == "HTTP/1.0" && res.reason != "Connection established")) {
+    // TODO this requires a not-entirely-obvious chain of calls to be correct
+    // for this to be safe. Maybe a code refactor (such as moving this out to
+    // the send function and getting rid of the recursiveness of the mutex)
+    // could make this more obvious.
+
+    // This is safe to call because process_request is only called by
+    // handle_request which is only called by send, which locks the request
+    // mutex during the process. It would be a bug to call it from a different
+    // thread since it's a thread-safety issue to do these things to the socket
+    // if another thread is using the socket.
+    std::lock_guard<std::mutex> guard(socket_mutex_);
+    shutdown_ssl(socket_, true);
+    shutdown_socket(socket_);
+    close_socket(socket_);
+  }
 
   if (300 < res.status && res.status < 400 && follow_location_) {
     req = req_save;

--- a/httplib.h
+++ b/httplib.h
@@ -1889,6 +1889,7 @@ inline std::string to_string(const Error error) {
     return "Unsupported HTTP multipart boundary characters";
   case Error::Compression: return "Compression failed";
   case Error::ConnectionTimeout: return "Connection timed out";
+  case Error::ProxyConnection: return "Proxy connection failed";
   case Error::Unknown: return "Unknown";
   default: break;
   }

--- a/httplib.h
+++ b/httplib.h
@@ -6702,15 +6702,12 @@ inline bool ClientImpl::handle_request(Stream &strm, Request &req,
   if (res.get_header_value("Connection") == "close" ||
       (res.version == "HTTP/1.0" && res.reason != "Connection established")) {
     // TODO this requires a not-entirely-obvious chain of calls to be correct
-    // for this to be safe. Maybe a code refactor (such as moving this out to
-    // the send function and getting rid of the recursiveness of the mutex)
-    // could make this more obvious.
+    // for this to be safe.
 
-    // This is safe to call because process_request is only called by
-    // handle_request which is only called by send, which locks the request
-    // mutex during the process. It would be a bug to call it from a different
-    // thread since it's a thread-safety issue to do these things to the socket
-    // if another thread is using the socket.
+    // This is safe to call because handle_request is only called by send_
+    // which locks the request mutex during the process. It would be a bug
+    // to call it from a different thread since it's a thread-safety issue
+    // to do these things to the socket if another thread is using the socket.
     std::lock_guard<std::mutex> guard(socket_mutex_);
     shutdown_ssl(socket_, true);
     shutdown_socket(socket_);


### PR DESCRIPTION
1. Moved `Connection: close` header control block from `process_request` to `handle_request` since the `process_request` is also called from `connect_with_proxy` method which causes a deadlock state.
2. Some improvements for proxy error handling:
   - Proxy connect response status control block added to stop the execution of the request when the proxy response is not successful. 
   - `ProxyConnection` error type added to distinguish proxy related unsuccessful response from standard response.