### PR TITLE
Fix CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6723,9 +6723,9 @@ inline bool ClientImpl::read_response_line(Stream &strm, const Request &req,
   if (!line_reader.getline()) { return false; }
 
 #ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
-  const static std::regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
-#else
   const static std::regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
+#else
+  const static std::regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
 #endif
 
   std::cmatch m;


### PR DESCRIPTION
In https://github.com/yhirose/cpp-httplib/commit/e5cacb465d3086c7d9be1d87dfffedbafeb02ce8 this issue was supposedly fixed, but in fact it introduced a bug and implemented it the wrong way.

The `\r?` is the default code path instead of specialized with `CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR` as it should be.

In my opinion this behavior should be opt-out instead of opt-in (to match curl, which doesn't require any special options either) but that's probably something to discuss another time.