### PR TITLE
Remove macOS select() fallback

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4600,7 +4600,8 @@ inline int poll_wrapper(struct pollfd *fds, nfds_t nfds, int timeout) {
 #endif
 }
 
-inline ssize_t select_impl(socket_t sock, short events, time_t sec, time_t usec) {
+inline ssize_t select_impl(socket_t sock, short events, time_t sec,
+                           time_t usec) {
   struct pollfd pfd;
   pfd.fd = sock;
   pfd.events = events;


### PR DESCRIPTION
macOS has supported `poll` for a long time now, so there's no need for the specific `select` code paths.

With this commit, we can successfully build on visionOS.