### PR TITLE
Add armeabi-v7a architecture support with optimized flags for Cross-Compile method

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,10 @@
 CXX = clang++
-CXXFLAGS = -g -std=c++11 -I. -Wall -Wextra -Wtype-limits -Wconversion -Wshadow $(EXTRA_CXXFLAGS) # -fno-exceptions -DCPPHTTPLIB_NO_EXCEPTIONS -fsanitize=address
+ifeq ($(BUILD_ARC), armeabi-v7a)
+    CXXFLAGS = -g -std=c++11 -I. -Wall -Wextra -Wtype-limits -Wconversion -Wshadow -march=armv7-a
+else
+    CXXFLAGS = -g -std=c++11 -I. -Wall -Wextra -Wtype-limits -Wconversion -Wshadow # -fno-exceptions -DCPPHTTPLIB_NO_EXCEPTIONS -fsanitize=address
+endif
+$(info    CXXFLAGS is $(CXXFLAGS))
 
 PREFIX ?= $(shell brew --prefix)
 


### PR DESCRIPTION
Optimize build flags for armeabi-v7a architecture，Conditionally set CXXFLAGS based on BUILD_ARC value，we want to add a compilation guide to help developers use the library