### PR TITLE
Added test to check set_file_content(), SEGFAULT with SSL enabled

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2958,7 +2958,7 @@ inline bool mmap::open(const char *path) {
   addr_ = ::mmap(NULL, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
 #endif
 
-  if (addr_ == nullptr) {
+  if (addr_ == nullptr || addr_ == MAP_FAILED) {
     close();
     return false;
   }

--- a/test/test.cc
+++ b/test/test.cc
@@ -2288,6 +2288,8 @@ protected:
   {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
     cli_.enable_server_certificate_verification(false);
+#else
+#error no ssl
 #endif
   }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -2300,6 +2300,14 @@ protected:
              [&](const Request & /*req*/, Response &res) {
                res.set_content("Hello World!", "text/plain");
              })
+        .Get("/file_content_dir_no_slash",
+             [&](const Request & /*req*/, Response &res) {
+               res.set_file_content("./www/dir");
+             })
+        .Get("/file_content_dir_with_slash/",
+             [&](const Request & /*req*/, Response &res) {
+               res.set_file_content("./www/dir/");
+             })
         .Get("/file_content",
              [&](const Request & /*req*/, Response &res) {
                res.set_file_content("./www/dir/test.html");
@@ -2916,13 +2924,31 @@ TEST_F(ServerTest, GetMethod200) {
   EXPECT_EQ("Hello World!", res->body);
 }
 
-TEST_F(ServerTest, GetFileContent) {
+TEST_F(ServerTest, GetFileContent_File) {
   auto res = cli_.Get("/file_content");
   ASSERT_TRUE(res);
   EXPECT_EQ(StatusCode::OK_200, res->status);
   EXPECT_EQ("text/html", res->get_header_value("Content-Type"));
   EXPECT_EQ(9, std::stoi(res->get_header_value("Content-Length")));
   EXPECT_EQ("test.html", res->body);
+}
+
+TEST_F(ServerTest, GetFileContent_DirNoSlash) {
+  auto res = cli_.Get("/file_content_dir_no_slash");
+  ASSERT_TRUE(res);
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ("text/html", res->get_header_value("Content-Type"));
+  EXPECT_EQ(9, std::stoi(res->get_header_value("Content-Length")));
+  EXPECT_EQ("index.html", res->body);
+}
+
+TEST_F(ServerTest, GetFileContent_DirWithSlash) {
+  auto res = cli_.Get("/file_content_dir_with_slash/");
+  ASSERT_TRUE(res);
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ("text/html", res->get_header_value("Content-Type"));
+  EXPECT_EQ(9, std::stoi(res->get_header_value("Content-Length")));
+  EXPECT_EQ("index.html", res->body);
 }
 
 TEST_F(ServerTest, GetFileContentWithContentType) {


### PR DESCRIPTION
So the problem with `set_file_content()` is that it exposed a problem with the `mmap()` call, specifically that it isn't checking if it opened a file.  The previous mountpoint and my alternative impl didn't ever ask httplib to send a directory as if it were a file.

This is only apparent when building with SSL enabled, because it causes a segfault deep in the SSL code.

```
erver_wfsync`httplib::detail::mmap::open(this=0x00007fffdc004e50, path="srvroot/server/folder") at httplib.h:2961:13
   2958	  addr_ = ::mmap(NULL, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
   2959	#endif
   2960	
-> 2961	  if (addr_ == nullptr) {
   2962	    close();
   2963	    return false;
   2964	  }
(lldb) p addr_
(void *) 0xffffffffffffffff
```

Note that mmap returns addr_ = 0xFF... when the target is a directory.

You did call stat() before, which reveals it is a dir:
```
(lldb) p sb
(stat) {
  st_dev = 66306
  st_ino = 65938351
  st_nlink = 9
  st_mode = 16877
  st_uid = 1001
  st_gid = 1001
  __pad0 = 0
  st_rdev = 0
  st_size = 4096
  st_blksize = 4096
  st_blocks = 8
  st_atim = (tv_sec = 1725847882, tv_nsec = 827899212)
  st_mtim = (tv_sec = 1725431048, tv_nsec = 175661468)
  st_ctim = (tv_sec = 1725431048, tv_nsec = 175661468)
  __glibc_reserved = ([0] = 0, [1] = 0, [2] = 0)
}

(lldb) p sb.st_mode & 0040000
(__mode_t) 16384
```
where 0040000 = S_IFDIR

Even if we test prior to mmap(), there is a race condition where a file could be swapped for a dir between the stat() call and the mmap() call.
So I guess we should be checking for invalid addr_ ... not just null but also the 0xff... value.

This PR demonstrates the SEGFAULT,
however it must be built with SSL enabled.  Plain HTTP doesn't trigger it (by luck)

I tested with:
```
cd cpp-httplib
mkdir build
cd build
cmake -D HTTPLIB_TEST=ON -D HTTPLIB_REQUIRE_OPENSSL=ON -D CMAKE_BUILD_TYPE=Debug -G Ninja ..
ninja
cd test
./httplib-test --gtest_filter="ServerTest.GetFileContent_DirNoSlash"
```
