### PR TITLE
build(meson): copy MountTest.MultibytesPathName files

### DIFF
--- a/test/www/meson.build
+++ b/test/www/meson.build
@@ -5,3 +5,4 @@
 configure_file(input: 'empty_file', output: 'empty_file', copy: true)
 configure_file(input: 'file',       output: 'file',       copy: true)
 subdir('dir')
+subdir('日本語Dir')

--- a/test/www/日本語Dir/meson.build
+++ b/test/www/日本語Dir/meson.build
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Andrea Pappacoda
+# SPDX-License-Identifier: MIT
+
+configure_file(input: '日本語File.txt', output: '日本語File.txt', copy: true)


### PR DESCRIPTION
Fixes the test suite in Meson.