### PR TITLE
Add {Response,DataSink}::is_alive

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -530,6 +530,7 @@ public:
 
   std::function<bool(const char *data, size_t data_len)> write;
   std::function<bool()> is_writable;
+  std::function<bool()> is_alive;
   std::function<void()> done;
   std::function<void(const Headers &trailer)> done_with_trailer;
   std::ostream os;
@@ -722,6 +723,7 @@ public:
 
   virtual bool is_readable() const = 0;
   virtual bool is_writable() const = 0;
+  virtual bool is_alive() const = 0;
 
   virtual ssize_t read(char *ptr, size_t size) = 0;
   virtual ssize_t write(const char *ptr, size_t size) = 0;
@@ -2333,6 +2335,7 @@ public:
 
   bool is_readable() const override;
   bool is_writable() const override;
+  bool is_alive() const override;
   ssize_t read(char *ptr, size_t size) override;
   ssize_t write(const char *ptr, size_t size) override;
   void get_remote_ip_and_port(std::string &ip, int &port) const override;
@@ -3205,6 +3208,7 @@ public:
 
   bool is_readable() const override;
   bool is_writable() const override;
+  bool is_alive() const override;
   ssize_t read(char *ptr, size_t size) override;
   ssize_t write(const char *ptr, size_t size) override;
   void get_remote_ip_and_port(std::string &ip, int &port) const override;
@@ -3235,6 +3239,7 @@ public:
 
   bool is_readable() const override;
   bool is_writable() const override;
+  bool is_alive() const override;
   ssize_t read(char *ptr, size_t size) override;
   ssize_t write(const char *ptr, size_t size) override;
   void get_remote_ip_and_port(std::string &ip, int &port) const override;
@@ -4410,6 +4415,7 @@ inline bool write_content(Stream &strm, const ContentProvider &content_provider,
   };
 
   data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
