### PR TITLE
build(meson): simplify build options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ project(
     'b_lto=true',
     'warning_level=3'
   ],
-  meson_version: '>=0.62.0'
+  meson_version: '>=0.63.0'
 )
 
 cxx = meson.get_compiler('cpp')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,10 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
-option('cpp-httplib_openssl', type: 'feature', value: 'auto', description: 'Enable OpenSSL support')
-option('cpp-httplib_zlib',    type: 'feature', value: 'auto', description: 'Enable zlib support')
-option('cpp-httplib_brotli',  type: 'feature', value: 'auto', description: 'Enable Brotli support')
-option('cpp-httplib_macosx_keychain', type: 'feature', value: 'auto', description: 'Enable loading certs from the Keychain on Apple devices')
-option('cpp-httplib_non_blocking_getaddrinfo', type: 'feature', value: 'auto', description: 'Enable asynchronous name lookup')
-option('cpp-httplib_compile', type: 'boolean', value: false,  description: 'Split the header into a compilable header & source file (requires python3)')
-option('cpp-httplib_test',    type: 'boolean', value: false,  description: 'Build tests')
+option('openssl', type: 'feature', value: 'auto', description: 'Enable OpenSSL support')
+option('zlib',    type: 'feature', value: 'auto', description: 'Enable zlib support')
+option('brotli',  type: 'feature', value: 'auto', description: 'Enable Brotli support')
+option('macosx_keychain', type: 'feature', value: 'auto', description: 'Enable loading certs from the Keychain on Apple devices')
+option('non_blocking_getaddrinfo', type: 'feature', value: 'auto', description: 'Enable asynchronous name lookup')
+option('compile', type: 'boolean', value: false,  description: 'Split the header into a compilable header & source file (requires python3)')
+option('test',    type: 'boolean', value: false,  description: 'Build tests')
+
+# Old option names
+option('cpp-httplib_openssl', type: 'feature', deprecated: 'openssl')
+option('cpp-httplib_zlib',    type: 'feature', deprecated: 'zlib')
+option('cpp-httplib_brotli',  type: 'feature', deprecated: 'brotli')
+option('cpp-httplib_macosx_keychain', type: 'feature', deprecated: 'macosx_keychain')
+option('cpp-httplib_non_blocking_getaddrinfo', type: 'feature', deprecated: 'non_blocking_getaddrinfo')
+option('cpp-httplib_compile', type: 'boolean', value: false, deprecated: 'compile')
+option('cpp-httplib_test',    type: 'boolean', value: false, deprecated: 'test')


### PR DESCRIPTION
The "cpp-httplib_" prefix of build options is now dropped, as Meson build options are already namespaced for each project. The old names remain as deprecated aliases for the new ones.