### PR TITLE
Fix error reporting in SSLClient

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -10911,7 +10911,11 @@ inline long SSLClient::get_openssl_verify_result() const {
 inline SSL_CTX *SSLClient::ssl_context() const { return ctx_; }
 
 inline bool SSLClient::create_and_connect_socket(Socket &socket, Error &error) {
-  return is_valid() && ClientImpl::create_and_connect_socket(socket, error);
+  if (!is_valid()) {
+    error = Error::SSLConnection;
+    return false;
+  }
+  return ClientImpl::create_and_connect_socket(socket, error);
 }
 
 // Assumes that socket_mutex_ is locked and that there are no requests in flight


### PR DESCRIPTION
When the `SSLClient` is used to connect to a plain-HTTP server (which can happen in clients due to some end-user misconfiguration) it can return a failure from the `send()` call without setting the `Error` reference to the corresponding error code. This can cause problems to callers, that may expect that, when the check like this is passed on the response:

```c++
if (res.error() == Error::Success)
```

then they can access the response contents with `res.value()`. When `SSLClient`'s connection fails - the contents `unique_ptr` is not set and an attemt to access it causes UB.

This change fixes the `SSLClient::create_and_connect_socket` method making sure that, the `Error` value is set correctly when the `is_valid()` check fails.