### PR TITLE
Correct default thread pool size in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Please see [Server example](https://github.com/yhirose/cpp-httplib/blob/master/e
 
 ### Default thread pool support
 
-`ThreadPool` is used as a **default** task queue, and the default thread count is 8, or `std::thread::hardware_concurrency()`. You can change it with `CPPHTTPLIB_THREAD_POOL_COUNT`.
+`ThreadPool` is used as the **default** task queue, with a default thread count of 8 or `std::thread::hardware_concurrency() - 1`, whichever is greater. You can change it with `CPPHTTPLIB_THREAD_POOL_COUNT`.
 
 If you want to set the thread count at runtime, there is no convenient way... But here is how.
 


### PR DESCRIPTION
https://github.com/yhirose/cpp-httplib/blob/a4b2c61a65f4ff3d18b3dd24d2abae40f30be7de/httplib.h#L129-L134