### PR TITLE
Fix struct member initialization issue in getaddrinfo_with_timeout 

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3809,22 +3809,30 @@ inline int getaddrinfo_with_timeout(const char *node, const char *service,
   // Fallback implementation using thread-based timeout for other Unix systems
 
   struct GetAddrInfoState {
+    ~GetAddrInfoState() {
+      if (info) { freeaddrinfo(info); }
+    }
+
     std::mutex mutex;
     std::condition_variable result_cv;
     bool completed = false;
     int result = EAI_SYSTEM;
-    std::string node = node;
-    std::string service = service;
-    struct addrinfo hints = hints;
+    std::string node;
+    std::string service;
+    struct addrinfo hints;
     struct addrinfo *info = nullptr;
   };
 
   // Allocate on the heap, so the resolver thread can keep using the data.
   auto state = std::make_shared<GetAddrInfoState>();
+  state->node = node;
+  state->service = service;
+  state->hints = *hints;
 
-  std::thread resolve_thread([=]() {
-    auto thread_result = getaddrinfo(
-        state->node.c_str(), state->service.c_str(), hints, &state->info);
+  std::thread resolve_thread([state]() {
+    auto thread_result =
+        getaddrinfo(state->node.c_str(), state->service.c_str(), &state->hints,
+                    &state->info);
 
     std::lock_guard<std::mutex> lock(state->mutex);
     state->result = thread_result;
@@ -3842,6 +3850,7 @@ inline int getaddrinfo_with_timeout(const char *node, const char *service,
     // Operation completed within timeout
     resolve_thread.join();
     *res = state->info;
+    state->info = nullptr; // Pass ownership to caller
     return state->result;
   } else {
     // Timeout occurred


### PR DESCRIPTION
The current member initialization for `struct GetAddrInfoState` does not work as the `node` on the right side of the assignment refers to the member `node` of `struct GetAddrInfoState`, which is empty for debug build and uninitialized for optimized build, instead of the `node` the function parameter.

This results in the following `getaddrinfo` getting called with unexpected parameters, thus it is yielding unexpected result. I found this issue on Android, and probably this also applies to platforms other than those in the `#if`.

Also this change fixes a potential memory leak. When timeout is hit on line 3857, and the `getaddrinfo` succeeds in the end, the `state->info` will be assigned to the pointer of a new `struct addrinfo` allocated by `getaddrinfo`, while no one will free that. This change adds a destructor on `GetAddrInfoState` to manage the lifecycle of that. 