### PR TITLE
ETag for static file server

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7942,12 +7942,13 @@ inline bool Server::handle_file_request(const Request &req, Response &res) {
   for (const auto &entry : base_dirs_) {
     // Prefix match
     if (!req.path.compare(0, entry.mount_point.size(), entry.mount_point)) {
-      std::string sub_path = "/" + req.path.substr(entry.mount_point.size());
+      const std::string sub_path =
+          "/" + req.path.substr(entry.mount_point.size());
       if (detail::is_valid_path(sub_path)) {
         auto path = entry.base_dir + sub_path;
         if (path.back() == '/') { path += "index.html"; }
 
-        detail::FileStat stat(path);
+        const detail::FileStat stat(path);
 
         if (stat.is_dir()) {
           res.set_redirect(sub_path + "/", StatusCode::MovedPermanently_301);
@@ -7965,7 +7966,7 @@ inline bool Server::handle_file_request(const Request &req, Response &res) {
             return false;
           }
 
-          if (is_etag_enabled)
+          if (is_etag_enabled) {
             /*
              * The HTTP request header If-Match and If-None-Match can be used
              * with other methods where they have the meaning to only execute if
@@ -8045,6 +8046,7 @@ inline bool Server::handle_file_request(const Request &req, Response &res) {
                 }
               }
             }
+          }
 
           res.set_content_provider(
               mm->size(),

--- a/test/test.cc
+++ b/test/test.cc
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <fstream>
 #include <future>
@@ -11460,8 +11461,8 @@ TEST(is_etag_enabled, getter_and_setter) {
   EXPECT_TRUE(svr.get_is_etag_enabled());
 }
 
-TEST(StaticFileSever, If_Match) {
-  detail::FileStat stat("./www/file");
+TEST(StaticFileSever, IfMatch) {
+  const detail::FileStat stat("./www/file");
   ASSERT_TRUE(stat.is_file());
   auto mm = std::make_shared<detail::mmap>("./www/file");
   ASSERT_TRUE(mm->is_open());
@@ -11475,7 +11476,8 @@ TEST(StaticFileSever, If_Match) {
    * 1: is_etag_enabled = true
    */
   for (std::uint8_t i = 0; i < 2; ++i) {
-    for (const std::string header_if_match : std::initializer_list<std::string>{
+    for (const std::string &header_if_match :
+         std::initializer_list<std::string>{
              R"("wcupin")", "  *  ", R"("r", *)", R"(*, "x")", etag,
              R"("o", )" + etag, etag + R"(, "a")"}) {
       httplib::Server svr;
@@ -11522,8 +11524,8 @@ TEST(StaticFileSever, If_Match) {
   }
 }
 
-TEST(StaticFileSever, If_None_Match) {
-  detail::FileStat stat("./www/file");
+TEST(StaticFileSever, IfNoneMatch) {
+  const detail::FileStat stat("./www/file");
   ASSERT_TRUE(stat.is_file());
   auto mm = std::make_shared<detail::mmap>("./www/file");
   ASSERT_TRUE(mm->is_open());
@@ -11537,7 +11539,7 @@ TEST(StaticFileSever, If_None_Match) {
    * 1: is_etag_enabled = true
    */
   for (std::uint8_t i = 0; i < 2; ++i) {
-    for (const std::string header_if_none_match :
+    for (const std::string &header_if_none_match :
          std::initializer_list<std::string>{"  *  ", R"("f", *)", R"(*, "i")",
                                             etag, R"("d", )" + etag,
                                             "W/" + etag + R"(, "g")"}) {


### PR DESCRIPTION
Programmed feature https://github.com/yhirose/cpp-httplib/issues/2242. First off, the static file server now sends HTTP response header "ETag". Following HTTP requests by the client which include HTTP request header "If-None-Match" are only served if the value for HTTP response header "ETag" is not included in the value of HTTP request header "If-None-Match", otherwise an HTTP response with status code 304 is served which includes the HTTP response header "ETag" again that would have been sent with a normal status code of 200.

Useful resources:
- https://http.dev/caching
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-None-Match
- https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified