### PR TITLE
Fix casting uint64_t to size_t for 32-bit builds

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7999,8 +7999,8 @@ inline bool ClientImpl::process_request(Stream &strm, Request &req,
 
     if (res.has_header("Content-Length")) {
       if (!req.content_receiver) {
-        auto len = std::min<size_t>(res.get_header_value_u64("Content-Length"),
-                                    res.body.max_size());
+        auto contentLength = (size_t)res.get_header_value_u64("Content-Length");
+        auto len = std::min<size_t>(contentLength, res.body.max_size());
         if (len > 0) { res.body.reserve(len); }
       }
     }


### PR DESCRIPTION
This fixes the following warning:
```
D:\cpp-httplib\httplib.h(8002,61): warning C4244: 'argument': conversion from 'uint64_t' to 'const _Ty', possible loss of data
D:\cpp-httplib\httplib.h(8002,61): warning C4244:         with
D:\cpp-httplib\httplib.h(8002,61): warning C4244:         [
D:\cpp-httplib\httplib.h(8002,61): warning C4244:             _Ty=size_t
D:\cpp-httplib\httplib.h(8002,61): warning C4244:         ]
(compiling source file '../src/test/HttpRequestTest.cpp')
```