### PR TITLE
Fix compilation on BoringSSL by replacing ASN1_TIME_to_tm

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -15457,26 +15457,18 @@ inline bool get_cert_validity(cert_t cert, time_t &not_before,
 
   ASN1_TIME *epoch = ASN1_TIME_new();
   if (!epoch) return false;
+  auto se = detail::scope_exit([&] { ASN1_TIME_free(epoch); });
 
-  if (!ASN1_TIME_set(epoch, 0)) {
-    ASN1_TIME_free(epoch);
-    return false;
-  }
+  if (!ASN1_TIME_set(epoch, 0)) return false;
+
   int pday, psec;
 
-  if (!ASN1_TIME_diff(&pday, &psec, epoch, nb)) {
-    ASN1_TIME_free(epoch);
-    return false;
-  }
+  if (!ASN1_TIME_diff(&pday, &psec, epoch, nb)) return false;
   not_before = 86400 * (time_t)pday + psec;
 
-  if (!ASN1_TIME_diff(&pday, &psec, epoch, na)) {
-    ASN1_TIME_free(epoch);
-    return false;
-  }
+  if (!ASN1_TIME_diff(&pday, &psec, epoch, na)) return false;
   not_after = 86400 * (time_t)pday + psec;
 
-  ASN1_TIME_free(epoch);
   return true;
 }
 


### PR DESCRIPTION
BoringSSL doesn't expose `ASN1_TIME_to_tm`.
This patch switches to using `ASN1_TIME_diff` to calculate `time_t`. This is supported by OpenSSL, LibreSSL, and BoringSSL, and also avoids the platform-specific `timegm` vs `_mkgmtime` logic.