### PR TITLE
Run 32-bit compiled unit tests on Ubuntu

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,15 +47,30 @@ jobs:
       (github.event_name == 'pull_request'  &&
        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.test_linux == 'true')
+    strategy:
+      matrix:
+        config:
+        - arch_flags: -m32
+          arch_suffix: :i386
+          name: (32-bit)
+        - arch_flags:
+          arch_suffix:
+          name: (64-bit)
+    name: ubuntu ${{ matrix.config.name }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - name: install libraries
-        run: sudo apt-get update && sudo apt-get install -y libbrotli-dev libcurl4-openssl-dev
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y libc6-dev${{ matrix.config.arch_suffix }} libstdc++-13-dev${{ matrix.config.arch_suffix }} \
+            libssl-dev${{ matrix.config.arch_suffix }} libcurl4-openssl-dev${{ matrix.config.arch_suffix }} \
+            zlib1g-dev${{ matrix.config.arch_suffix }} libbrotli-dev${{ matrix.config.arch_suffix }}
       - name: build and run tests
-        run: cd test && make
+        run: cd test && make EXTRA_CXXFLAGS="${{ matrix.config.arch_flags }}"
       - name: run fuzz test target
-        run: cd test && make fuzz_test
+        run: cd test && make EXTRA_CXXFLAGS="${{ matrix.config.arch_flags }}" fuzz_test
 
   macos:
     runs-on: macos-latest

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,5 @@
 CXX = clang++
-CXXFLAGS = -g -std=c++11 -I. -Wall -Wextra -Wtype-limits -Wconversion -Wshadow # -fno-exceptions -DCPPHTTPLIB_NO_EXCEPTIONS -fsanitize=address
+CXXFLAGS = -g -std=c++11 -I. -Wall -Wextra -Wtype-limits -Wconversion -Wshadow $(EXTRA_CXXFLAGS) # -fno-exceptions -DCPPHTTPLIB_NO_EXCEPTIONS -fsanitize=address
 
 PREFIX ?= $(shell brew --prefix)
 
@@ -41,6 +41,7 @@ proxy : test_proxy
 
 test : test.cc include_httplib.cc ../httplib.h Makefile cert.pem
 	$(CXX) -o $@ -I.. $(CXXFLAGS) test.cc include_httplib.cc $(TEST_ARGS)
+	@file $@
 
 # Note: The intention of test_split is to verify that it works to compile and
 # link the split httplib.h, so there is normally no need to execute it.
@@ -83,6 +84,7 @@ fuzz_test: server_fuzzer
 # Fuzz target, so that you can choose which $(LIB_FUZZING_ENGINE) to use.
 server_fuzzer : fuzzing/server_fuzzer.cc ../httplib.h standalone_fuzz_target_runner.o
 	$(CXX) -o $@ -I.. $(CXXFLAGS) $< $(OPENSSL_SUPPORT) $(ZLIB_SUPPORT) $(BROTLI_SUPPORT) $(LIB_FUZZING_ENGINE) -pthread
+	@file $@
 
 # Standalone fuzz runner, which just reads inputs from fuzzing/corpus/ dir and
 # feeds it to server_fuzzer.


### PR DESCRIPTION
This PR lays the groundwork for future changes to address #2084.

- Add `EXTRA_CXXFLAGS` to the `Makefile` to inject `-m32` for compiling in 32-bit mode.
- Test 32-bit and 64-bit in CI on Ubuntu requiring installation of additional dependencies. (Dependencies are installed with the `:i386` architecture qualifier for 32-bit.)