### PR TITLE
Allow hex for ipv6 literal addr in redirect

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7275,7 +7275,7 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
   if (location.empty()) { return false; }
 
   const static std::regex re(
-      R"((?:(https?):)?(?://(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
+      R"((?:(https?):)?(?://(?:\[([a-fA-F\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
 
   std::smatch m;
   if (!std::regex_match(location, m, re)) { return false; }


### PR DESCRIPTION
Fix the support for ipv6 literal address in redirect.

<img width="1059" alt="image" src="https://github.com/yhirose/cpp-httplib/assets/7844628/0b8ef436-5379-404b-8aa8-2aeee8d1b004">
