### PR TITLE
ci: add abidiff workflow

### DIFF
--- a/.github/workflows/abidiff.yaml
+++ b/.github/workflows/abidiff.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 Andrea Pappacoda <andrea@pappacoda.it>
+# SPDX-License-Identifier: MIT
+
+name: abidiff
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: sh
+
+jobs:
+  abi:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:testing
+
+    steps:
+    - name: Install dependencies
+      run: apt -y --update install --no-install-recommends
+        abigail-tools
+        ca-certificates
+        g++
+        git
+        libbrotli-dev
+        libssl-dev
+        meson
+        pkg-config
+        python3
+        zlib1g-dev
+
+    - uses: actions/checkout@v4
+      with:
+        path: current
+
+    - uses: actions/checkout@v4
+      with:
+        path: previous
+        fetch-depth: 0
+
+    - name: Checkout previous
+      working-directory: previous
+      run: |
+        git switch master
+        git describe --tags --abbrev=0 master | xargs git checkout
+
+    - name: Build current
+      working-directory: current
+      run: |
+        meson setup --buildtype=debug -Dcpp-httplib_compile=true build
+        ninja -C build
+
+    - name: Build previous
+      working-directory: previous
+      run: |
+        meson setup --buildtype=debug -Dcpp-httplib_compile=true build
+        ninja -C build
+
+    - name: Run abidiff
+      run: abidiff
+        --headers-dir1 previous/build
+        --headers-dir2 current/build
+        previous/build/libcpp-httplib.so
+        current/build/libcpp-httplib.so


### PR DESCRIPTION
This CI workflow checks ABI compatibility between the pushed commit and the previous, helping preventing accidental ABI breaks.

Helps with https://github.com/yhirose/cpp-httplib/issues/2043

Cc: @mgorny