### PR TITLE
Fix warnings from MSVC code analysis

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8659,8 +8659,8 @@ SSLClient::verify_host_with_subject_alt_name(X509 *server_cert) const {
 
   auto type = GEN_DNS;
 
-  struct in6_addr addr6;
-  struct in_addr addr;
+  struct in6_addr addr6 {};
+  struct in_addr addr {};
   size_t addr_len = 0;
 
 #ifndef __MINGW32__


### PR DESCRIPTION
[Warning C6001](https://learn.microsoft.com/en-us/cpp/code-quality/c6001) : Using uninitialized memory
[Warning C26444](https://learn.microsoft.com/en-us/cpp/code-quality/c26444) : Don't try to declare a local variable with no name