### PR TITLE
Add workflow_dispatch with Google Test filter and OS selection

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,15 +8,15 @@ on:
       gtest_filter:
         description: 'Google Test filter'
       test_linux:
-        description: 'Test Linux'
+        description: 'Test on Linux'
         type: boolean
         default: true
       test_macos:
-        description: 'Test MacOS'
+        description: 'Test on MacOS'
         type: boolean
         default: true
       test_windows:
-        description: 'Test Windows'
+        description: 'Test on Windows'
         type: boolean
         default: true
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,18 @@ on:
     inputs:
       gtest_filter:
         description: 'Google Test filter'
+      test_linux:
+        description: 'Test Linux'
+        type: boolean
+        default: true
+      test_macos:
+        description: 'Test MacOS'
+        type: boolean
+        default: true
+      test_windows:
+        description: 'Test Windows'
+        type: boolean
+        default: true
 
 env:
   GTEST_FILTER: ${{ github.event.inputs.gtest_filter || '*' }}
@@ -14,7 +26,11 @@ env:
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: >
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request'  &&
+       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.test_linux == 'true')
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -27,7 +43,11 @@ jobs:
 
   macos:
     runs-on: macos-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: >
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request'  &&
+       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.test_macos == 'true')
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -38,7 +58,11 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: >
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request'  &&
+       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.test_windows == 'true')
     steps:
     - name: Prepare Git for Checkout on Windows
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,15 @@
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      gtest_filter:
+        description: 'Google Test filter'
+
+env:
+  GTEST_FILTER: ${{ github.event.inputs.gtest_filter || '*' }}
 
 jobs:
   ubuntu:


### PR DESCRIPTION
A run of the `test.yaml` workflow can now be [triggered manually](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow#running-a-workflow), optionally with a Google Test filter pattern and OS selection.

Allows, for example, to only run `MaxTimeoutTest.*` on MacOS.