### PR TITLE
Correct sign comparison error with sk_X509_OBJECT_num

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -15596,7 +15596,7 @@ inline std::vector<std::string> get_ca_names(ctx_t ctx) {
   if (!objs) { return names; }
 
   auto count = sk_X509_OBJECT_num(objs);
-  for (int i = 0; i < count; i++) {
+  for (decltype(count) i = 0; i < count; i++) {
     auto obj = sk_X509_OBJECT_value(objs, i);
     if (!obj) { continue; }
     if (X509_OBJECT_get_type(obj) == X509_LU_X509) {


### PR DESCRIPTION
In some build configurations, sk_X509_OBJECT_num (from BoringSSL) returns a size_t. Comparing this directly against a signed int loop counter triggers -Werror,-Wsign-compare.

Instead, move the count into a local int variable so the compiler uses implicit conversion to ensure type consistency during the loop comparison.