### PR TITLE
Allow empty header values

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4115,7 +4115,7 @@ inline bool parse_header(const char *beg, const char *end, T fn) {
     p++;
   }
 
-  if (p < end) {
+  if (p <= end) {
     auto key_len = key_end - beg;
     if (!key_len) { return false; }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -4922,6 +4922,15 @@ TEST(ServerRequestParsingTest, InvalidFieldValueContains_CR_LF_NUL) {
   EXPECT_EQ("HTTP/1.1 400 Bad Request", out.substr(0, 24));
 }
 
+TEST(ServerRequestParsingTest, EmptyFieldValue) {
+  std::string out;
+
+  test_raw_request("GET /header_field_value_check HTTP/1.1\r\n"
+                   "Test: \r\n\r\n",
+                   &out);
+  EXPECT_EQ("HTTP/1.1 200 OK", out.substr(0, 15));
+}
+
 TEST(ServerStopTest, StopServerWithChunkedTransmission) {
   Server svr;
 


### PR DESCRIPTION
The current implementation rejects the request and responds with `400 Bad Request` if the header value is empty.
However, [RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2) states that empty header values are allowed.

```
header-field   = field-name ":" OWS field-value OWS

field-name     = token
field-value    = *( field-content / obs-fold )
field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
field-vchar    = VCHAR / obs-text

obs-fold       = CRLF 1*( SP / HTAB )
               ; obsolete line folding
               ; see [Section 3.2.4](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.4)
```
