### PR TITLE
Fix set_ca_cert_store() to skip system certs like set_ca_cert_path()

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -13093,7 +13093,7 @@ inline bool SSLClient::load_certs() {
         last_openssl_error_ = ERR_get_error();
         ret = false;
       }
-    } else {
+    } else if (!ca_cert_store_) {
       auto loaded = false;
 #ifdef _WIN32
       loaded =


### PR DESCRIPTION
## Problem

`set_ca_cert_path()` and `set_ca_cert_store()` behave inconsistently regarding system certificate loading:

| Method | Skips system certs |
|--------|-------------------|
| `set_ca_cert_path()` | Yes |
| `set_ca_cert_store()` | No |

Both APIs conceptually do the same thing: "use these CA certs for verification." However, when using `set_ca_cert_store()` for certificate pinning, system certs are still loaded in `load_certs()`, defeating the purpose of pinning.

## Root Cause

In `load_certs()`:

```cpp
if (!ca_cert_file_path_.empty()) {
  // load from file - skips else branch
} else if (!ca_cert_dir_path_.empty()) {
  // load from dir - skips else branch
} else {
  // load system certs - ALWAYS runs when using set_ca_cert_store()
}
```

`set_ca_cert_path()` sets `ca_cert_file_path_`, taking the first branch and skipping system cert loading.

`set_ca_cert_store()` sets `ca_cert_store_` (since #2217 fix), but `load_certs()` doesn't check it, so it falls through to the else branch where system certs are added to the user's custom store.

## Fix

Check `ca_cert_store_` in `load_certs()`:

```cpp
    } else if (!ca_cert_store_) {  // Was: } else {
      // load system certs
    }
```

This makes `set_ca_cert_store()` behave consistently with `set_ca_cert_path()`.

## Test

Added `SSLClientTest.SetCaCertStoreSkipsSystemCerts_Online` to verify system certs are not loaded when custom store is set.