### PR TITLE
Prevent redefinition of ssize_t

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -205,7 +205,10 @@
 
 #pragma comment(lib, "ws2_32.lib")
 
+#ifndef _SSIZE_T_DEFINED
 using ssize_t = __int64;
+#define _SSIZE_T_DEFINED
+#endif
 #endif // _MSC_VER
 
 #ifndef S_ISREG


### PR DESCRIPTION
On Windows cpp-httplib defines ssize_t, therefore applications needing to define ssize_t for their own needs or are using libraries that do require a means to avoid a possible incompatible redefinition.