### PR TITLE
Include missing stdint.h on fuzz test

### DIFF
--- a/test/fuzzing/server_fuzzer.cc
+++ b/test/fuzzing/server_fuzzer.cc
@@ -4,7 +4,7 @@
 
 class FuzzedStream : public httplib::Stream {
 public:
-  FuzzedStream(const std::uint8_t *data, size_t size)
+  FuzzedStream(const uint8_t *data, size_t size)
       : data_(data), size_(size), read_pos_(0) {}
 
   ssize_t read(char *ptr, size_t size) override {
@@ -40,7 +40,7 @@ public:
   socket_t socket() const override { return 0; }
 
 private:
-  const std::uint8_t *data_;
+  const uint8_t *data_;
   size_t size_;
   size_t read_pos_;
   std::string response_;
@@ -85,7 +85,7 @@ extern "C" int LLVMFuzzerInitialize(int * /*argc*/, char *** /*argv*/) {
   return 0;
 }
 
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, size_t size) {
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   FuzzedStream stream{data, size};
   g_server.ProcessFuzzedRequest(stream);
   return 0;

--- a/test/fuzzing/server_fuzzer.cc
+++ b/test/fuzzing/server_fuzzer.cc
@@ -1,9 +1,10 @@
+#include <cstdint>
+
 #include <httplib.h>
-#include <memory>
 
 class FuzzedStream : public httplib::Stream {
 public:
-  FuzzedStream(const uint8_t *data, size_t size)
+  FuzzedStream(const std::uint8_t *data, size_t size)
       : data_(data), size_(size), read_pos_(0) {}
 
   ssize_t read(char *ptr, size_t size) override {
@@ -39,7 +40,7 @@ public:
   socket_t socket() const override { return 0; }
 
 private:
-  const uint8_t *data_;
+  const std::uint8_t *data_;
   size_t size_;
   size_t read_pos_;
   std::string response_;
@@ -84,7 +85,7 @@ extern "C" int LLVMFuzzerInitialize(int * /*argc*/, char *** /*argv*/) {
   return 0;
 }
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, size_t size) {
   FuzzedStream stream{data, size};
   g_server.ProcessFuzzedRequest(stream);
   return 0;

--- a/test/fuzzing/standalone_fuzz_target_runner.cpp
+++ b/test/fuzzing/standalone_fuzz_target_runner.cpp
@@ -5,14 +5,14 @@
 // on the test corpus or on a single file,
 // e.g. the one that comes from a bug report.
 
-#include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <vector>
 
 // Forward declare the "fuzz target" interface.
 // We deliberately keep this interface simple and header-free.
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, size_t size);
 
 // It reads all files passed as parameters and feeds their contents
 // one by one into the fuzz target (LLVMFuzzerTestOneInput).
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
     // Allocate exactly length bytes so that we reliably catch buffer overflows.
     std::vector<char> bytes(length);
     in.read(bytes.data(), static_cast<std::streamsize>(bytes.size()));
-    LLVMFuzzerTestOneInput(reinterpret_cast<const uint8_t *>(bytes.data()),
+    LLVMFuzzerTestOneInput(reinterpret_cast<const std::uint8_t *>(bytes.data()),
                            bytes.size());
     std::cout << "Execution successful" << std::endl;
   }

--- a/test/fuzzing/standalone_fuzz_target_runner.cpp
+++ b/test/fuzzing/standalone_fuzz_target_runner.cpp
@@ -6,13 +6,13 @@
 // e.g. the one that comes from a bug report.
 
 #include <cstdint>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <vector>
 
 // Forward declare the "fuzz target" interface.
 // We deliberately keep this interface simple and header-free.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data, size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
 // It reads all files passed as parameters and feeds their contents
 // one by one into the fuzz target (LLVMFuzzerTestOneInput).
@@ -21,12 +21,12 @@ int main(int argc, char **argv) {
     std::ifstream in(argv[i]);
     in.seekg(0, in.end);
     size_t length = static_cast<size_t>(in.tellg());
-    in.seekg (0, in.beg);
+    in.seekg(0, in.beg);
     std::cout << "Reading " << length << " bytes from " << argv[i] << std::endl;
     // Allocate exactly length bytes so that we reliably catch buffer overflows.
     std::vector<char> bytes(length);
     in.read(bytes.data(), static_cast<std::streamsize>(bytes.size()));
-    LLVMFuzzerTestOneInput(reinterpret_cast<const std::uint8_t *>(bytes.data()),
+    LLVMFuzzerTestOneInput(reinterpret_cast<const uint8_t *>(bytes.data()),
                            bytes.size());
     std::cout << "Execution successful" << std::endl;
   }


### PR DESCRIPTION
Building fuzz test fails on Ubuntu workflow due to missing `stdint.h` and `std::`.

![fuzz](https://github.com/yhirose/cpp-httplib/assets/30493199/496ba596-b1d3-4e1f-b447-9cce764eb372)
