### PR TITLE
Run fuzz test in CTest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,3 +102,5 @@ if(HTTPLIB_IS_USING_OPENSSL)
         COMMAND_ERROR_IS_FATAL ANY
     )
 endif()
+
+add_subdirectory(fuzzing)

--- a/test/fuzzing/CMakeLists.txt
+++ b/test/fuzzing/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB HTTPLIB_CORPUS corpus/*)
+add_executable(httplib-test-fuzz
+    server_fuzzer.cc
+    standalone_fuzz_target_runner.cpp
+)
+target_link_libraries(httplib-test-fuzz PRIVATE httplib)
+add_test(
+    NAME httplib-test-fuzz
+    COMMAND httplib-test-fuzz ${HTTPLIB_CORPUS}
+)


### PR DESCRIPTION
Add missing fuzz tests when building with CMake.