### PR TITLE
Allow unlimited number of keep-alive requests by setting `keep_alive_max_count` to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ svr.set_expect_100_continue_handler([](const Request &req, Response &res) {
 ### Keep-Alive connection
 
 ```cpp
-svr.set_keep_alive_max_count(2); // Default is 100
+svr.set_keep_alive_max_count(2); // Default is 100. Set to 0 to disable.
 svr.set_keep_alive_timeout(10);  // Default is 5
 ```
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -7605,6 +7605,36 @@ TEST(KeepAliveTest, MaxCount) {
   }
 }
 
+TEST(KeepAliveTest, MaxCountZero) {
+  size_t keep_alive_max_count = 0;
+
+  Server svr;
+  svr.set_keep_alive_max_count(keep_alive_max_count);
+
+  svr.Get("/hi", [](const httplib::Request &, httplib::Response &res) {
+    res.set_content("Hello World!", "text/plain");
+  });
+
+  auto listen_thread = std::thread([&svr] { svr.listen(HOST, PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    listen_thread.join();
+    ASSERT_FALSE(svr.is_running());
+  });
+
+  svr.wait_until_ready();
+
+  Client cli(HOST, PORT);
+  cli.set_keep_alive(true);
+
+  for (size_t i = 0; i < 5; i++) {
+    auto result = cli.Get("/hi");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(StatusCode::OK_200, result->status);
+    EXPECT_FALSE(result->has_header("Connection"));
+  }
+}
+
 TEST(KeepAliveTest, Issue1041) {
   Server svr;
   svr.set_keep_alive_timeout(3);


### PR DESCRIPTION
Allow an unlimited number of requests on the same HTTP/1.1 connection as long as the keep-alive timer has not expired, by setting `keep_alive_max_count` to 0.

Right now, there is no elegant way to do this, as setting it to `std::numeric_limits<size_t>::max` is ugly (as it's also sent in the `Keep-Alive` header), and not really 'infinite' on 32 bit platforms with high number of requests per second, in long-running client-server applications.

Note that Apache HTTP Server also supports this in the same way: https://httpd.apache.org/docs/current/mod/core.html#maxkeepaliverequests.

We don't send the `max` parameter as part of `Keep-Alive` header if `keep_alive_max_count` is 0, also in line with https://github.com/apache/httpd/blob/51912a22e4b80889aa45bedb154e2dd0152bf208/modules/http/http_protocol.c#L289.