### PR TITLE
build(meson): copy 1MB.txt test file

### DIFF
--- a/test/www/dir/meson.build
+++ b/test/www/dir/meson.build
@@ -5,3 +5,4 @@
 configure_file(input: 'index.html', output: 'index.html', copy: true)
 configure_file(input: 'test.abcde', output: 'test.abcde', copy: true)
 configure_file(input: 'test.html',  output: 'test.html',  copy: true)
+configure_file(input: '1MB.txt',    output: '1MB.txt',    copy: true)


### PR DESCRIPTION
Since tests are run in the build directory, the 1MB.txt file has to be copied there.