### PR TITLE
Fix UB by use of dangling references in getaddrinfo_with_timeout

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3798,31 +3798,51 @@ inline int getaddrinfo_with_timeout(const char *node, const char *service,
   }
 #else
   // Fallback implementation using thread-based timeout for other Unix systems
-  std::mutex result_mutex;
-  std::condition_variable result_cv;
-  auto completed = false;
-  auto result = EAI_SYSTEM;
-  struct addrinfo *result_addrinfo = nullptr;
 
-  std::thread resolve_thread([&]() {
-    auto thread_result = getaddrinfo(node, service, hints, &result_addrinfo);
+  struct GetAddrInfoState {
+    std::mutex mutex{};
+    std::condition_variable result_cv;
+    bool completed{false};
+    int result{0};
+    std::string node{};
+    std::string service{};
+    struct addrinfo hints {};
+    struct addrinfo *info{nullptr};
+  };
 
-    std::lock_guard<std::mutex> lock(result_mutex);
-    result = thread_result;
-    completed = true;
-    result_cv.notify_one();
+  // Allocate on the heap, so the resolver thread can keep using the data.
+  auto state = std::make_shared<GetAddrInfoState>();
+
+  state->result = EAI_SYSTEM;
+  state->node = node;
+  state->service = service;
+  state->hints.ai_flags = hints->ai_flags;
+  state->hints.ai_family = hints->ai_family;
+  state->hints.ai_socktype = hints->ai_socktype;
+  state->hints.ai_protocol = hints->ai_protocol;
+  // The remaining fields of "hints" must be zeroed, so do not copy them.
+
+  std::thread resolve_thread([=]() {
+    auto thread_result = getaddrinfo(
+        state->node.c_str(), state->service.c_str(), hints, &state->info);
+
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->result = thread_result;
+    state->completed = true;
+    state->result_cv.notify_one();
   });
 
   // Wait for completion or timeout
-  std::unique_lock<std::mutex> lock(result_mutex);
-  auto finished = result_cv.wait_for(lock, std::chrono::seconds(timeout_sec),
-                                     [&] { return completed; });
+  std::unique_lock<std::mutex> lock(state->mutex);
+  auto finished =
+      state->result_cv.wait_for(lock, std::chrono::seconds(timeout_sec),
+                                [&] { return state->completed; });
 
   if (finished) {
     // Operation completed within timeout
     resolve_thread.join();
-    *res = result_addrinfo;
-    return result;
+    *res = state->info;
+    return state->result;
   } else {
     // Timeout occurred
     resolve_thread.detach(); // Let the thread finish in background

--- a/test/test.cc
+++ b/test/test.cc
@@ -1331,6 +1331,27 @@ TEST(RangeTest, FromHTTPBin_Online) {
   }
 }
 
+TEST(GetAddrInfoDanglingRefTest, LongTimeout) {
+  auto host = "unresolvableaddress.local";
+  auto path = std::string{"/"};
+
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  auto port = 443;
+  SSLClient cli(host, port);
+#else
+  auto port = 80;
+  Client cli(host, port);
+#endif
+  cli.set_connection_timeout(1);
+
+  {
+    auto res = cli.Get(path);
+    ASSERT_FALSE(res);
+  }
+
+  std::this_thread::sleep_for(8s);
+}
+
 TEST(ConnectionErrorTest, InvalidHost) {
   auto host = "-abcde.com";
 


### PR DESCRIPTION
The following code makes use of several dangling references, when the call to `getaddrinfo` times out:

https://github.com/yhirose/cpp-httplib/blob/89c932f313c6437c38f2982869beacc89c2f2246/httplib.h#L3800-L3830

Consider the following scenario:
1. A low timeout of e.g. 1 second is chosen, `getaddrinfo` takes 5 seconds to fail for an address that does not resolve.
2. As a consequence the `wait_for` call returns with `finished` containing `false`, the last value of `completed`.
3. The following else branch is executed and the `resolve_thread` is detached.
4. All local variables are destroyed.
5. After 4 seconds `getaddrinfo` returns control back to the caller (the resolve thread).
6. The lock guard locks `result_mutex`, which is destroyed (other variables are read from/written to as well).

The following test will fail on the current master branch:

```cpp
TEST(GetAddrInfoDanglingRefTest, LongTimeout) {
  auto host = "unresolvableaddress.local";
  auto path = std::string{"/"};

#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
  auto port = 443;
  SSLClient cli(host, port);
#else
  auto port = 80;
  Client cli(host, port);
#endif
  cli.set_connection_timeout(1);

  {
    auto res = cli.Get(path);
    ASSERT_FALSE(res);
  }

  std::this_thread::sleep_for(8s);
}
```

Since it's UB, you can trigger it more easily like this e.g.:

```cpp
  std::thread resolve_thread([&]() {
    auto thread_result = getaddrinfo(node, service, hints, &result_addrinfo);
    {std::lock_guard<std::mutex> lock(result_mutex);
    result = thread_result;
    completed = true;
    result_cv.notify_one();}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
    {std::lock_guard<std::mutex> lock(result_mutex);}
  });
```