### PR TITLE
fix:set_file_content with range request return 416.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7183,14 +7183,6 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
                                       : StatusCode::PartialContent_206;
     }
 
-    if (detail::range_error(req, res)) {
-      res.body.clear();
-      res.content_length_ = 0;
-      res.content_provider_ = nullptr;
-      res.status = StatusCode::RangeNotSatisfiable_416;
-      return write_response(strm, close_connection, req, res);
-    }
-
     // Serve file content by using a content provider
     if (!res.file_content_path_.empty()) {
       const auto &path = res.file_content_path_;
@@ -7215,6 +7207,14 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
             sink.write(mm->data() + offset, length);
             return true;
           });
+    }
+
+    if (detail::range_error(req, res)) {
+      res.body.clear();
+      res.content_length_ = 0;
+      res.content_provider_ = nullptr;
+      res.status = StatusCode::RangeNotSatisfiable_416;
+      return write_response(strm, close_connection, req, res);
     }
 
     return write_response_with_content(strm, close_connection, req, res);

--- a/test/test.cc
+++ b/test/test.cc
@@ -3036,6 +3036,16 @@ TEST_F(ServerTest, GetFileContent) {
   EXPECT_EQ("test.html", res->body);
 }
 
+TEST_F(ServerTest, GetFileContentWithRange) {
+  auto res = cli_.Get("/file_content", {{make_range_header({{1, 3}})}});
+  ASSERT_TRUE(res);
+  EXPECT_EQ(StatusCode::PartialContent_206, res->status);
+  EXPECT_EQ("text/html", res->get_header_value("Content-Type"));
+  EXPECT_EQ("bytes 1-3/9", res->get_header_value("Content-Range"));
+  EXPECT_EQ(3, std::stoi(res->get_header_value("Content-Length")));
+  EXPECT_EQ("est", res->body);
+}
+
 TEST_F(ServerTest, GetFileContentWithContentType) {
   auto res = cli_.Get("/file_content_with_content_type");
   ASSERT_TRUE(res);


### PR DESCRIPTION
in function "detail::range_error",check range pos and content_length:
`
      // Range must be within content length
      if (!(0 <= first_pos && first_pos <= last_pos &&
            last_pos <= contant_len - 1)) {
        return true;
      }
`

use res.set_file_content in callback, set "content_length_" in res.set_content_provider function, but res.set_content_provider is after "detail::range_error", cause  "detail::range_error" return true(error).

to solve this problem，put "detail::range_error()" after file content served, it's ok.