### PR TITLE
test(meson): fix `SSLClientServerTest.*` tests with OpenSSL 3.2.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ project(
     'b_lto=true',
     'warning_level=3'
   ],
-  meson_version: '>=0.47.0'
+  meson_version: '>=0.62.0'
 )
 
 # Check just in case downstream decides to edit the source
@@ -98,20 +98,18 @@ if get_option('cpp-httplib_compile')
   )
 else
   install_headers('httplib.h')
-  cpp_httplib_dep = declare_dependency(compile_args: args, dependencies: deps, include_directories: include_directories('.'))
+  cpp_httplib_dep = declare_dependency(compile_args: args, dependencies: deps, include_directories: '.')
 
   import('pkgconfig').generate(
     name: 'cpp-httplib',
     description: 'A C++ HTTP/HTTPS server and client library',
-    install_dir: join_paths(get_option('datadir'), 'pkgconfig'),
+    install_dir: get_option('datadir')/'pkgconfig',
     url: 'https://github.com/yhirose/cpp-httplib',
     version: version
   )
 endif
 
-if meson.version().version_compare('>=0.54.0')
-  meson.override_dependency('cpp-httplib', cpp_httplib_dep)
-endif
+meson.override_dependency('cpp-httplib', cpp_httplib_dep)
 
 if get_option('cpp-httplib_test')
   subdir('test')

--- a/test/meson.build
+++ b/test/meson.build
@@ -6,6 +6,7 @@ gtest_dep = dependency('gtest', main: true)
 libcurl_dep = dependency('libcurl')
 openssl = find_program('openssl')
 test_conf = files('test.conf')
+req_x509_flag = openssl.version().version_compare('>=3.2.0') ? '-x509v1' : '-x509'
 
 key_pem = custom_target(
   'key_pem',
@@ -31,7 +32,7 @@ cert2_pem = custom_target(
   'cert2_pem',
   input: key_pem,
   output: 'cert2.pem',
-  command: [openssl, 'req', '-x509', '-config', test_conf, '-key', '@INPUT@', '-sha256', '-days', '3650', '-nodes', '-out', '@OUTPUT@', '-extensions', 'SAN']
+  command: [openssl, 'req', req_x509_flag, '-config', test_conf, '-key', '@INPUT@', '-sha256', '-days', '3650', '-nodes', '-out', '@OUTPUT@', '-extensions', 'SAN']
 )
 
 key_encrypted_pem = custom_target(
@@ -44,7 +45,7 @@ cert_encrypted_pem = custom_target(
   'cert_encrypted_pem',
   input: key_encrypted_pem,
   output: 'cert_encrypted.pem',
-  command: [openssl, 'req', '-x509', '-config', test_conf, '-key', '@INPUT@', '-sha256', '-days', '3650', '-nodes', '-out', '@OUTPUT@', '-extensions', 'SAN']
+  command: [openssl, 'req', req_x509_flag, '-config', test_conf, '-key', '@INPUT@', '-sha256', '-days', '3650', '-nodes', '-out', '@OUTPUT@', '-extensions', 'SAN']
 )
 
 rootca_key_pem = custom_target(
@@ -57,7 +58,7 @@ rootca_cert_pem = custom_target(
   'rootca_cert_pem',
   input: rootca_key_pem,
   output: 'rootCA.cert.pem',
-  command: [openssl, 'req', '-x509', '-new', '-batch', '-config', files('test.rootCA.conf'), '-key', '@INPUT@', '-days', '1024', '-out', '@OUTPUT@']
+  command: [openssl, 'req', req_x509_flag, '-new', '-batch', '-config', files('test.rootCA.conf'), '-key', '@INPUT@', '-days', '1024', '-out', '@OUTPUT@']
 )
 
 client_key_pem = custom_target(

--- a/test/meson.build
+++ b/test/meson.build
@@ -103,9 +103,9 @@ client_encrypted_cert_pem = custom_target(
 # Copy test files to the build directory
 configure_file(input: 'ca-bundle.crt', output: 'ca-bundle.crt', copy: true)
 configure_file(input: 'image.jpg',     output: 'image.jpg',     copy: true)
-subdir(join_paths('www', 'dir'))
-subdir(join_paths('www2', 'dir'))
-subdir(join_paths('www3', 'dir'))
+subdir('www' /'dir')
+subdir('www2'/'dir')
+subdir('www3'/'dir')
 
 # GoogleTest 1.13.0 requires C++14
 test_options = []


### PR DESCRIPTION
This pull request fixes issue #1798 when building with Meson, while also bumping the minimum required Meson version to 0.62.0. Please do not squash on merge!

Here are the descriptions of the two individual commits:

### build(meson): bump minimum version to 0.62.0

This allows making some minor cleanups

### test(meson): fix `SSLClientServerTest.*` tests with OpenSSL 3.2.0

Since OpenSSL commit <https://github.com/openssl/openssl/commit/342e3652c791bdb06e08abcc169b4456c83ccd00>, the default X.509 certificate format generated with the `openssl req` command has been changed to X.509 v3 from X.509 v1.

For some reason, this change breaks cpp-httplib's `SSLClientServerTest.*` tests.

To fix the test failures, this patch passes the `-x509v1` flag instead of `-x509` when OpenSSL 3.2.0 or newer is detected. To detect the version of a command line utility, Meson 0.62.0 or later is required.

Fixes <https://github.com/yhirose/cpp-httplib/issues/1798>, but only for the Meson build system.