### PR TITLE
Fix linker error on macOS when using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,14 +269,16 @@ target_include_directories(${PROJECT_NAME} SYSTEM ${_INTERFACE_OR_PUBLIC}
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-# Always require threads
 target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
+		# Always require threads
 		Threads::Threads
 		# Needed for Windows libs on Mingw, as the pragma comment(lib, "xyz") aren't triggered.
 		$<$<PLATFORM_ID:Windows>:ws2_32>
 		$<$<PLATFORM_ID:Windows>:crypt32>
 		# Needed for API from MacOS Security framework
 		"$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>,$<BOOL:${HTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN}>>:-framework CoreFoundation -framework Security>"
+		# Needed for non-blocking getaddrinfo on MacOS
+		"$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_USE_NON_BLOCKING_GETADDRINFO}>>:-framework CFNetwork>"
 		# Can't put multiple targets in a single generator expression or it bugs out.
 		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::common>
 		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>


### PR DESCRIPTION
This pull request fixes an issue where the CMake build was missing linking against `CFNetwork`, which is used in the non-blocking `getaddrinfo` logic on macOS. This wasn't caught in CI because the tests use plain `make` on macOS. 

Example error when building the httplib tests on mac:
```
[1/2] Linking CXX executable test/httplib-test
FAILED: [code=1] test/httplib-test test/httplib-test[1]_tests.cmake /Users/carter/git/cpp-httplib/build/test/httplib-test[1]_tests.cmake
: && /usr/bin/c++ -arch arm64 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -L/opt/homebrew/opt/openssl@3/lib test/CMakeFiles/httplib-test.dir/test.cc.o test/CMakeFiles/httplib-test.dir/include_httplib.cc.o -o test/httplib-test  /opt/homebrew/lib/libgtest_main.a  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libcurl.tbd  -framework CoreFoundation -framework Security  /opt/homebrew/Cellar/brotli/1.2.0/lib/libbrotlicommon.dylib  /opt/homebrew/Cellar/brotli/1.2.0/lib/libbrotlienc.dylib  /opt/homebrew/Cellar/brotli/1.2.0/lib/libbrotlidec.dylib  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libz.tbd  /opt/homebrew/lib/libzstd.a  /opt/homebrew/Cellar/openssl@3/3.6.0/lib/libssl.dylib  /opt/homebrew/Cellar/openssl@3/3.6.0/lib/libcrypto.dylib  /opt/homebrew/lib/libgtest.a  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libcurl.tbd && cd /Users/carter/git/cpp-httplib/build/test && /opt/homebrew/bin/cmake -D TEST_TARGET=httplib-test -D TEST_EXECUTABLE=/Users/carter/git/cpp-httplib/build/test/httplib-test -D TEST_EXECUTOR= -D TEST_WORKING_DIR=/Users/carter/git/cpp-httplib/build/test -D TEST_EXTRA_ARGS= -D TEST_PROPERTIES= -D TEST_PREFIX= -D TEST_SUFFIX= -D TEST_FILTER= -D NO_PRETTY_TYPES=FALSE -D NO_PRETTY_VALUES=FALSE -D TEST_LIST=httplib-test_TESTS -D CTEST_FILE=/Users/carter/git/cpp-httplib/build/test/httplib-test[1]_tests.cmake -D TEST_DISCOVERY_TIMEOUT=5 -D TEST_DISCOVERY_EXTRA_ARGS= -D TEST_XML_OUTPUT_DIR= -P /opt/homebrew/share/cmake/Modules/GoogleTestAddTests.cmake
Undefined symbols for architecture arm64:
  "_CFHostCancelInfoResolution", referenced from:
      httplib::detail::getaddrinfo_with_timeout(char const*, char const*, addrinfo const*, addrinfo**, long) in test.cc.o
  "_CFHostCreateWithName", referenced from:
      httplib::detail::getaddrinfo_with_timeout(char const*, char const*, addrinfo const*, addrinfo**, long) in test.cc.o
  "_CFHostGetAddressing", referenced from:
      httplib::detail::getaddrinfo_with_timeout(char const*, char const*, addrinfo const*, addrinfo**, long)::'lambda'(__CFHost*, CFHostInfoType, CFStreamError const*, void*)::operator()(__CFHost*, CFHostInfoType, CFStreamError const*, void*) const in test.cc.o
  "_CFHostScheduleWithRunLoop", referenced from:
      httplib::detail::getaddrinfo_with_timeout(char const*, char const*, addrinfo const*, addrinfo**, long) in test.cc.o
  "_CFHostSetClient", referenced from:
      httplib::detail::getaddrinfo_with_timeout(char const*, char const*, addrinfo const*, addrinfo**, long) in test.cc.o
      httplib::detail::getaddrinfo_with_timeout(char const*, char const*, addrinfo const*, addrinfo**, long) in test.cc.o
  "_CFHostStartInfoResolution", referenced from:
      httplib::detail::getaddrinfo_with_timeout(char const*, char const*, addrinfo const*, addrinfo**, long) in test.cc.o
  "_CFHostUnscheduleFromRunLoop", referenced from:
      httplib::detail::getaddrinfo_with_timeout(char const*, char const*, addrinfo const*, addrinfo**, long) in test.cc.o
      httplib::detail::getaddrinfo_with_timeout(char const*, char const*, addrinfo const*, addrinfo**, long) in test.cc.o
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```