### PR TITLE
Remove space between operator"" and _t

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3760,7 +3760,7 @@ inline unsigned int str2tag(const std::string &s) {
 
 namespace udl {
 
-inline constexpr unsigned int operator"" _t(const char *s, size_t l) {
+inline constexpr unsigned int operator""_t(const char *s, size_t l) {
   return str2tag_core(s, l, 0);
 }
 


### PR DESCRIPTION
This should fix a -Wdeprecated-literal-operator instance since this is deprecated as a result of CWG2521 (iiuc C++23).