### PR TITLE
Accept AbsoluteURI in Request Lines

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5781,6 +5781,27 @@ inline bool Server::parse_request_line(const char *s, Request &req) {
   if (req.version != "HTTP/1.1" && req.version != "HTTP/1.0") { return false; }
 
   {
+    // Find path in URL
+    bool path_found = false;
+    for (size_t i = 0; i < req.target.size(); i++) {
+      if (req.target[i] == '/') {
+        if (i + 1 < req.target.size() && req.target[i + 1] == '/') {
+          // Skip scheme
+          i++;
+          continue;
+        }
+        req.target.erase(0, i);
+        path_found = true;
+        break;
+      }
+    }
+    if (!path_found) {
+      // An empty abs_path is equivalent to an abs_path of "/".
+      if (req.target != "*") {
+        req.target = "/";
+      }
+    }
+
     // Skip URL fragment
     for (size_t i = 0; i < req.target.size(); i++) {
       if (req.target[i] == '#') {

--- a/test/test.cc
+++ b/test/test.cc
@@ -3538,6 +3538,12 @@ TEST_F(ServerTest, URL) {
   EXPECT_EQ(200, res->status);
 }
 
+TEST_F(ServerTest, AbsoluteURL) {
+  auto res = cli_.Get("http://localhost:1234/request-target?aaa=bbb&ccc=ddd");
+  ASSERT_TRUE(res);
+  EXPECT_EQ(200, res->status);
+}
+
 TEST_F(ServerTest, ArrayParam) {
   auto res = cli_.Get("/array-param?array=value1&array=value2&array=value3");
   ASSERT_TRUE(res);


### PR DESCRIPTION
RFC2616 says

> all HTTP/1.1 servers MUST accept the absoluteURI form in requests

https://datatracker.ietf.org/doc/html/rfc2616#section-5.1.2

I found the current implementation does not accept this form and fixed this issue by just ignoring unrelated parts (scheme, host, and etc) and extracting path part.
