### PR TITLE
Fix #1969 (without unnecessary sleep_for)

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3308,8 +3308,6 @@ inline bool keep_alive(const std::atomic<socket_t> &svr_sock, socket_t sock,
     } else {
       return true; // Ready for read
     }
-
-    std::this_thread::sleep_for(microseconds{interval_usec});
   }
 
   return false;


### PR DESCRIPTION
Removed unnecessary sleep_for. Confirmed that all platforms (linux, mac, windows) have no problem without it.