### PR TITLE
Refactor streams: rename `is_*` to `wait_*` for clarity

### DIFF
--- a/test/fuzzing/server_fuzzer.cc
+++ b/test/fuzzing/server_fuzzer.cc
@@ -25,7 +25,9 @@ public:
 
   bool is_readable() const override { return true; }
 
-  bool is_writable() const override { return true; }
+  bool wait_readable() const override { return true; }
+
+  bool wait_writable() const override { return true; }
 
   void get_remote_ip_and_port(std::string &ip, int &port) const override {
     ip = "127.0.0.1";

--- a/test/test.cc
+++ b/test/test.cc
@@ -156,7 +156,7 @@ TEST_F(UnixSocketTest, abstract) {
 }
 #endif
 
-TEST(SocketStream, is_writable_UNIX) {
+TEST(SocketStream, wait_writable_UNIX) {
   int fds[2];
   ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
 
@@ -167,17 +167,17 @@ TEST(SocketStream, is_writable_UNIX) {
   };
   asSocketStream(fds[0], [&](Stream &s0) {
     EXPECT_EQ(s0.socket(), fds[0]);
-    EXPECT_TRUE(s0.is_writable());
+    EXPECT_TRUE(s0.wait_writable());
 
     EXPECT_EQ(0, close(fds[1]));
-    EXPECT_FALSE(s0.is_writable());
+    EXPECT_FALSE(s0.wait_writable());
 
     return true;
   });
   EXPECT_EQ(0, close(fds[0]));
 }
 
-TEST(SocketStream, is_writable_INET) {
+TEST(SocketStream, wait_writable_INET) {
   sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
@@ -212,7 +212,7 @@ TEST(SocketStream, is_writable_INET) {
   };
   asSocketStream(disconnected_svr_sock, [&](Stream &ss) {
     EXPECT_EQ(ss.socket(), disconnected_svr_sock);
-    EXPECT_FALSE(ss.is_writable());
+    EXPECT_FALSE(ss.wait_writable());
 
     return true;
   });


### PR DESCRIPTION
- Replace `is_readable()` with `wait_readable()` and `is_writable()` with `wait_writable()` in the Stream interface.
- Implement a new `is_readable()` function with semantics that more closely reflect its name. It returns immediately whether data is available for reading, without waiting.
- Update call sites of `is_writable()`, removing redundant checks.

<hr />

**Note:** The new `is_readable()` capability is *essential* for the WebSockets code, as there's currently no way to tell if `read()` would block. I have an alternative proposal to add `has_buffered_data()`, which is identical to `is_readable()` in this PR. This alternative is less invasive and requires no other code changes, while this PR also aims to enhance semantic clarity.