### PR TITLE
Add StatusCode enum

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1791,6 +1791,81 @@ inline void default_socket_options(socket_t sock) {
 #endif
 }
 
+enum StatusCode {
+  // Information responses
+  Continue = 100,                      ///< 100 Continue
+  SwitchingProtocol = 101,             ///< 101 Switching Protocols
+  Processing = 102,                    ///< 102 Processing
+  EarlyHints = 103,                    ///< 103 Early Hints
+
+  // Successful responses
+  OK = 200,                            ///< 200 OK
+  Created = 201,                       ///< 201 Created
+  Accepted = 202,                      ///< 202 Accepted
+  NonAuthoritativeInformation = 203,   ///< 203 Non-Authoritative Information
+  NoContent = 204,                     ///< 204 No Content
+  ResetContent = 205,                  ///< 205 Reset Content
+  PartialContent = 206,                ///< 206 Partial Content
+  MultiStatus = 207,                   ///< 207 Multi-Status
+  AlreadyReported = 208,               ///< 208 Already Reported
+  IMUsed = 226,                        ///< 226 IM Used
+
+  // Redirection messages
+  MultipleChoices = 300,               ///< 300 Multiple Choices
+  MovedPermanently = 301,              ///< 301 Moved Permanently
+  Found = 302,                         ///< 302 Found
+  SeeOther = 303,                      ///< 303 See Other
+  NotModified = 304,                   ///< 304 Not Modified
+  UseProxy = 305,                      ///< 305 Use Proxy
+  unused = 306,                        ///< 306 unused
+  TemporaryRedirect = 307,             ///< 307 Temporary Redirect
+  PermanentRedirect = 308,             ///< 308 Permanent Redirect
+
+  // Client error responses
+  BadRequest = 400,                    ///< 400 Bad Request
+  Unauthorized = 401,                  ///< 401 Unauthorized
+  PaymentRequired = 402,               ///< 402 Payment Required
+  Forbidden = 403,                     ///< 403 Forbidden
+  NotFound = 404,                      ///< 404 Not Found
+  MethodNotAllowed = 405,              ///< 405 Method Not Allowed
+  NotAcceptable = 406,                 ///< 406 Not Acceptable
+  ProxyAuthenticationRequired = 407,   ///< 407 Proxy Authentication Required
+  RequestTimeout = 408,                ///< 408 Request Timeout
+  Conflict = 409,                      ///< 409 Conflict
+  Gone = 410,                          ///< 410 Gone
+  LengthRequired = 411,                ///< 411 Length Required
+  PreconditionFailed = 412,            ///< 412 Precondition Failed
+  PayloadTooLarge = 413,               ///< 413 Payload Too Large
+  UriTooLong = 414,                    ///< 414 URI Too Long
+  UnsupportedMediaType = 415,          ///< 415 Unsupported Media Type
+  RangeNotSatisfiable = 416,           ///< 416 Range Not Satisfiable
+  ExpectationFailed = 417,             ///< 417 Expectation Failed
+  ImATeapot = 418,                     ///< 418 I'm a teapot
+  MisdirectedRequest = 421,            ///< 421 Misdirected Request
+  UnprocessableContent = 422,          ///< 422 Unprocessable Content
+  Locked = 423,                        ///< 423 Locked
+  FailedDependency = 424,              ///< 424 Failed Dependency
+  TooEarly = 425,                      ///< 425 Too Early
+  UpgradeRequired = 426,               ///< 426 Upgrade Required
+  PreconditionRequired = 428,          ///< 428 Precondition Required
+  TooManyRequests = 429,               ///< 429 Too Many Requests
+  RequestHeaderFieldsTooLarge = 431,   ///< 431 Request Header Fields Too Large
+  UnavailableForLegalReasons = 451,    ///< 451 Unavailable For Legal Reasons
+
+  // Server error responses
+  InternalServerError = 500,           ///< 500 Internal Server Error
+  NotImplemented = 501,                ///< 501 Not Implemented
+  BadGateway = 502,                    ///< 502 Bad Gateway
+  ServiceUnavailable = 503,            ///< 503 Service Unavailable
+  GatewayTimeout = 504,                ///< 504 Gateway Timeout
+  HttpVersionNotSupported = 505,       ///< 505 HTTP Version Not Supported
+  VariantAlsoNegotiates = 506,         ///< 506 Variant Also Negotiates
+  InsufficientStorage = 507,           ///< 507 Insufficient Storage
+  LoopDetected = 508,                  ///< 508 Loop Detected
+  NotExtended = 510,                   ///< 510 Not Extended
+  NetworkAuthenticationRequired = 511, ///< 511 Network Authentication Required
+};
+
 inline const char *status_message(int status) {
   switch (status) {
   case 100: return "Continue";
@@ -1807,7 +1882,7 @@ inline const char *status_message(int status) {
   case 207: return "Multi-Status";
   case 208: return "Already Reported";
   case 226: return "IM Used";
-  case 300: return "Multiple Choice";
+  case 300: return "Multiple Choices";
   case 301: return "Moved Permanently";
   case 302: return "Found";
   case 303: return "See Other";
@@ -1836,7 +1911,7 @@ inline const char *status_message(int status) {
   case 417: return "Expectation Failed";
   case 418: return "I'm a teapot";
   case 421: return "Misdirected Request";
-  case 422: return "Unprocessable Entity";
+  case 422: return "Unprocessable Content";
   case 423: return "Locked";
   case 424: return "Failed Dependency";
   case 425: return "Too Early";

--- a/httplib.h
+++ b/httplib.h
@@ -1793,77 +1793,77 @@ inline void default_socket_options(socket_t sock) {
 
 enum StatusCode {
   // Information responses
-  Continue_100 = 100,                      ///< 100 Continue
-  SwitchingProtocol_101 = 101,             ///< 101 Switching Protocols
-  Processing_102 = 102,                    ///< 102 Processing
-  EarlyHints_103 = 103,                    ///< 103 Early Hints
+  Continue_100 = 100,
+  SwitchingProtocol_101 = 101,
+  Processing_102 = 102,
+  EarlyHints_103 = 103,
 
   // Successful responses
-  OK_200 = 200,                            ///< 200 OK
-  Created_201 = 201,                       ///< 201 Created
-  Accepted_202 = 202,                      ///< 202 Accepted
-  NonAuthoritativeInformation_203 = 203,   ///< 203 Non-Authoritative Information
-  NoContent_204 = 204,                     ///< 204 No Content
-  ResetContent_205 = 205,                  ///< 205 Reset Content
-  PartialContent_206 = 206,                ///< 206 Partial Content
-  MultiStatus_207 = 207,                   ///< 207 Multi-Status
-  AlreadyReported_208 = 208,               ///< 208 Already Reported
-  IMUsed_226 = 226,                        ///< 226 IM Used
+  OK_200 = 200,
+  Created_201 = 201,
+  Accepted_202 = 202,
+  NonAuthoritativeInformation_203 = 203,
+  NoContent_204 = 204,
+  ResetContent_205 = 205,
+  PartialContent_206 = 206,
+  MultiStatus_207 = 207,
+  AlreadyReported_208 = 208,
+  IMUsed_226 = 226,
 
   // Redirection messages
-  MultipleChoices_300 = 300,               ///< 300 Multiple Choices
-  MovedPermanently_301 = 301,              ///< 301 Moved Permanently
-  Found_302 = 302,                         ///< 302 Found
-  SeeOther_303 = 303,                      ///< 303 See Other
-  NotModified_304 = 304,                   ///< 304 Not Modified
-  UseProxy_305 = 305,                      ///< 305 Use Proxy
-  unused_306 = 306,                        ///< 306 unused
-  TemporaryRedirect_307 = 307,             ///< 307 Temporary Redirect
-  PermanentRedirect_308 = 308,             ///< 308 Permanent Redirect
+  MultipleChoices_300 = 300,
+  MovedPermanently_301 = 301,
+  Found_302 = 302,
+  SeeOther_303 = 303,
+  NotModified_304 = 304,
+  UseProxy_305 = 305,
+  unused_306 = 306,
+  TemporaryRedirect_307 = 307,
+  PermanentRedirect_308 = 308,
 
   // Client error responses
-  BadRequest_400 = 400,                    ///< 400 Bad Request
-  Unauthorized_401 = 401,                  ///< 401 Unauthorized
-  PaymentRequired_402 = 402,               ///< 402 Payment Required
-  Forbidden_403 = 403,                     ///< 403 Forbidden
-  NotFound_404 = 404,                      ///< 404 Not Found
-  MethodNotAllowed_405 = 405,              ///< 405 Method Not Allowed
-  NotAcceptable_406 = 406,                 ///< 406 Not Acceptable
-  ProxyAuthenticationRequired_407 = 407,   ///< 407 Proxy Authentication Required
-  RequestTimeout_408 = 408,                ///< 408 Request Timeout
-  Conflict_409 = 409,                      ///< 409 Conflict
-  Gone_410 = 410,                          ///< 410 Gone
-  LengthRequired_411 = 411,                ///< 411 Length Required
-  PreconditionFailed_412 = 412,            ///< 412 Precondition Failed
-  PayloadTooLarge_413 = 413,               ///< 413 Payload Too Large
-  UriTooLong_414 = 414,                    ///< 414 URI Too Long
-  UnsupportedMediaType_415 = 415,          ///< 415 Unsupported Media Type
-  RangeNotSatisfiable_416 = 416,           ///< 416 Range Not Satisfiable
-  ExpectationFailed_417 = 417,             ///< 417 Expectation Failed
-  ImATeapot_418 = 418,                     ///< 418 I'm a teapot
-  MisdirectedRequest_421 = 421,            ///< 421 Misdirected Request
-  UnprocessableContent_422 = 422,          ///< 422 Unprocessable Content
-  Locked_423 = 423,                        ///< 423 Locked
-  FailedDependency_424 = 424,              ///< 424 Failed Dependency
-  TooEarly_425 = 425,                      ///< 425 Too Early
-  UpgradeRequired_426 = 426,               ///< 426 Upgrade Required
-  PreconditionRequired_428 = 428,          ///< 428 Precondition Required
-  TooManyRequests_429 = 429,               ///< 429 Too Many Requests
-  RequestHeaderFieldsTooLarge_431 = 431,   ///< 431 Request Header Fields Too Large
-  UnavailableForLegalReasons_451 = 451,    ///< 451 Unavailable For Legal Reasons
+  BadRequest_400 = 400,
+  Unauthorized_401 = 401,
+  PaymentRequired_402 = 402,
+  Forbidden_403 = 403,
+  NotFound_404 = 404,
+  MethodNotAllowed_405 = 405,
+  NotAcceptable_406 = 406,
+  ProxyAuthenticationRequired_407 = 407,
+  RequestTimeout_408 = 408,
+  Conflict_409 = 409,
+  Gone_410 = 410,
+  LengthRequired_411 = 411,
+  PreconditionFailed_412 = 412,
+  PayloadTooLarge_413 = 413,
+  UriTooLong_414 = 414,
+  UnsupportedMediaType_415 = 415,
+  RangeNotSatisfiable_416 = 416,
+  ExpectationFailed_417 = 417,
+  ImATeapot_418 = 418,
+  MisdirectedRequest_421 = 421,
+  UnprocessableContent_422 = 422,
+  Locked_423 = 423,
+  FailedDependency_424 = 424,
+  TooEarly_425 = 425,
+  UpgradeRequired_426 = 426,
+  PreconditionRequired_428 = 428,
+  TooManyRequests_429 = 429,
+  RequestHeaderFieldsTooLarge_431 = 431,
+  UnavailableForLegalReasons_451 = 451,
 
   // Server error responses
-  InternalServerError_500 = 500,           ///< 500 Internal Server Error
-  NotImplemented_501 = 501,                ///< 501 Not Implemented
-  BadGateway_502 = 502,                    ///< 502 Bad Gateway
-  ServiceUnavailable_503 = 503,            ///< 503 Service Unavailable
-  GatewayTimeout_504 = 504,                ///< 504 Gateway Timeout
-  HttpVersionNotSupported_505 = 505,       ///< 505 HTTP Version Not Supported
-  VariantAlsoNegotiates_506 = 506,         ///< 506 Variant Also Negotiates
-  InsufficientStorage_507 = 507,           ///< 507 Insufficient Storage
-  LoopDetected_508 = 508,                  ///< 508 Loop Detected
-  NotExtended_510 = 510,                   ///< 510 Not Extended
-  NetworkAuthenticationRequired_511 = 511, ///< 511 Network Authentication Required
+  InternalServerError_500 = 500,
+  NotImplemented_501 = 501,
+  BadGateway_502 = 502,
+  ServiceUnavailable_503 = 503,
+  GatewayTimeout_504 = 504,
+  HttpVersionNotSupported_505 = 505,
+  VariantAlsoNegotiates_506 = 506,
+  InsufficientStorage_507 = 507,
+  LoopDetected_508 = 508,
+  NotExtended_510 = 510,
+  NetworkAuthenticationRequired_511 = 511,
 };
 
 inline const char *status_message(int status) {

--- a/httplib.h
+++ b/httplib.h
@@ -1882,7 +1882,7 @@ inline const char *status_message(int status) {
   case 207: return "Multi-Status";
   case 208: return "Already Reported";
   case 226: return "IM Used";
-  case 300: return "Multiple Choices";
+  case 300: return "Multiple Choice";
   case 301: return "Moved Permanently";
   case 302: return "Found";
   case 303: return "See Other";
@@ -1911,7 +1911,7 @@ inline const char *status_message(int status) {
   case 417: return "Expectation Failed";
   case 418: return "I'm a teapot";
   case 421: return "Misdirected Request";
-  case 422: return "Unprocessable Content";
+  case 422: return "Unprocessable Entity";
   case 423: return "Locked";
   case 424: return "Failed Dependency";
   case 425: return "Too Early";

--- a/httplib.h
+++ b/httplib.h
@@ -1793,77 +1793,77 @@ inline void default_socket_options(socket_t sock) {
 
 enum StatusCode {
   // Information responses
-  Continue = 100,                      ///< 100 Continue
-  SwitchingProtocol = 101,             ///< 101 Switching Protocols
-  Processing = 102,                    ///< 102 Processing
-  EarlyHints = 103,                    ///< 103 Early Hints
+  Continue_100 = 100,                      ///< 100 Continue
+  SwitchingProtocol_101 = 101,             ///< 101 Switching Protocols
+  Processing_102 = 102,                    ///< 102 Processing
+  EarlyHints_103 = 103,                    ///< 103 Early Hints
 
   // Successful responses
-  OK = 200,                            ///< 200 OK
-  Created = 201,                       ///< 201 Created
-  Accepted = 202,                      ///< 202 Accepted
-  NonAuthoritativeInformation = 203,   ///< 203 Non-Authoritative Information
-  NoContent = 204,                     ///< 204 No Content
-  ResetContent = 205,                  ///< 205 Reset Content
-  PartialContent = 206,                ///< 206 Partial Content
-  MultiStatus = 207,                   ///< 207 Multi-Status
-  AlreadyReported = 208,               ///< 208 Already Reported
-  IMUsed = 226,                        ///< 226 IM Used
+  OK_200 = 200,                            ///< 200 OK
+  Created_201 = 201,                       ///< 201 Created
+  Accepted_202 = 202,                      ///< 202 Accepted
+  NonAuthoritativeInformation_203 = 203,   ///< 203 Non-Authoritative Information
+  NoContent_204 = 204,                     ///< 204 No Content
+  ResetContent_205 = 205,                  ///< 205 Reset Content
+  PartialContent_206 = 206,                ///< 206 Partial Content
+  MultiStatus_207 = 207,                   ///< 207 Multi-Status
+  AlreadyReported_208 = 208,               ///< 208 Already Reported
+  IMUsed_226 = 226,                        ///< 226 IM Used
 
   // Redirection messages
-  MultipleChoices = 300,               ///< 300 Multiple Choices
-  MovedPermanently = 301,              ///< 301 Moved Permanently
-  Found = 302,                         ///< 302 Found
-  SeeOther = 303,                      ///< 303 See Other
-  NotModified = 304,                   ///< 304 Not Modified
-  UseProxy = 305,                      ///< 305 Use Proxy
-  unused = 306,                        ///< 306 unused
-  TemporaryRedirect = 307,             ///< 307 Temporary Redirect
-  PermanentRedirect = 308,             ///< 308 Permanent Redirect
+  MultipleChoices_300 = 300,               ///< 300 Multiple Choices
+  MovedPermanently_301 = 301,              ///< 301 Moved Permanently
+  Found_302 = 302,                         ///< 302 Found
+  SeeOther_303 = 303,                      ///< 303 See Other
+  NotModified_304 = 304,                   ///< 304 Not Modified
+  UseProxy_305 = 305,                      ///< 305 Use Proxy
+  unused_306 = 306,                        ///< 306 unused
+  TemporaryRedirect_307 = 307,             ///< 307 Temporary Redirect
+  PermanentRedirect_308 = 308,             ///< 308 Permanent Redirect
 
   // Client error responses
-  BadRequest = 400,                    ///< 400 Bad Request
-  Unauthorized = 401,                  ///< 401 Unauthorized
-  PaymentRequired = 402,               ///< 402 Payment Required
-  Forbidden = 403,                     ///< 403 Forbidden
-  NotFound = 404,                      ///< 404 Not Found
-  MethodNotAllowed = 405,              ///< 405 Method Not Allowed
-  NotAcceptable = 406,                 ///< 406 Not Acceptable
-  ProxyAuthenticationRequired = 407,   ///< 407 Proxy Authentication Required
-  RequestTimeout = 408,                ///< 408 Request Timeout
-  Conflict = 409,                      ///< 409 Conflict
-  Gone = 410,                          ///< 410 Gone
-  LengthRequired = 411,                ///< 411 Length Required
-  PreconditionFailed = 412,            ///< 412 Precondition Failed
-  PayloadTooLarge = 413,               ///< 413 Payload Too Large
-  UriTooLong = 414,                    ///< 414 URI Too Long
-  UnsupportedMediaType = 415,          ///< 415 Unsupported Media Type
-  RangeNotSatisfiable = 416,           ///< 416 Range Not Satisfiable
-  ExpectationFailed = 417,             ///< 417 Expectation Failed
-  ImATeapot = 418,                     ///< 418 I'm a teapot
-  MisdirectedRequest = 421,            ///< 421 Misdirected Request
-  UnprocessableContent = 422,          ///< 422 Unprocessable Content
-  Locked = 423,                        ///< 423 Locked
-  FailedDependency = 424,              ///< 424 Failed Dependency
-  TooEarly = 425,                      ///< 425 Too Early
-  UpgradeRequired = 426,               ///< 426 Upgrade Required
-  PreconditionRequired = 428,          ///< 428 Precondition Required
-  TooManyRequests = 429,               ///< 429 Too Many Requests
-  RequestHeaderFieldsTooLarge = 431,   ///< 431 Request Header Fields Too Large
-  UnavailableForLegalReasons = 451,    ///< 451 Unavailable For Legal Reasons
+  BadRequest_400 = 400,                    ///< 400 Bad Request
+  Unauthorized_401 = 401,                  ///< 401 Unauthorized
+  PaymentRequired_402 = 402,               ///< 402 Payment Required
+  Forbidden_403 = 403,                     ///< 403 Forbidden
+  NotFound_404 = 404,                      ///< 404 Not Found
+  MethodNotAllowed_405 = 405,              ///< 405 Method Not Allowed
+  NotAcceptable_406 = 406,                 ///< 406 Not Acceptable
+  ProxyAuthenticationRequired_407 = 407,   ///< 407 Proxy Authentication Required
+  RequestTimeout_408 = 408,                ///< 408 Request Timeout
+  Conflict_409 = 409,                      ///< 409 Conflict
+  Gone_410 = 410,                          ///< 410 Gone
+  LengthRequired_411 = 411,                ///< 411 Length Required
+  PreconditionFailed_412 = 412,            ///< 412 Precondition Failed
+  PayloadTooLarge_413 = 413,               ///< 413 Payload Too Large
+  UriTooLong_414 = 414,                    ///< 414 URI Too Long
+  UnsupportedMediaType_415 = 415,          ///< 415 Unsupported Media Type
+  RangeNotSatisfiable_416 = 416,           ///< 416 Range Not Satisfiable
+  ExpectationFailed_417 = 417,             ///< 417 Expectation Failed
+  ImATeapot_418 = 418,                     ///< 418 I'm a teapot
+  MisdirectedRequest_421 = 421,            ///< 421 Misdirected Request
+  UnprocessableContent_422 = 422,          ///< 422 Unprocessable Content
+  Locked_423 = 423,                        ///< 423 Locked
+  FailedDependency_424 = 424,              ///< 424 Failed Dependency
+  TooEarly_425 = 425,                      ///< 425 Too Early
+  UpgradeRequired_426 = 426,               ///< 426 Upgrade Required
+  PreconditionRequired_428 = 428,          ///< 428 Precondition Required
+  TooManyRequests_429 = 429,               ///< 429 Too Many Requests
+  RequestHeaderFieldsTooLarge_431 = 431,   ///< 431 Request Header Fields Too Large
+  UnavailableForLegalReasons_451 = 451,    ///< 451 Unavailable For Legal Reasons
 
   // Server error responses
-  InternalServerError = 500,           ///< 500 Internal Server Error
-  NotImplemented = 501,                ///< 501 Not Implemented
-  BadGateway = 502,                    ///< 502 Bad Gateway
-  ServiceUnavailable = 503,            ///< 503 Service Unavailable
-  GatewayTimeout = 504,                ///< 504 Gateway Timeout
-  HttpVersionNotSupported = 505,       ///< 505 HTTP Version Not Supported
-  VariantAlsoNegotiates = 506,         ///< 506 Variant Also Negotiates
-  InsufficientStorage = 507,           ///< 507 Insufficient Storage
-  LoopDetected = 508,                  ///< 508 Loop Detected
-  NotExtended = 510,                   ///< 510 Not Extended
-  NetworkAuthenticationRequired = 511, ///< 511 Network Authentication Required
+  InternalServerError_500 = 500,           ///< 500 Internal Server Error
+  NotImplemented_501 = 501,                ///< 501 Not Implemented
+  BadGateway_502 = 502,                    ///< 502 Bad Gateway
+  ServiceUnavailable_503 = 503,            ///< 503 Service Unavailable
+  GatewayTimeout_504 = 504,                ///< 504 Gateway Timeout
+  HttpVersionNotSupported_505 = 505,       ///< 505 HTTP Version Not Supported
+  VariantAlsoNegotiates_506 = 506,         ///< 506 Variant Also Negotiates
+  InsufficientStorage_507 = 507,           ///< 507 Insufficient Storage
+  LoopDetected_508 = 508,                  ///< 508 Loop Detected
+  NotExtended_510 = 510,                   ///< 510 Not Extended
+  NetworkAuthenticationRequired_511 = 511, ///< 511 Network Authentication Required
 };
 
 inline const char *status_message(int status) {


### PR DESCRIPTION
Hi there!

C++ Core Guidelines recommend avoiding "magic constants" ([link](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es45-avoid-magic-constants-use-symbolic-constants)) and clang-tidy enforces this. I added a enum with Response Status Codes to use them instead of plain numbers in dependent code, please let me know if you would like to use them in httplib too.

~~Also I changed some of status messages based on [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes)~~ 
Moved RFC 9110 changes to a separate pr https://github.com/yhirose/cpp-httplib/pull/1740