### PR TITLE
Fix compile err in example dir

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -18,7 +18,7 @@ ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz
 BROTLI_DIR = $(PREFIX)/opt/brotli
 BROTLI_SUPPORT = -DCPPHTTPLIB_BROTLI_SUPPORT -I$(BROTLI_DIR)/include -L$(BROTLI_DIR)/lib -lbrotlicommon -lbrotlienc -lbrotlidec
 
-all: server client hello simplecli simplesvr upload redirect ssesvr ssecli benchmark issue
+all: server client hello simplecli simplesvr upload redirect ssesvr ssecli benchmark one_time_request server_and_client
 
 server : server.cc ../httplib.h Makefile
 	$(CXX) -o server $(CXXFLAGS) server.cc $(OPENSSL_SUPPORT) $(ZLIB_SUPPORT) $(BROTLI_SUPPORT)
@@ -61,4 +61,4 @@ pem:
 	openssl req -new -key key.pem | openssl x509 -days 3650 -req -signkey key.pem > cert.pem
 
 clean:
-	rm server client hello simplecli simplesvr upload redirect ssesvr ssecli benchmark one_time_request server_and_client *.pem
+	rm server client hello simplecli simplesvr upload redirect ssesvr ssecli benchmark one_time_request server_and_client


### PR DESCRIPTION
When I build in example dir on fedora 40 server. I get some errors like below:
```
▸ make
...                                                                                                                                                                                                                                                                                                                             make: *** No rule to make target 'issue', needed by 'all'.  Stop.
make: *** Waiting for unfinished jobs....

...

▸ make clean
rm server client hello simplecli simplesvr upload redirect ssesvr ssecli benchmark one_time_request server_and_client *.pem                                                                                                                           rm: cannot remove 'one_time_request': No such file or directory
rm: cannot remove 'server_and_client': No such file or directory
rm: cannot remove '*.pem': No such file or directory
```
So I made this modify to optimize makefile in example dir.