### PR TITLE
Performance: reserve body to avoid frequent reallocations and copies

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4030,6 +4030,7 @@ bool read_content(Stream &strm, T &x, size_t payload_max_length, int &status,
             skip_content_with_length(strm, len);
             ret = false;
           } else if (len > 0) {
+            x.body.reserve(len);
             ret = read_content_with_length(strm, len, std::move(progress), out);
           }
         }

--- a/httplib.h
+++ b/httplib.h
@@ -4030,7 +4030,9 @@ bool read_content(Stream &strm, T &x, size_t payload_max_length, int &status,
             skip_content_with_length(strm, len);
             ret = false;
           } else if (len > 0) {
-            x.body.reserve(len);
+            if (len > 0 && len < payload_max_length) {
+              x.body.reserve(len);
+            }
             ret = read_content_with_length(strm, len, std::move(progress), out);
           }
         }


### PR DESCRIPTION
This is an alternative approach to https://github.com/yhirose/cpp-httplib/pull/1781.

It is simpler: only one line, the checks on length have already been made.

But I wasn't sure if it was OK or not, since this implies `x` has a `body` member, so it makes this template function less generic, which might defeat the purpose of having a template here...