### PR TITLE
Apply range header base on response status code

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -1873,7 +1873,6 @@ protected:
              })
         .Get("/with-range-customized-response",
              [&](const Request & /*req*/, Response &res) {
-              res.ignore_range = true;
               res.status = StatusCode::BadRequest_400;
               res.set_content(JSON_DATA,  "application/json");
              })

--- a/test/test.cc
+++ b/test/test.cc
@@ -1871,6 +1871,12 @@ protected:
              [&](const Request & /*req*/, Response &res) {
                res.set_content("abcdefg", "text/plain");
              })
+        .Get("/with-range-customized-response",
+             [&](const Request & /*req*/, Response &res) {
+              res.ignore_range = true;
+              res.status = StatusCode::BadRequest_400;
+              res.set_content(JSON_DATA,  "application/json");
+             })
         .Post("/chunked",
               [&](const Request &req, Response & /*res*/) {
                 EXPECT_EQ(req.body, "dechunked post body");
@@ -3145,6 +3151,24 @@ TEST_F(ServerTest, GetWithRangeMultipartOffsetGreaterThanContent) {
       cli_.Get("/with-range", {{make_range_header({{-1, 2}, {10000, 30000}})}});
   ASSERT_TRUE(res);
   EXPECT_EQ(StatusCode::RangeNotSatisfiable_416, res->status);
+}
+
+TEST_F(ServerTest, GetWithRangeCustomizedResponse) {
+  auto res = cli_.Get("/with-range-customized-response", {{make_range_header({{1, 2}})}});
+  ASSERT_TRUE(res);
+  EXPECT_EQ(StatusCode::BadRequest_400, res->status);
+  EXPECT_EQ(true, res->has_header("Content-Length"));
+  EXPECT_EQ(false, res->has_header("Content-Range"));
+  EXPECT_EQ(JSON_DATA, res->body);
+}
+
+TEST_F(ServerTest, GetWithRangeMultipartCustomizedResponseMultipleRange) {
+  auto res = cli_.Get("/with-range-customized-response", {{make_range_header({{1, 2}, {4, 5}})}});
+  ASSERT_TRUE(res);
+  EXPECT_EQ(StatusCode::BadRequest_400, res->status);
+  EXPECT_EQ(true, res->has_header("Content-Length"));
+  EXPECT_EQ(false, res->has_header("Content-Range"));
+  EXPECT_EQ(JSON_DATA, res->body);
 }
 
 TEST_F(ServerTest, Issue1772) {


### PR DESCRIPTION
I've recently been using cpp-httplib to handle range requests for streaming video. 
However, when I try to use JSON as the response to provide additional error information,  response body get truncated and content-type might be override by 'multipart/byteranges' due to the range header of request. 
This PR employs a naive approach to address this issue. 
If there's a better implementation or other methods to achieve my goal, please let me know. 
Thank you.