### PR TITLE
Prevent re-encoding of path when following a redirect

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8661,10 +8661,11 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
   if (next_host.empty()) { next_host = host_; }
   if (next_path.empty()) { next_path = "/"; }
 
-  auto path = detail::decode_path(next_path, true) + next_query;
+  auto path = next_path + next_query;
 
   // Same host redirect - use current client
   if (next_scheme == scheme && next_host == host_ && next_port == port_) {
+    this->set_path_encode(false); //Disable path encoding, redirects should already be encoded
     return detail::redirect(*this, req, res, path, location, error);
   }
 
@@ -8756,7 +8757,7 @@ inline void ClientImpl::setup_redirect_client(ClientType &client) {
   client.set_keep_alive(keep_alive_);
   client.set_follow_location(
       true); // Enable redirects to handle multi-step redirects
-  client.set_path_encode(path_encode_);
+  client.set_path_encode(false); //Disable encoding, redirects should already be encoded
   client.set_compress(compress_);
   client.set_decompress(decompress_);
 

--- a/httplib.h
+++ b/httplib.h
@@ -8665,7 +8665,8 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
 
   // Same host redirect - use current client
   if (next_scheme == scheme && next_host == host_ && next_port == port_) {
-    this->set_path_encode(false); //Disable path encoding, redirects should already be encoded
+    this->set_path_encode(
+        false); //Disable path encoding, redirects should already be encoded
     return detail::redirect(*this, req, res, path, location, error);
   }
 
@@ -8757,7 +8758,8 @@ inline void ClientImpl::setup_redirect_client(ClientType &client) {
   client.set_keep_alive(keep_alive_);
   client.set_follow_location(
       true); // Enable redirects to handle multi-step redirects
-  client.set_path_encode(false); //Disable encoding, redirects should already be encoded
+  client.set_path_encode(
+      false); //Disable encoding, redirects should already be encoded
   client.set_compress(compress_);
   client.set_decompress(decompress_);
 

--- a/httplib.h
+++ b/httplib.h
@@ -8666,7 +8666,7 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
   // Same host redirect - use current client
   if (next_scheme == scheme && next_host == host_ && next_port == port_) {
     this->set_path_encode(
-        false); //Disable path encoding, redirects should already be encoded
+        false); // Disable path encoding, redirects should already be encoded
     return detail::redirect(*this, req, res, path, location, error);
   }
 
@@ -8759,7 +8759,7 @@ inline void ClientImpl::setup_redirect_client(ClientType &client) {
   client.set_follow_location(
       true); // Enable redirects to handle multi-step redirects
   client.set_path_encode(
-      false); //Disable encoding, redirects should already be encoded
+      false); // Disable encoding, redirects should already be encoded
   client.set_compress(compress_);
   client.set_decompress(decompress_);
 


### PR DESCRIPTION
The current implementation re-encodes the path and query when following a redirect, unless `path_encode_` is set to `false`.
However, the query is never decoded. This causes issues if the query contains a space `' '` (encoded as `'+'`). Since it's never decoded, but later re-encoded, the space `' '` (encoded as `'+'`) gets changed into a `'+'` (encoded as `'%2B'`). Thus, the value of the parameter gets changed.

This fixes it by disabling path encoding on the redirect client.