### PR TITLE
Add move optimizations

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3792,7 +3792,7 @@ inline bool read_content_chunked(Stream &strm, T &x,
 
     if (chunk_len == 0) { break; }
 
-    if (!read_content_with_length(strm, chunk_len, nullptr, out)) {
+    if (!read_content_with_length(strm, chunk_len, nullptr, std::move(out))) {
       return false;
     }
 
@@ -4265,7 +4265,7 @@ public:
   MultipartFormDataParser() = default;
 
   void set_boundary(std::string &&boundary) {
-    boundary_ = boundary;
+    boundary_ = std::move(boundary);
     dash_boundary_crlf_ = dash_ + boundary_ + crlf_;
     crlf_dash_boundary_ = crlf_ + dash_ + boundary_;
   }
@@ -5228,7 +5228,7 @@ inline void Response::set_content_provider(
   set_header("Content-Type", content_type);
   content_length_ = in_length;
   if (in_length > 0) { content_provider_ = std::move(provider); }
-  content_provider_resource_releaser_ = resource_releaser;
+  content_provider_resource_releaser_ = std::move(resource_releaser);
   is_chunked_content_provider_ = false;
 }
 
@@ -6552,7 +6552,7 @@ Server::process_request(Stream &strm, bool close_connection,
   } catch (...) {
     if (exception_handler_) {
       auto ep = std::current_exception();
-      exception_handler_(req, res, ep);
+      exception_handler_(req, res, std::move(ep));
       routed = true;
     } else {
       res.status = 500;


### PR DESCRIPTION
A few move optimizations suggested by Coverity. There are a couple other places where lambda parameters can be moved, but IIRC that's only supported since C++14.