### PR TITLE
Fix: Query parameter including query delimiter ('?') not being parsed properly

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1988,7 +1988,8 @@ void read_file(const std::string &path, std::string &out);
 
 std::string trim_copy(const std::string &s);
 
-void split(const char *b, const char *e, char d, std::function<void(const char *, const char *)> fn);
+void split(const char *b, const char *e, char d,
+  std::function<void(const char *, const char *)> fn);
 
 void split(const char *b, const char *e, char d, size_t m,
            std::function<void(const char *, const char *)> fn);

--- a/test/test.cc
+++ b/test/test.cc
@@ -108,10 +108,10 @@ TEST(SplitTest, ParseQueryString) {
   string s = "key1=val1&key2=val2&key3=val3";
   Params dic;
 
-  detail::split(s.c_str(), s.c_str() + s.size(), '&', -1,
+  detail::split(s.c_str(), s.c_str() + s.size(), '&',
                 [&](const char *b, const char *e) {
                   string key, val;
-                  detail::split(b, e, '=', -1, [&](const char *b2, const char *e2) {
+                  detail::split(b, e, '=', [&](const char *b2, const char *e2) {
                     if (key.empty()) {
                       key.assign(b2, e2);
                     } else {


### PR DESCRIPTION
When query delimiter `?` is contained inside the query parameters, split function is cutting it and query parameters and not being parsed properly.

As an example:

```
/regex-with-delimiter?key=^(?.*(value))
```

This PR fixes it by adding `m` (maximum) parameter to `details::split`. This parameter indicates the maximum number of parts which will be got when splitting: `-1` (infinite, no max), >= 0.

In `Server::parse_request_line` we use it as m=2 so we only get two parts: url and query parameters. By this way, we avoid splitting query parameters if they contain `?`.