### PR TITLE
Fix typo in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ endif
 if cxx.has_function('poll', prefix: '#include <poll.h>')
   # Use poll if present
   add_project_arguments('-DCPPHTTPLIB_USE_POLL', language: 'cpp')
-else if cxx.has_function('select', prefix: '#include <sys/select.h>')
+elif cxx.has_function('select', prefix: '#include <sys/select.h>')
   # Use select otherwise
   add_project_arguments('-DCPPHTTPLIB_USE_SELECT', language: 'cpp')
 endif


### PR DESCRIPTION
2b5d1eea8d7e9f881ac4be04ce31df782b26b6a9 introduced a typo, breaking the abidiff workflow.

See it failing [here](https://github.com/yhirose/cpp-httplib/actions/runs/13420574673/job/37491955273?pr=2069).