### PR TITLE
Initialize start time for server

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8265,6 +8265,7 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
   if (!line_reader.getline()) { return false; }
 
   Request req;
+  req.start_time_ = std::chrono::steady_clock::now();
 
   Response res;
   res.version = "HTTP/1.1";

--- a/test/test.cc
+++ b/test/test.cc
@@ -5805,9 +5805,7 @@ TEST_F(ServerTest, TooManyRedirect) {
   EXPECT_EQ(Error::ExceedRedirectCount, res.error());
 }
 
-TEST_F(ServerTest, StartTime) {
-  auto res = cli_.Get("/test-start-time");
-}
+TEST_F(ServerTest, StartTime) { auto res = cli_.Get("/test-start-time"); }
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
 TEST_F(ServerTest, Gzip) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -3200,9 +3200,10 @@ protected:
              [&](const Request & /*req*/, Response &res) {
                res.set_content("abcdefg", "text/plain");
              })
-        .Get("/custom",
+        .Get("/test-start-time",
              [&](const Request &req, Response &res) {
-               if (custom_fn) { custom_fn(req, res); }
+               EXPECT_NE(req.start_time_,
+                         std::chrono::steady_clock::time_point::min());
              })
         .Get("/with-range-customized-response",
              [&](const Request & /*req*/, Response &res) {
@@ -3598,7 +3599,6 @@ protected:
 #endif
   thread t_;
   std::vector<thread> request_threads_;
-  std::function<void(const Request &, Response &)> custom_fn;
 };
 
 TEST_F(ServerTest, GetMethod200) {
@@ -5806,10 +5806,7 @@ TEST_F(ServerTest, TooManyRedirect) {
 }
 
 TEST_F(ServerTest, StartTime) {
-  custom_fn = [](const Request &req, Response &res) {
-    EXPECT_NE(req.start_time_, std::chrono::steady_clock::time_point::min());
-  };
-  auto res = cli_.Get("/custom");
+  auto res = cli_.Get("/test-start-time");
 }
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT


### PR DESCRIPTION
By initializing start_time_ for server, I hope to measure the time taken to process a request at the end maybe in the set_logger callback and print it.

I only see current usage in client with server retaining the inital min value