### PR TITLE
Avoid a -Warray-bounds false positive in GCC 13.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4986,7 +4986,7 @@ inline bool parse_www_authenticate(const Response &res,
         s = s.substr(pos + 1);
         auto beg = std::sregex_iterator(s.begin(), s.end(), re);
         for (auto i = beg; i != std::sregex_iterator(); ++i) {
-          auto m = *i;
+          const auto &m = *i;
           auto key = s.substr(static_cast<size_t>(m.position(1)),
                               static_cast<size_t>(m.length(1)));
           auto val = m.length(2) > 0


### PR DESCRIPTION
The exact circumstances when this false positive is triggered are quite tricky to reproduce, but it happened reproducibly with g++ 13.1 and 13.2 in a close-source SW I'm working on.  The fix even improves performance by a very tiny bit: There is no need to copy the std::smatch, having a const reference is enough.

Just as a side note: -Warray-bounds seems to cause trouble in other projects, too, so e.g. the Linux kernel has disabled since June 2022.