### PR TITLE
Fix shadow parameter warning

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -366,7 +366,7 @@ inline unsigned char to_lower(int c) {
 inline bool equal(const std::string &a, const std::string &b) {
   return a.size() == b.size() &&
          std::equal(a.begin(), a.end(), b.begin(),
-                    [](char a, char b) { return to_lower(a) == to_lower(b); });
+                    [](char ca, char cb) { return to_lower(ca) == to_lower(cb); });
 }
 
 struct equal_to {


### PR DESCRIPTION
Compiling on Ubuntu 22.04, I get a shadow parameter warning. Since we treat all warnings as errors, it fails our build.
```
[...]/cpp-httplib/httplib.h: In lambda function:
[...]/cpp-httplib/httplib.h:353:37: error: declaration of ‘char b’ shadows a parameter [-Werror=shadow]
  353 |                     [](char a, char b) { return to_lower(a) == to_lower(b); });
      |                                ~~~~~^
[...]/cpp-httplib/httplib.h:350:60: note: shadowed declaration is here
  350 | inline bool equal(const std::string &a, const std::string &b) {
      |                                         ~~~~~~~~~~~~~~~~~~~^
[...]/cpp-httplib/httplib.h:353:29: error: declaration of ‘char a’ shadows a parameter [-Werror=shadow]
  353 |                     [](char a, char b) { return to_lower(a) == to_lower(b); });
      |                        ~~~~~^
[...]/cpp-httplib/httplib.h:350:38: note: shadowed declaration is here
  350 | inline bool equal(const std::string &a, const std::string &b) {
      |                   ~~~~~~~~~~~~~~~~~~~^
cc1plus: all warnings being treated as errors
```