### PR TITLE
Treat paths with embedded NUL bytes as invalid in detail::is_valid_path

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2412,6 +2412,7 @@ inline bool is_valid_path(const std::string &path) {
     // Read component
     auto beg = i;
     while (i < path.size() && path[i] != '/') {
+      if (path[i] == '\0') { return false; }
       i++;
     }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -71,6 +71,15 @@ TEST(DecodeURLTest, PercentCharacter) {
       R"(descrip=Gastos áéíóúñÑ 6)");
 }
 
+TEST(DecodeURLTest, PercentCharacterNUL) {
+  string expected;
+  expected.push_back('x');
+  expected.push_back('\0');
+  expected.push_back('x');
+
+  EXPECT_EQ(detail::decode_url("x%00x", false), expected);
+}
+
 TEST(EncodeQueryParamTest, ParseUnescapedChararactersTest) {
   string unescapedCharacters = "-_.!~*'()";
 
@@ -2478,6 +2487,12 @@ TEST_F(ServerTest, GetMethodDirMountTestWithDoubleDots) {
 
 TEST_F(ServerTest, GetMethodInvalidMountPath) {
   auto res = cli_.Get("/mount/dir/../test.html");
+  ASSERT_TRUE(res);
+  EXPECT_EQ(StatusCode::NotFound_404, res->status);
+}
+
+TEST_F(ServerTest, GetMethodEmbeddedNUL) {
+  auto res = cli_.Get("/mount/dir/test.html%00.js");
   ASSERT_TRUE(res);
   EXPECT_EQ(StatusCode::NotFound_404, res->status);
 }


### PR DESCRIPTION
I've tested this on Linux, but from what I could find, NUL should also not appear in paths on other platforms.

Also adds a test that demonstrates `decode_url`'s behavior with %00.

Fixes #1763.