### PR TITLE
‘constexpr’ error

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -355,7 +355,7 @@ struct case_ignore_equal {
 };
 
 struct case_ignore_hash {
-  constexpr size_t operator()(const std::string &key) const {
+  size_t operator()(const std::string &key) const {
     return hash_core(key.data(), key.size(), 0);
   }
 


### PR DESCRIPTION
httplib.h: In member function ‘constexpr size_t httplib::detail::case_ignore_hash::operator()(const string&) const’: httplib.h:359:30: error: call to non-‘constexpr’ function ‘const _CharT* std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::data() const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
  359 |     return hash_core(key.data(), key.size(), 0);