### PR TITLE
Remove extra semicolon

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -395,7 +395,7 @@ struct hash {
   }
 };
 
-}; // namespace case_ignore
+} // namespace case_ignore
 
 // This is based on
 // "http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4189".


### PR DESCRIPTION
This fixes a -Wc++98-compat-extra-semi instance.