### PR TITLE
Fix #1628 (OpenSSL 1.1.1 End of Life on September 11, 2023)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ option(HTTPLIB_NO_EXCEPTIONS "Disable the use of C++ exceptions" OFF)
 
 # Change as needed to set an OpenSSL minimum version.
 # This is used in the installed Cmake config file.
-set(_HTTPLIB_OPENSSL_MIN_VER "1.1.1")
+set(_HTTPLIB_OPENSSL_MIN_VER "3.0.0")
 
 # Allow for a build to require OpenSSL to pass, instead of just being optional
 option(HTTPLIB_REQUIRE_OPENSSL "Requires OpenSSL to be found & linked, or fails build." OFF)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ SSL Support
 
 SSL support is available with `CPPHTTPLIB_OPENSSL_SUPPORT`. `libssl` and `libcrypto` should be linked.
 
-NOTE: cpp-httplib currently supports only version 1.1.1 and 3.0.
+NOTE: cpp-httplib currently supports only version 3.0 or later. Please see [this page](https://www.openssl.org/policies/releasestrat.html) to get more information.
 
 NOTE for macOS: cpp-httplib now can use system certs with `CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN`. `CoreFoundation` and `Security` should be linked with `-framework`.
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -4,8 +4,7 @@ CXXFLAGS = -O2 -std=c++11 -I.. -Wall -Wextra -pthread
 PREFIX = /usr/local
 #PREFIX = $(shell brew --prefix)
 
-OPENSSL_DIR = $(PREFIX)/opt/openssl@1.1
-#OPENSSL_DIR = $(PREFIX)/opt/openssl@3
+OPENSSL_DIR = $(PREFIX)/opt/openssl@3
 OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I$(OPENSSL_DIR)/include -L$(OPENSSL_DIR)/lib -lssl -lcrypto
 
 ifneq ($(OS), Windows_NT)

--- a/httplib.h
+++ b/httplib.h
@@ -264,10 +264,8 @@ using socket_t = int;
 #include <iostream>
 #include <sstream>
 
-#if OPENSSL_VERSION_NUMBER < 0x1010100fL
-#error Sorry, OpenSSL versions prior to 1.1.1 are not supported
-#elif OPENSSL_VERSION_NUMBER < 0x30000000L
-#define SSL_get1_peer_certificate SSL_get_peer_certificate
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#error Sorry, OpenSSL versions prior to 3.0.0 are not supported
 #endif
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ endif
 deps = [dependency('threads')]
 args = []
 
-openssl_dep = dependency('openssl', version: '>=1.1.1', required: get_option('cpp-httplib_openssl'))
+openssl_dep = dependency('openssl', version: '>=3.0.0', required: get_option('cpp-httplib_openssl'))
 if openssl_dep.found()
   deps += openssl_dep
   args += '-DCPPHTTPLIB_OPENSSL_SUPPORT'

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,8 +4,7 @@ CXXFLAGS = -g -std=c++11 -I. -Wall -Wextra -Wtype-limits -Wconversion -Wshadow #
 PREFIX = /usr/local
 #PREFIX = $(shell brew --prefix)
 
-OPENSSL_DIR = $(PREFIX)/opt/openssl@1.1
-#OPENSSL_DIR = $(PREFIX)/opt/openssl@3
+OPENSSL_DIR = $(PREFIX)/opt/openssl@3
 OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -I$(OPENSSL_DIR)/include -L$(OPENSSL_DIR)/lib -lssl -lcrypto
 
 ifneq ($(OS), Windows_NT)


### PR DESCRIPTION
This minimum version is now 3.0.0.