### PR TITLE
Removed unused local variable

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -11801,7 +11801,7 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
 #else
   try {
     routed = routing(req, res, strm);
-  } catch (std::exception &e) {
+  } catch (std::exception &) {
     if (exception_handler_) {
       auto ep = std::current_exception();
       exception_handler_(req, res, ep);


### PR DESCRIPTION
Small fix for unused local variable causing treat warnings as errors to fail.

```
[build] E:\CodingProjects\04_Projects\NoteShare_Dec2025\build\MSVC 64bit\external\httplib.h(11799,28): error C2220: the following warning is treated as an error [E:\CodingProjects\04_Projects\NoteShare_Dec2025\build\MSVC 64bit\sharepaste.vcxproj]
[build]   (compiling source file 'CMakeFiles/sharepaste.dir/cmake_pch.cxx')
[build]   
[build] E:\CodingProjects\04_Projects\NoteShare_Dec2025\build\MSVC 64bit\external\httplib.h(11799,28): warning C4101: 'e': unreferenced local variable [E:\CodingProjects\04_Projects\NoteShare_Dec2025\build\MSVC 64bit\sharepaste.vcxproj]
```