### PR TITLE
Stop using u8 string literals for more recent compilers

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -42,6 +42,12 @@
 #define SERVER_ENCRYPTED_PRIVATE_KEY_FILE "./key_encrypted.pem"
 #define SERVER_ENCRYPTED_PRIVATE_KEY_PASS "test123!"
 
+#if __cplusplus >= 201402L
+#define U8(str) str
+#else
+#define U8(str) u8##str
+#endif
+
 using namespace std;
 using namespace httplib;
 
@@ -372,7 +378,7 @@ TEST(DecodePathTest, PercentCharacter) {
   EXPECT_EQ(
       decode_path_component(
           R"(descrip=Gastos%20%C3%A1%C3%A9%C3%AD%C3%B3%C3%BA%C3%B1%C3%91%206)"),
-      u8"descrip=Gastos áéíóúñÑ 6");
+      U8("descrip=Gastos áéíóúñÑ 6"));
 }
 
 TEST(DecodePathTest, PercentCharacterNUL) {
@@ -430,9 +436,9 @@ TEST(ClientQueryOrder, PreserveOrder) {
 }
 
 TEST(EncodeQueryParamTest, TestUTF8Characters) {
-  string chineseCharacters = u8"中国語";
-  string russianCharacters = u8"дом";
-  string brazilianCharacters = u8"óculos";
+  string chineseCharacters = U8("中国語");
+  string russianCharacters = U8("дом");
+  string brazilianCharacters = U8("óculos");
 
   EXPECT_EQ(httplib::encode_uri_component(chineseCharacters),
             "%E4%B8%AD%E5%9B%BD%E8%AA%9E");
@@ -457,9 +463,9 @@ TEST(EncodeUriComponentTest, ParseReservedCharactersTest) {
 }
 
 TEST(EncodeUriComponentTest, TestUTF8Characters) {
-  string chineseCharacters = u8"中国語";
-  string russianCharacters = u8"дом";
-  string brazilianCharacters = u8"óculos";
+  string chineseCharacters = U8("中国語");
+  string russianCharacters = U8("дом");
+  string brazilianCharacters = U8("óculos");
 
   EXPECT_EQ(httplib::encode_uri_component(chineseCharacters),
             "%E4%B8%AD%E5%9B%BD%E8%AA%9E");
@@ -491,9 +497,9 @@ TEST(EncodeUriTest, ParseReservedCharactersTest) {
 }
 
 TEST(EncodeUriTest, TestUTF8Characters) {
-  string chineseCharacters = u8"中国語";
-  string russianCharacters = u8"дом";
-  string brazilianCharacters = u8"óculos";
+  string chineseCharacters = U8("中国語");
+  string russianCharacters = U8("дом");
+  string brazilianCharacters = U8("óculos");
 
   EXPECT_EQ(httplib::encode_uri(chineseCharacters),
             "%E4%B8%AD%E5%9B%BD%E8%AA%9E");
@@ -538,9 +544,9 @@ TEST(DecodeUriComponentTest, TestUTF8Characters) {
   string encodedRussian = "%D0%B4%D0%BE%D0%BC";
   string encodedBrazilian = "%C3%B3culos";
 
-  EXPECT_EQ(httplib::decode_uri_component(encodedChinese), u8"中国語");
-  EXPECT_EQ(httplib::decode_uri_component(encodedRussian), u8"дом");
-  EXPECT_EQ(httplib::decode_uri_component(encodedBrazilian), u8"óculos");
+  EXPECT_EQ(httplib::decode_uri_component(encodedChinese), U8("中国語"));
+  EXPECT_EQ(httplib::decode_uri_component(encodedRussian), U8("дом"));
+  EXPECT_EQ(httplib::decode_uri_component(encodedBrazilian), U8("óculos"));
 }
 
 TEST(DecodeUriComponentTest, TestPathComponentDecoding) {
@@ -567,9 +573,9 @@ TEST(DecodeUriTest, TestUTF8Characters) {
   string encodedRussian = "%D0%B4%D0%BE%D0%BC";
   string encodedBrazilian = "%C3%B3culos";
 
-  EXPECT_EQ(httplib::decode_uri(encodedChinese), u8"中国語");
-  EXPECT_EQ(httplib::decode_uri(encodedRussian), u8"дом");
-  EXPECT_EQ(httplib::decode_uri(encodedBrazilian), u8"óculos");
+  EXPECT_EQ(httplib::decode_uri(encodedChinese), U8("中国語"));
+  EXPECT_EQ(httplib::decode_uri(encodedRussian), U8("дом"));
+  EXPECT_EQ(httplib::decode_uri(encodedBrazilian), U8("óculos"));
 }
 
 TEST(DecodeUriTest, TestCompleteUri) {
@@ -7422,10 +7428,10 @@ TEST(MountTest, MultibytesPathName) {
 
   Client cli("localhost", PORT);
 
-  auto res = cli.Get(u8"/日本語Dir/日本語File.txt");
+  auto res = cli.Get(U8("/日本語Dir/日本語File.txt"));
   ASSERT_TRUE(res);
   EXPECT_EQ(StatusCode::OK_200, res->status);
-  EXPECT_EQ(u8"日本語コンテンツ", res->body);
+  EXPECT_EQ(U8("日本語コンテンツ"), res->body);
 }
 
 TEST(KeepAliveTest, ReadTimeout) {


### PR DESCRIPTION
GCC 15 will fail with u8 string literals.

Alternative to #2321.