### PR TITLE
Applied clang-tidy suggestions and export of compile commands for linter support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ project(httplib
 	DESCRIPTION "A C++ header-only HTTP/HTTPS server and client library."
 	HOMEPAGE_URL "https://github.com/yhirose/cpp-httplib"
 )
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Change as needed to set an OpenSSL minimum version.
 # This is used in the installed Cmake config file.

--- a/httplib.h
+++ b/httplib.h
@@ -2961,7 +2961,7 @@ inline bool is_socket_alive(socket_t sock) {
     return false;
   }
   char buf[1];
-  return detail::read_socket(sock, buf.data(), sizeof(buf), MSG_PEEK) > 0;
+  return detail::read_socket(sock, &buf[0], sizeof(buf), MSG_PEEK) > 0;
 }
 
 class SocketStream final : public Stream {
@@ -8964,7 +8964,7 @@ inline bool SSLClient::check_host_name(const char *pattern,
   // Wildcard match
   // https://bugs.launchpad.net/ubuntu/+source/firefox-3.0/+bug/376484
   std::vector<std::string> pattern_components;
-  detail::split(pattern.data(), &pattern[pattern_len], '.',
+  detail::split(&pattern[0], &pattern[pattern_len], '.',
                 [&](const char *b, const char *e) {
                   pattern_components.emplace_back(b, e);
                 });

--- a/httplib.h
+++ b/httplib.h
@@ -274,7 +274,6 @@ using socket_t = int;
 #include <openssl/asn1.h>
 #include <openssl/bio.h>
 #include <openssl/crypto.h>
-#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/obj_mac.h>
 #include <openssl/opensslv.h>

--- a/httplib.h
+++ b/httplib.h
@@ -692,7 +692,7 @@ class ThreadPool final : public TaskQueue {
 public:
   explicit ThreadPool(size_t n, size_t mqr = 0)
       : shutdown_(false), max_queued_requests_(mqr) {
-    while (n > 0) {
+    while (n) {
       threads_.emplace_back(worker(*this));
       n--;
     }
@@ -3581,7 +3581,7 @@ inline EncodingType encoding_type(const Request &req, const Response &res) {
 
 inline bool nocompressor::compress(const char *data, size_t data_length,
                                    bool /*last*/, Callback callback) {
-  if (data_length == 0) { return true; }
+  if (!data_length) { return true; }
   return callback(data, data_length);
 }
 


### PR DESCRIPTION
The export of the compile commands in the `CMakeLists.txt`, I put them where I think it is fitting. Please adjust how you like if you want to keep.

The changes in the source code are minor. There are still suggestions by `clang-tidy` left but I programmed the minor ones. Please take especially a look at the headers I added or removed. I do not not whether the place I put them is correct since you support different environments.

The removed ones were not needed. The added ones are needed for the following data types in your source code.

```cpp
#include <asm-generic/socket.h> //provides SOL_SOCKET, SO_ERROR, SO_PEERCRED, SO_RCVTIMEO, SO_REUSEPORT and 1 more
#include <bits/signum-generic.h> //provides SIGPIPE
#include <cerrno> //provides EAGAIN, EBADF, EINPROGRESS, EINTR, EMFILE and 1 more; preferred in C++ instead of <errno.h>
#include <chrono> //provides duration, duration_cast, microseconds, milliseconds, seconds and 1 more
#include <cstddef> //provides NULL, nullptr_t, size_t
#include <cstdint> //provides int64_t, uint64_t, uint8_t
#include <cstdio> //provides BUFSIZ, snprintf
#include <cstdlib> //provides strtoul, strtoull
#include <ctime> //provides time_t
#include <iterator> //provides advance, distance
#include <limits> //provides numeric_limits
#include <stdexcept> //provides invalid_argument
#include <sys/types.h> //provides ssize_t
#include <vector> //provides vector
#include <bits/types/struct_timeval.h> //provides timeval
#include <type_traits> //provides enable_if, is_array, remove_extent, underlying_type
#include <zconf.h> //provides Bytef, uInt
#include <openssl/asn1.h> //provides ASN1_STRING_get0_data, ASN1_STRING_length
#include <openssl/bio.h> //provides BIO_NOCLOSE, BIO_free_all, BIO_new_mem_buf, BIO_new_socket, BIO_set_nbio
#include <openssl/crypto.h> //provides OPENSSL_INIT_LOAD_CRYPTO_STRINGS
#include <openssl/obj_mac.h> //provides NID_commonName, NID_subject_alt_name
#include <openssl/opensslv.h> //provides OPENSSL_VERSION_NUMBER
#include <openssl/pem.h> //provides PEM_X509_INFO_read_bio
#include <openssl/prov_ssl.h> //provides TLS1_1_VERSION
#include <openssl/safestack.h> //provides STACK_OF
#include <openssl/tls1.h> //provides TLSEXT_NAMETYPE_host_name
#include <openssl/x509.h> //provides X509_INFO_free, X509_NAME_get_text_by_NID, X509_free, X509_get_ext_d2i, X509_get_subject_name and 3 more
#include <openssl/x509_vfy.h> //provides X509_STORE_add_cert, X509_STORE_add_crl, X509_STORE_free, X509_STORE_new, X509_V_OK
```

The tests succeed like with commit 548dfff0aef25e36e971af96b49ce7fbb72d840e. There happend fails and a segmentation fault but like I said that already happened before so these commits probably did not cause them. I probably have not setup the tests correctly.