### PR TITLE
add missing #include for strcasecmp

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -198,6 +198,9 @@ using socket_t = SOCKET;
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+#if defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L
+#include <strings.h>
+#endif
 
 using socket_t = int;
 #ifndef INVALID_SOCKET


### PR DESCRIPTION
Posix specifications say you need strings.h to use strcasecmp

- it happens to work on most Linux systems without it, but that's basically just a compiler include bug (i think?)
- Cygwin gcc actually requires strings.h, compiling on Cygwin is how I noticed strings.h was missing