### PR TITLE
Fix path params with empty values

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6178,8 +6178,10 @@ inline std::string params_to_query_str(const Params &params) {
   for (auto it = params.begin(); it != params.end(); ++it) {
     if (it != params.begin()) { query += '&'; }
     query += encode_query_component(it->first);
-    query += '=';
-    query += encode_query_component(it->second);
+    if (!it->second.empty()) {
+      query += '=';
+      query += encode_query_component(it->second);
+    }
   }
   return query;
 }


### PR DESCRIPTION
This PR fix path params with empty values.

Before:
`/path?key1&key2` will become `/path?key1=&key2=`

Now we just ignore empty values and leave keys only.