### PR TITLE
Fix mingw-w64 building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,22 @@ if(CMAKE_SIZEOF_VOID_P LESS 8)
 	message(WARNING "Pointer size ${CMAKE_SIZEOF_VOID_P} is not supported. Please use a 64-bit compiler.")
 endif()
 
+# check CreateFile2 for mingw
+INCLUDE(CheckCXXSourceCompiles)
+if(MINGW)
+	check_cxx_source_compiles("#include <windows.h>
+	#include <fileapi.h>
+	int main() {
+		HANDLE h = CreateFile2(L\"nul\", GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, NULL);
+		if (h != INVALID_HANDLE_VALUE) CloseHandle(h);
+		return 0;
+	}" HAVE_CREATEFILE2)
+
+	if(HAVE_CREATEFILE2)
+		add_compile_definitions(HAVE_CREATEFILE2)
+	endif()
+endif()
+
 # Set some variables that are used in-tree and while building based on our options
 set(HTTPLIB_IS_COMPILED ${HTTPLIB_COMPILE})
 set(HTTPLIB_IS_USING_CERTS_FROM_MACOSX_KEYCHAIN ${HTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN})

--- a/httplib.h
+++ b/httplib.h
@@ -3078,8 +3078,13 @@ inline bool mmap::open(const char *path) {
   auto wpath = u8string_to_wstring(path);
   if (wpath.empty()) { return false; }
 
+#if defined(HAVE_CREATEFILE2)
   hFile_ = ::CreateFile2(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ,
                          OPEN_EXISTING, NULL);
+#else
+  hFile_ = ::CreateFileW(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
+                         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+#endif
 
   if (hFile_ == INVALID_HANDLE_VALUE) { return false; }
 


### PR DESCRIPTION
Since v0.23.1 cpp-httplib can not be complied with mingw-w64. The error message looks like this:

```console
> D:\a\_temp\msys64\mingw64\bin\x86_64-w64-mingw32-g++ -c -m64 -std=c++11 -IC:\Users\runneradmin\AppData\Local\.xmake\packages\c\cpp-httplib\v0.25.0\cd2fddbf26ef4285ab9708e0209f52e0\include -o D:\a\_temp\msys64\tmp\.xmake\250808\_97BBC115DC5B437086AEA0BA215614B0.o D:\a\_temp\msys64\tmp\.xmake\250808\_7D0C25F8195246278D1C039D74425C23.cpp
> checking for c++ includes(httplib.h)
> checking for c++ snippet(test)
checkinfo: ...amdir\core\sandbox\modules\import\core\tool\compiler.lua:84: @programdir\modules\core\tools\gcc.lua:1035: In file included from D:\a\_temp\msys64\tmp\.xmake\250808\_7D0C25F8195246278D1C039D74425C23.cpp:2:
C:\Users\runneradmin\AppData\Local\.xmake\packages\c\cpp-httplib\v0.25.0\cd2fddbf26ef4285ab9708e0209f52e0\include/httplib.h: In member function 'bool httplib::detail::mmap::open(const char*)':
C:\Users\runneradmin\AppData\Local\.xmake\packages\c\cpp-httplib\v0.25.0\cd2fddbf26ef4285ab9708e0209f52e0\include/httplib.h:3081:14: error: '::CreateFile2' has not been declared; did you mean 'CreateFileW'?
 3081 |   hFile_ = ::CreateFile2(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ,
      |              ^~~~~~~~~~~
      |              CreateFileW
```

<img width="1436" height="215" alt="image" src="https://github.com/user-attachments/assets/85d17927-56e7-4b88-8c77-70ce25df9c8c" />

You can find the whole CI log here: [link](https://github.com/xmake-io/xmake-repo/actions/runs/16819883022/job/47644569540?pr=7837)

The function `::CreateFile2` needs `_WIN32_WINNT >= 0x0602`, however mingw-w64 in our CI cannot detect the correct value of it and set the value to `0x0600` and `0x0502`, that makes the code cannot use `CreateFile2`.

Because cpp-httplib requires Windows 10 or newer, let's just set the `_WIN32_WINNT` to `_WIN32_WINNT_WIN10` if we are using mingw-w64. Now mingw-w64 should compile the code.