### PR TITLE
Fix range parser when parsing too many ranges

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -352,6 +352,25 @@ TEST(ParseHeaderValueTest, Range) {
     EXPECT_EQ(300u, ranges[2].first);
     EXPECT_EQ(400u, ranges[2].second);
   }
+
+  {
+    Ranges ranges;
+
+    EXPECT_FALSE(detail::parse_range_header("bytes", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=0", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=-", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes= ", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=,", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=,,", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=,,,", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=a-b", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=1-0", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=0--1", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=0- 1", ranges));
+    EXPECT_FALSE(detail::parse_range_header("bytes=0 -1", ranges));
+    EXPECT_TRUE(ranges.empty());
+  }
 }
 
 TEST(ParseAcceptEncoding1, AcceptEncoding) {


### PR DESCRIPTION
Stack overflow is detected by AddressSanitizer on MSVC when parsing too many ranges using `std::regex`.
`ServerTest.GetStreamedWithTooManyRanges` has failed due to this reason.
I would like to suggest a range parser with plain string manipulations rather than relying on `std::regex`.
And some test cases are added for invalid ranges not covered by the current implementation.