### PR TITLE
Fixes Windows std::max macro problem

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2557,7 +2557,7 @@ inline std::string trim_double_quotes_copy(const std::string &s) {
 
 inline void split(const char *b, const char *e, char d,
                   std::function<void(const char *, const char *)> fn) {
-  return split(b, e, d, std::numeric_limits<size_t>::max(), fn);
+  return split(b, e, d, (std::numeric_limits<size_t>::max)(), fn);
 }
 
 inline void split(const char *b, const char *e, char d, size_t m,


### PR DESCRIPTION
Prevents the need for NOMINMAX macro on Windows compilation.