### PR TITLE
timegm api absent in AIX

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3547,6 +3547,8 @@ inline time_t parse_http_date(const std::string &date_str) {
 
 #ifdef _WIN32
   return _mkgmtime(&tm_buf);
+#elif defined _AIX
+  return mktime(&tm_buf);
 #else
   return timegm(&tm_buf);
 #endif


### PR DESCRIPTION
The timegm api is not part of AIX libc. Hence we want to use the alternative available ie. mktime