### PR TITLE
Fix for autocrlf and failing tests issue on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/test/www*/dir/*.html text eol=lf
+/test/www*/dir/*.txt text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ Release
 ipch
 *.dSYM
 .*
+!/.gitattributes
 !/.travis.yml


### PR DESCRIPTION
Cloning repository on Windows with autocrlf git option enabled causes changes in line ending style for html ant txt files using in tests. That leads to failing of following tests (because files size gets bigger):

ServerTest.HeadMethod200Static
ServerTest.GetMethodDir
ServerTest.StaticFileRangeBigFile
ServerTest.StaticFileRangeBigFile2
ServerTest.StaticFileBigFile

Proposed solution introduces .gitattributes file to control line ending style for individual files.