### PR TITLE
Preparations for WebSockets

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5132,7 +5132,7 @@ private:
   size_t buf_epos_ = 0;
 };
 
-inline std::string random_string(size_t length) {
+inline void random_bytes(char *ptr, size_t length, bool alphanum) {
   static const char data[] =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
@@ -5147,11 +5147,26 @@ inline std::string random_string(size_t length) {
 
   static std::mt19937 engine(seed_sequence);
 
-  std::string result;
-  for (size_t i = 0; i < length; i++) {
-    result += data[engine() % (sizeof(data) - 1)];
+  if (alphanum) {
+    for (size_t i = 0; i < length; i++) {
+      *(ptr++) = data[engine() % (sizeof(data) - 1)];
+    }
+  } else {
+    for (size_t i = 0; i < length;) {
+      auto val = engine();
+      for (size_t j = 0; i < length && j < sizeof(val); ++i, ++j) {
+        *(ptr++) = static_cast<char>(val);
+        val >>= 8;
+      }
+    }
   }
-  return result;
+}
+
+inline std::string random_string(size_t length) {
+  std::string s;
+  s.resize(length);
+  random_bytes(&s[0], length, true);
+  return s;
 }
 
 inline std::string make_multipart_data_boundary() {

--- a/httplib.h
+++ b/httplib.h
@@ -2371,11 +2371,22 @@ bool parse_multipart_boundary(const std::string &content_type,
 
 bool parse_range_header(const std::string &s, Ranges &ranges);
 
+void random_bytes(char *ptr, size_t length, bool alphanum);
+
+std::string random_string(size_t length);
+
 int close_socket(socket_t sock);
 
 ssize_t send_socket(socket_t sock, const void *ptr, size_t size, int flags);
 
 ssize_t read_socket(socket_t sock, void *ptr, size_t size, int flags);
+
+ssize_t select_read(socket_t sock, time_t sec, time_t usec);
+
+ssize_t select_read(socket_t sock, socket_t extra_fd, time_t sec, time_t usec,
+                    bool &sock_readable, bool &extra_fd_readable);
+
+void set_nonblocking(socket_t sock, bool nonblocking);
 
 enum class EncodingType { None = 0, Gzip, Brotli };
 

--- a/test/fuzzing/server_fuzzer.cc
+++ b/test/fuzzing/server_fuzzer.cc
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <limits>
 
 #include <httplib.h>
 
@@ -26,6 +27,8 @@ public:
   bool is_readable() const override { return true; }
 
   bool is_writable() const override { return true; }
+
+  size_t nonblocking_read_size() const override { return (std::numeric_limits<size_t>::max)(); }
 
   void get_remote_ip_and_port(std::string &ip, int &port) const override {
     ip = "127.0.0.1";


### PR DESCRIPTION
This PR lays the groundwork for an upcoming implementation of WebSockets. It makes the following changes:

1. **Stream handler:** Introduce a new callback `StreamHandler`. If set, it replaces all other content-serving mechanisms and – in conjunction with a response handler – provides a minimal interface to implement a WebSocket client. The `Response` struct gained a `set_stream_handler()` function to accomplish the same server-side.
2. **Stream changes:** Add `nonblocking_read_size()` which returns a size that is guaranteed to not block `read()` calls. `read()` may return fewer bytes including none at all. ~~Add timeout setters, to allow other protocol implementations to set more appropriate timeouts in stream handlers.~~
3. **`random_bytes()`:** Refactor `random_string()` into `random_bytes()`. This will be used to generate the masking key for WebSockets.
4. **`select_read()`:** Add a two FD version of `select_read()` with support for infinite timeouts. This change is critical to implement bidirectional communication. The WebSockets implementation will use this to interrupt reads when a message is added to the send queue. Branching on the non-type template parameter ensures the common, single FD case isn't pessimized.
5. **Forward declaration:** Forward declare a few functions used by the WebSockets header to allow it to compile with split `httplib.{h,cc}`.

I'm aware of #1103 and while I liked it initially, IMHO, it falls short of its goal of supporting protocol switching generically. The stream handler mechanism doesn't bill itself as anything but another way to handle the body of an HTTP response. It's meant as a low-level, advanced feature that doesn't have to be exposed in the high-level API. (Protocol switching isn't limited to `GET` requests.)
I've happily taken some inspiration from it, though. (Thanks, @PixlRainbow!)

**Checklist:**
- [x] Explore requirements for WebSocket servers.
- [ ] Replace all occurrences of `std::function<bool(Stream&)>` with `StreamHandler`?
- [ ] Test on platforms other than Linux. Also, test with `CPPHTTPLIB_USE_POLL` where applicable.
- [ ] Test split header/implementation.
- [ ] Documentation.