### PR TITLE
Fix call to CreateFileMappingW.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2859,8 +2859,7 @@ inline bool mmap::open(const char *path) {
   hMapping_ =
       ::CreateFileMappingFromApp(hFile_, NULL, PAGE_READONLY, size_, NULL);
 #else
-  hMapping_ = ::CreateFileMappingW(hFile_, NULL, PAGE_READONLY, size.HighPart,
-                                   size.LowPart, NULL);
+  hMapping_ = ::CreateFileMappingW(hFile_, NULL, PAGE_READONLY, 0, 0, NULL);
 #endif
 
   if (hMapping_ == NULL) {

--- a/httplib.h
+++ b/httplib.h
@@ -2851,7 +2851,13 @@ inline bool mmap::open(const char *path) {
   DWORD sizeLow;
   sizeLow = ::GetFileSize(hFile_, &sizeHigh);
   if (sizeLow == INVALID_FILE_SIZE) { return false; }
-  size_ = (static_cast<size_t>(sizeHigh) << (sizeof(DWORD) * 8)) | sizeLow;
+  size_ = sizeLow;
+#if defined(_WIN64)
+  size_ |= (static_cast<size_t>(sizeHigh) << (sizeof(DWORD) * 8));
+#else
+  // The size of the file is too large to fit into `size_`, which is 32 bit.
+  if (sizeHigh != 0) { return false; }
+#endif
 #endif
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_SYSTEM) && \


### PR DESCRIPTION
The call shouldn't rely on the `size` variable, since it is available only conditionally, based on preprocessor macros.

https://github.com/yhirose/cpp-httplib/issues/1901