### PR TITLE
build(meson): warn/fail on 32-bit machines

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,14 @@ project(
 
 cxx = meson.get_compiler('cpp')
 
+if cxx.sizeof('void *') != 8
+  if host_machine.system() == 'windows'
+    error('unsupported architecture: cpp-httplib doesn\'t support 32-bit Windows. Please use a 64-bit compiler.')
+  else
+    warning('cpp-httplib doesn\'t support 32-bit platforms. Please use a 64-bit compiler.')
+  endif
+endif
+
 # Check just in case downstream decides to edit the source
 # and add a project version
 version = meson.project_version()


### PR DESCRIPTION
On 32-bit Windows, `meson setup` fails with an unclear error:

    meson.build:25:16: ERROR: Could not get define 'CPPHTTPLIB_VERSION'

The actual problem is that `httplib.h` `#error`s out.

Have the Meson logic explicitly check for a 32-bit host and warn or error, matching the check in `httplib.h`.  Phrase the Windows error in a way that triggers WrapDB CI's unsupported architecture check.