### PR TITLE
Fix comparison of integers of different signs warning when compiling with BoringSSL.

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -15341,7 +15341,7 @@ inline bool get_cert_sans(cert_t cert, std::vector<SanEntry> &sans) {
   if (!names) return true; // No SANs is valid
 
   auto count = sk_GENERAL_NAME_num(names);
-  for (int i = 0; i < count; i++) {
+  for (decltype(count) i = 0; i < count; i++) {
     auto gen = sk_GENERAL_NAME_value(names, i);
     if (!gen) continue;
 


### PR DESCRIPTION
This PR fixes the following warning:

```
httplib/httplib.h:15402:21: error: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Werror,-Wsign-compare]
 15402 |   for (int i = 0; i < count; i++) {
       |                   ~ ^ ~~~~~
1 error generated.
```

The PR fixing the similar issue was merged recently https://github.com/yhirose/cpp-httplib/pull/2355, but somehow the one usage of `int` was missed.