### PR TITLE
Added move assignment operator to Client class.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1530,6 +1530,7 @@ public:
                   const std::string &client_key_path);
 
   Client(Client &&) = default;
+  Client &operator=(Client &&) = default;
 
   ~Client();
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -54,9 +54,15 @@ MultipartFormData &get_file_value(MultipartFormDataItems &files,
 #endif
 }
 
-TEST(ConstructorTest, MoveConstructible) {
+TEST(ClientTest, MoveConstructible) {
   EXPECT_FALSE(std::is_copy_constructible<Client>::value);
   EXPECT_TRUE(std::is_nothrow_move_constructible<Client>::value);
+}
+
+TEST(ClientTest, MoveAssignable)
+{
+    EXPECT_FALSE(std::is_copy_assignable<Client>::value);
+    EXPECT_TRUE(std::is_nothrow_move_assignable<Client>::value);
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
Fixes issue similar to #1050, solution is based on #1051 approach. After brief inspection i haven't found any drawbacks of making Client class move assignable in addition to move construction.