+  data_sink.is_alive = [&]() -> bool { return strm.is_alive(); };
 
   while (offset < end_offset && !is_shutting_down()) {
     if (!strm.is_writable()) {
@@ -4456,6 +4462,7 @@ write_content_without_length(Stream &strm,
   };
 
   data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
+  data_sink.is_alive = [&]() -> bool { return strm.is_alive(); };
 
   data_sink.done = [&](void) { data_available = false; };
 
@@ -4508,6 +4515,7 @@ write_content_chunked(Stream &strm, const ContentProvider &content_provider,
   };
 
   data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
+  data_sink.is_alive = [&]() -> bool { return strm.is_alive(); };
 
   auto done_with_trailer = [&](const Headers *trailer) {
     if (!ok) { return; }
@@ -5821,6 +5829,10 @@ inline bool SocketStream::is_writable() const {
          is_socket_alive(sock_);
 }
 
+inline bool SocketStream::is_alive() const {
+  return is_socket_alive(sock_);
+}
+
 inline ssize_t SocketStream::read(char *ptr, size_t size) {
 #ifdef _WIN32
   size =
@@ -5894,6 +5906,8 @@ inline socket_t SocketStream::socket() const { return sock_; }
 inline bool BufferStream::is_readable() const { return true; }
 
 inline bool BufferStream::is_writable() const { return true; }
+
+inline bool BufferStream::is_alive() const { return true; }
 
 inline ssize_t BufferStream::read(char *ptr, size_t size) {
 #if defined(_MSC_VER) && _MSC_VER < 1910
@@ -8902,6 +8916,10 @@ inline bool SSLSocketStream::is_readable() const {
 inline bool SSLSocketStream::is_writable() const {
   return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 &&
          is_socket_alive(sock_);
+}
+
+inline bool SSLSocketStream::is_alive() const {
+  return is_socket_alive(sock_);
 }
 
 inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {

--- a/httplib.h
+++ b/httplib.h
@@ -530,7 +530,6 @@ public:
 
   std::function<bool(const char *data, size_t data_len)> write;
   std::function<bool()> is_writable;
-  std::function<bool()> is_alive;
   std::function<void()> done;
   std::function<void(const Headers &trailer)> done_with_trailer;
   std::ostream os;
@@ -666,6 +665,7 @@ struct Response {
   Headers headers;
   std::string body;
   std::string location; // Redirect location
+  std::function<bool()> is_alive;
 
   bool has_header(const std::string &key) const;
   std::string get_header_value(const std::string &key, const char *def = "",
@@ -4415,7 +4415,6 @@ inline bool write_content(Stream &strm, const ContentProvider &content_provider,
   };
 
   data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
-  data_sink.is_alive = [&]() -> bool { return strm.is_alive(); };
 
   while (offset < end_offset && !is_shutting_down()) {
     if (!strm.is_writable()) {
@@ -4462,7 +4461,6 @@ write_content_without_length(Stream &strm,
   };
 
   data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
-  data_sink.is_alive = [&]() -> bool { return strm.is_alive(); };
 
   data_sink.done = [&](void) { data_available = false; };
 
@@ -4515,7 +4513,6 @@ write_content_chunked(Stream &strm, const ContentProvider &content_provider,
   };
 
   data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
-  data_sink.is_alive = [&]() -> bool { return strm.is_alive(); };
 
   auto done_with_trailer = [&](const Headers *trailer) {
     if (!ok) { return; }
@@ -4609,6 +4606,7 @@ inline bool redirect(T &cli, Request &req, Response &res,
   }
 
   Response new_res;
+  new_res.is_alive = res.is_alive;
 
   auto ret = cli.send(new_req, new_res, error);
   if (ret) {
@@ -7005,6 +7003,7 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
   Request req;
 
   Response res;
+  res.is_alive = [&strm]() { return strm.is_alive(); };
   res.version = "HTTP/1.1";
   res.headers = default_headers_;
 

--- a/test/fuzzing/server_fuzzer.cc
+++ b/test/fuzzing/server_fuzzer.cc
@@ -27,6 +27,8 @@ public:
 
   bool is_writable() const override { return true; }
 
+  bool is_alive() const override { return true; }
+
   void get_remote_ip_and_port(std::string &ip, int &port) const override {
     ip = "127.0.0.1";
     port = 8080;

--- a/test/test.cc
+++ b/test/test.cc
@@ -165,9 +165,11 @@ TEST(SocketStream, is_writable_UNIX) {
   };
   asSocketStream(fds[0], [&](Stream &s0) {
     EXPECT_EQ(s0.socket(), fds[0]);
+    EXPECT_TRUE(s0.is_alive());
     EXPECT_TRUE(s0.is_writable());
 
     EXPECT_EQ(0, close(fds[1]));
+    EXPECT_FALSE(s0.is_alive());
     EXPECT_FALSE(s0.is_writable());
 
     return true;
@@ -209,6 +211,7 @@ TEST(SocketStream, is_writable_INET) {
   };
   asSocketStream(disconnected_svr_sock, [&](Stream &ss) {
     EXPECT_EQ(ss.socket(), disconnected_svr_sock);
+    EXPECT_FALSE(ss.is_alive());
     EXPECT_FALSE(ss.is_writable());
 
     return true;
@@ -5456,14 +5459,16 @@ TEST(LongPollingTest, ClientCloseDetection) {
   svr.Get("/events", [&](const Request & /*req*/, Response &res) {
     res.set_chunked_content_provider(
         "text/plain", [](std::size_t const, DataSink &sink) -> bool {
-          EXPECT_TRUE(sink.is_writable()); // the socket is alive
+          EXPECT_TRUE(sink.is_alive());
+          EXPECT_TRUE(sink.is_writable());
           sink.os << "hello";
 
           auto count = 10;
-          while (count > 0 && sink.is_writable()) {
+          while (count > 0 && sink.is_writable() && sink.is_alive()) {
             this_thread::sleep_for(chrono::milliseconds(10));
           }
-          EXPECT_FALSE(sink.is_writable()); // the socket is closed
+          EXPECT_FALSE(sink.is_alive());
+          EXPECT_FALSE(sink.is_writable());
           return true;
         });
   });


### PR DESCRIPTION
This is to be able to detect if the client connection was lost.

Context: https://github.com/yhirose/cpp-httplib/issues/1952 / https://github.com/ggerganov/llama.cpp/pull/9679

As suggested by @ngxson, since is_writable / select_write may be a bit heavyweight, I tried using just select_read (given it's in a context when every other thread is done reading) but it didn't do the trick alone, so settled for is_socket_alive (which uses select_read + read_socket): seems to work.

*Update*: I finally realized having is_alive on DataSink isn't enough, so moved it to Response itself (by lack of a better place?). In the llama.cpp use case we need to test for liveness *before* status / headers are even written back. Added a tiny test to exercise this.

Tested (no new failures): `cmake -B build -DHTTPLIB_TEST=1 -DHTTPLIB_REQUIRE_OPENSSL=0 -DHTTPLIB_COMPILE=1 -DHTTPLIB_TEST=1 -DHTTPLIB_REQUIRE_ZLIB=1 -DHTTPLIB_REQUIRE_BROTLI=1 && cmake --build build -j && ctest --test-dir build -j`