### PR TITLE
Fix -Wold-style-cast warning

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -141,11 +141,11 @@ using ssize_t = long;
 #endif // _MSC_VER
 
 #ifndef S_ISREG
-#define S_ISREG(m) (((m) & S_IFREG) == S_IFREG)
+#define S_ISREG(m) (((m)&S_IFREG) == S_IFREG)
 #endif // S_ISREG
 
 #ifndef S_ISDIR
-#define S_ISDIR(m) (((m) & S_IFDIR) == S_IFDIR)
+#define S_ISDIR(m) (((m)&S_IFDIR) == S_IFDIR)
 #endif // S_ISDIR
 
 #ifndef NOMINMAX
@@ -2705,7 +2705,9 @@ inline bool mmap::is_open() const { return addr_ != nullptr; }
 
 inline size_t mmap::size() const { return size_; }
 
-inline const char *mmap::data() const { return (const char *)addr_; }
+inline const char *mmap::data() const {
+  return static_cast<const char *>(addr_);
+}
 
 inline void mmap::close() {
 #if defined(_WIN32)
@@ -8693,11 +8695,11 @@ inline bool SSLClient::initialize_ssl(Socket &socket, Error &error) {
         return true;
       },
       [&](SSL *ssl2) {
-        // NOTE: With -Wold-style-cast, this can produce a warning, since
-        //  SSL_set_tlsext_host_name is a macro (in OpenSSL), which contains
-        //  an old style cast. Short of doing compiler specific pragma's
-        //  here, we can't get rid of this warning. :'(
-        SSL_set_tlsext_host_name(ssl2, host_.c_str());
+        // NOTE: Direct call instead of using the OpenSSL macro to suppress
+        // -Wold-style-cast warning
+        // SSL_set_tlsext_host_name(ssl2, host_.c_str());
+        SSL_ctrl(ssl2, SSL_CTRL_SET_TLSEXT_HOSTNAME, TLSEXT_NAMETYPE_host_name,
+                 static_cast<void *>(const_cast<char *>(host_.c_str())));
         return true;
       });
 


### PR DESCRIPTION
Fix -Wold-style-cast warning.
SSL_set_tlsext_host_name macro calls SSL_ctrl under the hood.

There are some -Wuseless-cast warnings as well (the solution is a bit clumsy). Let me know if this type of pull request is welcome.