### PR TITLE
Fix find_package for curl

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     FetchContent_MakeAvailable(gtest)
 endif()
 
-find_package(curl REQUIRED)
+find_package(CURL REQUIRED)
 
 add_executable(httplib-test test.cc)
 target_compile_options(httplib-test PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/utf-8;/bigobj>")


### PR DESCRIPTION
Fixes the `find_package` call to point to the curl module provided by CMake (https://cmake.org/cmake/help/latest/module/FindCURL.html)

Without this change, building via CMake produces the following error:
```
  CMake Error at test/CMakeLists.txt:27 (find_package):
  By not providing "Findcurl.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "curl", but
  CMake did not find one.

  Could not find a package configuration file provided by "curl" with any of
  the following names:

    curlConfig.cmake
    curl-config.cmake

  Add the installation prefix of "curl" to CMAKE_PREFIX_PATH or set
  "curl_DIR" to a directory containing one of the above files.  If "curl"
  provides a separate development package or SDK, be sure it has been
  installed.
  ```