### PR TITLE
Fix: handle EAI_ALLDONE from gai_suspend in getaddrinfo_with_timeout

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3776,7 +3776,7 @@ inline int getaddrinfo_with_timeout(const char *node, const char *service,
   int wait_result =
       gai_suspend((const struct gaicb *const *)requests, 1, &timeout);
 
-  if (wait_result == 0) {
+  if (wait_result == 0 || wait_result == EAI_ALLDONE) {
     // Completed successfully, get the result
     int gai_result = gai_error(&request);
     if (gai_result == 0) {


### PR DESCRIPTION
According to glibc docs, gai_suspend may return EAI_ALLDONE (-103) to indicate that all requests are already complete. This is not an error condition and should be treated the same as 0 (success). 
Related issue: #2225 