### PR TITLE
Detect additional CMake build failures

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 
 find_package(CURL REQUIRED)
 
-add_executable(httplib-test test.cc)
+add_executable(httplib-test test.cc include_httplib.cc $<$<BOOL:${WIN32}>:include_windows_h.cc>)
 target_compile_options(httplib-test PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/utf-8;/bigobj>")
 target_link_libraries(httplib-test PRIVATE httplib GTest::gtest_main CURL::libcurl)
 gtest_discover_tests(httplib-test)

--- a/test/include_windows_h.cc
+++ b/test/include_windows_h.cc
@@ -1,0 +1,6 @@
+// Test if including windows.h conflicts with httplib.h
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <httplib.h>


### PR DESCRIPTION
Add `include_httplib.cc` to the main test executable (already done in `Makefile`), and add `include_windows_h.cc` to the main test executable on Windows to test if including `windows.h` conflicts with `httplib.h`.

Detects breakage fixed in #2057.
