### PR TITLE
Remove `cryptui` on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,6 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
 		# Needed for Windows libs on Mingw, as the pragma comment(lib, "xyz") aren't triggered.
 		$<$<PLATFORM_ID:Windows>:ws2_32>
 		$<$<PLATFORM_ID:Windows>:crypt32>
-		$<$<PLATFORM_ID:Windows>:cryptui>
 		# Needed for API from MacOS Security framework
 		"$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>,$<BOOL:${HTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN}>>:-framework CoreFoundation -framework Security>"
 		# Can't put multiple targets in a single generator expression or it bugs out.

--- a/httplib.h
+++ b/httplib.h
@@ -247,7 +247,6 @@ using socket_t = int;
 
 #ifdef _MSC_VER
 #pragma comment(lib, "crypt32.lib")
-#pragma comment(lib, "cryptui.lib")
 #endif
 #elif defined(CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN) && defined(__APPLE__)
 #include <TargetConditionals.h>


### PR DESCRIPTION
`cryptui` library is linked when building on Windows, but isn't actually used. If `cryptui.lib` doesn't exist on some Windows platforms (especially MinGW32), building with `httplib.h` will fail.
I have tested without linking `cryptui` on the various Windows environments (MSVC, MinGW, Cygwin), and it works fine.

Related to #1703.