### PR TITLE
Available on Win7

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -2940,7 +2940,7 @@ inline bool mmap::open(const char *path) {
   auto wpath = u8string_to_wstring(path);
   if (wpath.empty()) { return false; }
 
-#if _WIN32_WINNT >= _WIN32_WINNT_WIN8
+#if _WIN32_WINNT > _WIN32_WINNT_WIN7
   hFile_ = ::CreateFile2(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ,
                          OPEN_EXISTING, NULL);
 #else
@@ -2962,7 +2962,7 @@ inline bool mmap::open(const char *path) {
   }
   size_ = static_cast<size_t>(size.QuadPart);
 
-#if _WIN32_WINNT >= _WIN32_WINNT_WIN8
+#if _WIN32_WINNT > _WIN32_WINNT_WIN7
   hMapping_ =
       ::CreateFileMappingFromApp(hFile_, NULL, PAGE_READONLY, size_, NULL);
 #else
@@ -2981,7 +2981,7 @@ inline bool mmap::open(const char *path) {
     return false;
   }
 
-#if _WIN32_WINNT >= _WIN32_WINNT_WIN8
+#if _WIN32_WINNT > _WIN32_WINNT_WIN7
   addr_ = ::MapViewOfFileFromApp(hMapping_, FILE_MAP_READ, 0, 0);
 #else
   addr_ = ::MapViewOfFile(hMapping_, FILE_MAP_READ, 0, 0, 0);


### PR DESCRIPTION
May cause abnormal usage Because there is no definition of `_WIN32_WINNT_WIN8` in C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Include\sdkddkver.h