### PR TITLE
Control exit-time destructors with new static variable macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ test/httplib.cc
 test/httplib.h
 test/test
 test/server_fuzzer
+test/test_no_exit_time_dtors
 test/test_proxy
 test/test_split
 test/test.xcodeproj/xcuser*

--- a/README.md
+++ b/README.md
@@ -963,6 +963,16 @@ Include `httplib.h` before `Windows.h` or include `Windows.h` by defining `WIN32
 > [!NOTE]
 > Windows 8 or lower, Visual Studio 2015 or lower, and Cygwin and MSYS2 including MinGW are neither supported nor tested.
 
+### Exit-time destructors
+
+By default, the library relies on exit-time destructors for the cleanup of its static objects when the program terminates. To disable these exit-time destructors, define the preprocessor macro `CPPHTTPLIB_NO_EXIT_TIME_DESTRUCTORS` before including `httplib.h`.
+
+> [!NOTE]
+> When exit-time destructors are disabled, all static variables are allocated on the heap and are not deleted, to prevent their destructors from being called at exit time. This results in purposeful memory leaks, but since the program is exiting, it typically does not affect the application's behavior.
+
+> [!NOTE]
+> If you use `std::atexit()` to register a function that accesses client or server objects from this library, it is recommended to disable exit-time destructors. This ensures that the objects remain valid when your registered function runs, avoiding potential issues with destructors being called before your function executes.
+
 License
 -------
 

--- a/httplib.h
+++ b/httplib.h
@@ -5100,16 +5100,15 @@ inline std::string random_string(size_t length) {
   constexpr const char data[] =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-  // std::random_device might actually be deterministic on some
-  // platforms, but due to lack of support in the c++ standard library,
-  // doing better requires either some ugly hacks or breaking portability.
-  static std::random_device seed_gen;
-
-  // Request 128 bits of entropy for initialization
-  static std::seed_seq seed_sequence{seed_gen(), seed_gen(), seed_gen(),
-                                     seed_gen()};
-
-  static std::mt19937 engine(seed_sequence);
+  static thread_local std::mt19937 engine([]() {
+    // std::random_device might actually be deterministic on some
+    // platforms, but due to lack of support in the c++ standard library,
+    // doing better requires either some ugly hacks or breaking portability.
+    std::random_device seed_gen;
+    // Request 128 bits of entropy for initialization
+    std::seed_seq seed_sequence{seed_gen(), seed_gen(), seed_gen(), seed_gen()};
+    return std::mt19937(seed_sequence);
+  }());
 
   std::string result;
   for (size_t i = 0; i < length; i++) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,7 +18,7 @@ ZLIB_SUPPORT = -DCPPHTTPLIB_ZLIB_SUPPORT -lz
 BROTLI_DIR = $(PREFIX)/opt/brotli
 BROTLI_SUPPORT = -DCPPHTTPLIB_BROTLI_SUPPORT -I$(BROTLI_DIR)/include -L$(BROTLI_DIR)/lib -lbrotlicommon -lbrotlienc -lbrotlidec
 
-TEST_ARGS = gtest/src/gtest-all.cc gtest/src/gtest_main.cc -Igtest -Igtest/include $(OPENSSL_SUPPORT) $(ZLIB_SUPPORT) $(BROTLI_SUPPORT) -pthread -lcurl
+TEST_ARGS = gtest_main.o gtest-all.o -Igtest -Igtest/include $(OPENSSL_SUPPORT) $(ZLIB_SUPPORT) $(BROTLI_SUPPORT) -pthread -lcurl
 
 # By default, use standalone_fuzz_target_runner.
 # This runner does no fuzzing, but simply executes the inputs
@@ -33,19 +33,30 @@ REALPATH = $(shell which grealpath 2>/dev/null || which realpath 2>/dev/null)
 STYLE_CHECK_FILES = $(filter-out httplib.h httplib.cc, \
 	$(wildcard example/*.h example/*.cc fuzzing/*.h fuzzing/*.cc *.h *.cc ../httplib.h))
 
-all : test test_split
+all : test test_no_exit_time_dtors test_split
 	./test
+	GTEST_FILTER="ExitTimeDtorsTest.*" ./test_no_exit_time_dtors
 
 proxy : test_proxy
 	./test_proxy
 
-test : test.cc include_httplib.cc ../httplib.h Makefile cert.pem
+gtest-all.o : gtest/src/gtest-all.cc
+	$(CXX) -c -o $@ $(CXXFLAGS) -Igtest -Igtest/include $<
+
+gtest_main.o : gtest/src/gtest_main.cc
+	$(CXX) -c -o $@ $(CXXFLAGS) -Igtest -Igtest/include $<
+
+test : gtest_main.o gtest-all.o test.cc include_httplib.cc ../httplib.h Makefile cert.pem
 	$(CXX) -o $@ -I.. $(CXXFLAGS) test.cc include_httplib.cc $(TEST_ARGS)
 	@file $@
 
+test_no_exit_time_dtors : gtest_main.o gtest-all.o test.cc ../httplib.h Makefile cert.pem
+	$(CXX) -o $@ -I.. $(CXXFLAGS) -DCPPHTTPLIB_NO_EXIT_TIME_DESTRUCTORS \
+		$(if $(findstring clang,$(CXX)),-Wexit-time-destructors -Werror=exit-time-destructors) test.cc $(TEST_ARGS)
+
 # Note: The intention of test_split is to verify that it works to compile and
 # link the split httplib.h, so there is normally no need to execute it.
-test_split : test.cc ../httplib.h httplib.cc Makefile cert.pem
+test_split : gtest_main.o gtest-all.o test.cc ../httplib.h httplib.cc Makefile cert.pem
 	$(CXX) -o $@ $(CXXFLAGS) test.cc httplib.cc $(TEST_ARGS)
 
 check_abi:
@@ -73,7 +84,7 @@ style_check: $(STYLE_CHECK_FILES)
 		echo "All files are properly formatted."; \
 	fi
 
-test_proxy : test_proxy.cc ../httplib.h Makefile cert.pem
+test_proxy : gtest_main.o gtest-all.o test_proxy.cc ../httplib.h Makefile cert.pem
 	$(CXX) -o $@ -I.. $(CXXFLAGS) test_proxy.cc $(TEST_ARGS)
 
 # Runs server_fuzzer.cc based on value of $(LIB_FUZZING_ENGINE).
@@ -98,5 +109,5 @@ cert.pem:
 	./gen-certs.sh
 
 clean:
-	rm -rf test test_split test_proxy server_fuzzer *.pem *.0 *.o *.1 *.srl httplib.h httplib.cc _build* *.dSYM
+	rm -rf test test_no_exit_time_dtors test_split test_proxy server_fuzzer *.pem *.0 *.o *.1 *.srl httplib.h httplib.cc _build* *.dSYM
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -40,12 +40,14 @@ using namespace httplib;
 const char *HOST = "localhost";
 const int PORT = 1234;
 
-const string LONG_QUERY_VALUE = string(25000, '@');
-const string LONG_QUERY_URL = "/long-query-value?key=" + LONG_QUERY_VALUE;
+CPPHTTPLIB_DEFINE_STATIC(const string, LONG_QUERY_VALUE, (25000, '@'));
+CPPHTTPLIB_DEFINE_STATIC(const string, LONG_QUERY_URL,
+                         ("/long-query-value?key=" + LONG_QUERY_VALUE));
 
-const std::string JSON_DATA = "{\"hello\":\"world\"}";
+CPPHTTPLIB_DEFINE_STATIC(const string, JSON_DATA, ("{\"hello\":\"world\"}"));
 
-const string LARGE_DATA = string(1024 * 1024 * 100, '@'); // 100MB
+CPPHTTPLIB_DEFINE_STATIC(const string, LARGE_DATA,
+                         (1024 * 1024 * 100, '@')); // 100MB
 
 MultipartFormData &get_file_value(MultipartFormDataItems &files,
                                   const char *key) {


### PR DESCRIPTION
Introduce the `CPPHTTPLIB_DEFINE_STATIC` macro to define static variables with optional dynamic allocation, enabled by defining `CPPHTTPLIB_NO_EXIT_TIME_DESTRUCTORS`. Dynamic allocation prevents running their destructors, which avoids race conditions with atexit handlers that may depend on them. Also includes a test to verify this functionality and updates the documentation to explain the usage and rationale for disabling exit-time destructors.

Note: gtest v1.12.1 does not include the fix for exit-time destructors (after finding the last C++11 version, I forgot to re-check that it includes the relevant commit), necessitating compiling gtest separately and without `-Wexit-time-destructors`.

Resolves #2097.

**To do:**
- [X] Add regression test for #2097.
- [X] Compile with `-Wexit-time-destructors`. (Requries: #2103 #2100)
- [X] Add documentation.