### PR TITLE
Parallelize testing with/without SSL on Windows & set concurrency group

### DIFF
--- a/.github/workflows/abidiff.yaml
+++ b/.github/workflows/abidiff.yaml
@@ -5,6 +5,10 @@ name: abidiff
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: sh

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -1,5 +1,11 @@
 name: CIFuzz
+
 on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,14 @@ jobs:
       (github.event_name == 'pull_request'  &&
        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.test_windows == 'true')
+    strategy:
+      matrix:
+        config:
+        - with_ssl: false
+          name: without SSL
+        - with_ssl: true
+          name: with SSL
+    name: windows ${{ matrix.config.name }}
     steps:
     - name: Prepare Git for Checkout on Windows
       run: |
@@ -90,24 +98,25 @@ jobs:
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
     - name: Setup msbuild on windows
       uses: microsoft/setup-msbuild@v2
-    - name: Install libraries
-      run: |
-        vcpkg install gtest curl zlib brotli
-        choco install openssl
-
-    - name: Configure CMake with SSL
-      run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake -DHTTPLIB_TEST=ON -DHTTPLIB_REQUIRE_OPENSSL=ON -DHTTPLIB_REQUIRE_ZLIB=ON -DHTTPLIB_REQUIRE_BROTLI=ON
-    - name: Build with with SSL
-      run: cmake --build build --config Release
-    - name: Run tests with SSL
+    - name: Install vcpkg dependencies
+      run: vcpkg install gtest curl zlib brotli
+    - name: Install OpenSSL
+      if: ${{ matrix.config.with_ssl }}
+      run: choco install openssl
+    - name: Configure CMake ${{ matrix.config.name }}
+      run: >
+        cmake -B build -S .
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+        -DHTTPLIB_TEST=ON
+        -DHTTPLIB_REQUIRE_ZLIB=ON
+        -DHTTPLIB_REQUIRE_BROTLI=ON
+        -DHTTPLIB_REQUIRE_OPENSSL=${{ matrix.config.with_ssl && 'ON' || 'OFF' }}
+    - name: Build ${{ matrix.config.name }}
+      run: cmake --build build --config Release -- /v:m /clp:ShowCommandLine
+    - name: Run tests ${{ matrix.config.name }}
       run: ctest --output-on-failure --test-dir build -C Release
 
-    - name: Configure CMake without SSL
-      run: cmake -B build-no-ssl -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake -DHTTPLIB_TEST=ON -DHTTPLIB_REQUIRE_OPENSSL=OFF -DHTTPLIB_REQUIRE_ZLIB=ON -DHTTPLIB_REQUIRE_BROTLI=ON
-    - name: Build without SSL
-      run: cmake --build build-no-ssl --config Release
-    - name: Run tests without SSL
-      run: ctest --output-on-failure --test-dir build-no-ssl -C Release
     env:
       VCPKG_ROOT: "C:/vcpkg"
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,10 @@ on:
         type: boolean
         default: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   GTEST_FILTER: ${{ github.event.inputs.gtest_filter || '*' }}
 


### PR DESCRIPTION
- Start two Windows runners: one with SSL, and one without.
- Set concurrency group on workflows such that pushes to the same branch/PR cancel currently running workflows.

This does apply to multiple PR merges to master in short succession, which could be changed if not desired.