### PR TITLE
build(meson): add non_blocking_getaddrinfo option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,11 +16,12 @@ project(
   meson_version: '>=0.62.0'
 )
 
+cxx = meson.get_compiler('cpp')
+
 # Check just in case downstream decides to edit the source
 # and add a project version
 version = meson.project_version()
 if version == 'undefined'
-  cxx = meson.get_compiler('cpp')
   version = cxx.get_define('CPPHTTPLIB_VERSION',
     prefix: '#include <httplib.h>',
     include_directories: include_directories('.')).strip('"')
@@ -63,6 +64,21 @@ endforeach
 if brotli_found_all
   deps += brotli_deps
   args += '-DCPPHTTPLIB_BROTLI_SUPPORT'
+endif
+
+async_ns_opt = get_option('cpp-httplib_non_blocking_getaddrinfo')
+
+if host_machine.system() == 'windows'
+  async_ns_dep = cxx.find_library('ws2_32', required: async_ns_opt)
+elif host_machine.system() == 'darwin'
+  async_ns_dep = dependency('appleframeworks', modules: ['CFNetwork'], required: async_ns_opt)
+else
+  async_ns_dep = cxx.find_library('anl', required: async_ns_opt)
+endif
+
+if async_ns_dep.found()
+  deps += async_ns_dep
+  args += '-DCPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO'
 endif
 
 cpp_httplib_dep = dependency('', required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,5 +6,6 @@ option('cpp-httplib_openssl', type: 'feature', value: 'auto', description: 'Enab
 option('cpp-httplib_zlib',    type: 'feature', value: 'auto', description: 'Enable zlib support')
 option('cpp-httplib_brotli',  type: 'feature', value: 'auto', description: 'Enable Brotli support')
 option('cpp-httplib_macosx_keychain', type: 'feature', value: 'auto', description: 'Enable loading certs from the Keychain on Apple devices')
+option('cpp-httplib_non_blocking_getaddrinfo', type: 'feature', value: 'auto', description: 'Enable asynchronous name lookup')
 option('cpp-httplib_compile', type: 'boolean', value: false,  description: 'Split the header into a compilable header & source file (requires python3)')
 option('cpp-httplib_test',    type: 'boolean', value: false,  description: 'Build tests')


### PR DESCRIPTION
This new option automatically enables the new non-blocking name resolution when the appropriate libraries are found, automatically adding them to the list of required dependencies. It will gracefully fall back to the old behaviour when no library is found.

This complements commit ea850cbfa74e2dff228c49bf94542ce5331d73b5.