### PR TITLE
Use std::move for boundary in set_boundary method

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5618,7 +5618,7 @@ public:
   FormDataParser() = default;
 
   void set_boundary(std::string &&boundary) {
-    boundary_ = boundary;
+    boundary_ = std::move(boundary);
     dash_boundary_crlf_ = dash_ + boundary_ + crlf_;
     crlf_dash_boundary_ = crlf_ + dash_ + boundary_;
   }


### PR DESCRIPTION
Add missing std::move. `boundary` is bound by name inside the function scope so becomes an lvalue. Needs std::move to explicitly have it be an xvalue again.