### PR TITLE
Client: allow default constructor

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1378,6 +1378,8 @@ private:
 
 class Client {
 public:
+  Client() = default;
+
   // Universal interface
   explicit Client(const std::string &scheme_host_port);
 


### PR DESCRIPTION
Allow default constructor for `Client`, to support use cases such as the following:
````
       [...]
       httplib::Client cli;

       switch (var) {
       case 1:
           cli = httplib::Client(host1);
           break;
       case 2:
           cli = httplib::Client(host2);
           break;
       case 3:
           cli = httplib::Client(host3);
           break;

           [...]
       }
       result = cli.Get(path);
       // use result
       [...]
````
There are ofc many ways to workaround this limitation, but it would be handy to have also this additional way to use the Client class.