### PR TITLE
check request range and fix response Content-Range.

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -2536,6 +2536,7 @@ TEST_F(ServerTest, StaticFileRange) {
   EXPECT_EQ("text/abcde", res->get_header_value("Content-Type"));
   EXPECT_EQ("2", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 2-3/5", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("cd"), res->body);
 }
 
@@ -2549,7 +2550,7 @@ TEST_F(ServerTest, StaticFileRanges) {
           .find(
               "multipart/byteranges; boundary=--cpp-httplib-multipart-data-") ==
       0);
-  EXPECT_EQ("265", res->get_header_value("Content-Length"));
+  EXPECT_EQ("266", res->get_header_value("Content-Length"));
 }
 
 TEST_F(ServerTest, StaticFileRangeHead) {
@@ -2559,6 +2560,7 @@ TEST_F(ServerTest, StaticFileRangeHead) {
   EXPECT_EQ("text/abcde", res->get_header_value("Content-Type"));
   EXPECT_EQ("2", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 2-3/5", res->get_header_value("Content-Range"));
 }
 
 TEST_F(ServerTest, StaticFileRangeBigFile) {
@@ -2568,6 +2570,7 @@ TEST_F(ServerTest, StaticFileRangeBigFile) {
   EXPECT_EQ("text/plain", res->get_header_value("Content-Type"));
   EXPECT_EQ("5", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 1048571-1048575/1048576", res->get_header_value("Content-Range"));
   EXPECT_EQ("LAST\n", res->body);
 }
 
@@ -2578,6 +2581,7 @@ TEST_F(ServerTest, StaticFileRangeBigFile2) {
   EXPECT_EQ("text/plain", res->get_header_value("Content-Type"));
   EXPECT_EQ("4097", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 1-4097/1048576", res->get_header_value("Content-Range"));
 }
 
 TEST_F(ServerTest, StaticFileBigFile) {
@@ -2904,6 +2908,8 @@ TEST_F(ServerTest, GetStreamed2) {
   ASSERT_TRUE(res);
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("2", res->get_header_value("Content-Length"));
+  EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 2-3/6", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("ab"), res->body);
 }
 
@@ -2921,6 +2927,7 @@ TEST_F(ServerTest, GetStreamedWithRange1) {
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("3", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 3-5/7", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("def"), res->body);
 }
 
@@ -2930,6 +2937,7 @@ TEST_F(ServerTest, GetStreamedWithRange2) {
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("6", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 1-6/7", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("bcdefg"), res->body);
 }
 
@@ -2939,6 +2947,7 @@ TEST_F(ServerTest, GetStreamedWithRangeSuffix1) {
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("3", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 4-6/7", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("efg"), res->body);
 }
 
@@ -2948,6 +2957,7 @@ TEST_F(ServerTest, GetStreamedWithRangeSuffix2) {
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("7", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 0-6/7", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("abcdefg"), res->body);
 }
 
@@ -2965,6 +2975,7 @@ TEST_F(ServerTest, GetRangeWithMaxLongLength) {
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("7", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 0-6/7", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("abcdefg"), res->body);
 }
 
@@ -3025,6 +3036,7 @@ TEST_F(ServerTest, GetWithRange1) {
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("3", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 3-5/7", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("def"), res->body);
 }
 
@@ -3034,6 +3046,7 @@ TEST_F(ServerTest, GetWithRange2) {
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("6", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 1-6/7", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("bcdefg"), res->body);
 }
 
@@ -3043,6 +3056,7 @@ TEST_F(ServerTest, GetWithRange3) {
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("1", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 0-0/7", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("a"), res->body);
 }
 
@@ -3052,6 +3066,7 @@ TEST_F(ServerTest, GetWithRange4) {
   EXPECT_EQ(206, res->status);
   EXPECT_EQ("2", res->get_header_value("Content-Length"));
   EXPECT_EQ(true, res->has_header("Content-Range"));
+  EXPECT_EQ("bytes 5-6/7", res->get_header_value("Content-Range"));
   EXPECT_EQ(std::string("fg"), res->body);
 }
 


### PR DESCRIPTION

Adjusted content 

The return value of the "apply_ranges" in the "write_response_core" is adjusted to bool. In the "apply_ranges", the validity of the requested range field is verified and saved to res.ranges_offset_length_ (new field) (using the original get_range_offset_and_length logic). Caching this fields are also needed for subsequent code and do not need to be processed again.

If "apply_ranges" returns false, it means that the range is wrong. Return 416 directly and clear the content.
The subsequent code only removes the offset verification, because all offsets and lengths have been verified in "apply_ranges".

Adjusted content in "make_content_range_header_field"
In the Content-Range field of the return value, if the request range-start or range-end is empty(-1),the offset and length of the actual returned content must be filled in, otherwise the browser will not work. (Use the Chrome view mp4 file, and the request is Range:1024-. If the return field does not fill in the range-end, such as "bytes 1024-/3124123", it cannot be played normally)

get_range_offset_and_length method is no longer needed, so removed

Several range processing logics are:
Assuming the content length is 10,
range:0-9 -> bytes 0-9/10, content-length:10
range:-3 -> bytes 7-9/10, content-length:3 (last 3 bytes)
range:-99 -> bytes 0-9/10, content-length:10 (fix length to 10, last 10 bytes)
range:0- -> bytes 0-9/10, content-length:10
range:0-99 -> bytes 0-9/10, content-length:10 (fix length to 10)
range:10- -> error:416 (range error)
range:10-99 -> error:416 (range error)

fix some string param(without .c_str())


ps.translated by google.
