### PR TITLE
MSVC Fixes

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -15791,8 +15791,14 @@ inline bool is_ipv4_address(const std::string &str) {
 // Parse IPv4 address string to bytes
 inline bool parse_ipv4(const std::string &str, unsigned char *out) {
   int parts[4];
+#ifdef _WIN32
+  if (sscanf_s(str.c_str(), "%d.%d.%d.%d", &parts[0], &parts[1], &parts[2],
+               &parts[3]) != 4)
+#else
   if (sscanf(str.c_str(), "%d.%d.%d.%d", &parts[0], &parts[1], &parts[2],
-             &parts[3]) != 4) {
+             &parts[3]) != 4)
+#endif
+  {
     return false;
   }
   for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
## Introduction

This is related to this issue: https://github.com/yhirose/cpp-httplib/issues/2383

On Microsoft's compiler it has warnings (that can be treated as an error).  This fixes a few of those warnings.

## Details

Consider the following:
```cpp
#include <algorithm>
#include <cctype>
#include <string>

int main()
{
    std::string upgrade_val;

    std::transform(upgrade_val.begin(), upgrade_val.end(), upgrade_val.begin(),
               ::tolower);
}
```

On MSVC (with level `3` & `4` warnings) it has a warning.  Here is an online link as well: https://godbolt.org/z/Grx46c7hb
<img width="3840" height="2063" alt="image" src="https://github.com/user-attachments/assets/324a8bf0-51a9-4fd7-96a9-24d2bdaee3da" />


To fix that I wrapped all places to call a function that doesn't have the warning.

I also got a few errors about casting from a `uint64_t` to a `unsigned long`:
<img width="3357" height="1839" alt="image" src="https://github.com/user-attachments/assets/7807a60d-6028-4caa-b70c-b9671db73b3d" />

To fix those I added some `static_cast`s.  I don't feel too strongly about this should we want to go a different way to resolve that.

I also got a warning about using `sscanf`:
<img width="3378" height="1722" alt="image" src="https://github.com/user-attachments/assets/2c0a9cce-8ab2-4530-88c6-12fcc033bbc5" />

I used the `sscanf_s` replacement for MSVC which is not cross-platform.  So only MSVC uses this version in place to fix the warning.

Lastly I did get a warning about using `[[deprecated]]`:
<img width="3076" height="1358" alt="image" src="https://github.com/user-attachments/assets/15120e38-899b-46f4-bc2a-7fd7d452e259" />

But MSVC is not suppose to have a warning about simply having `[[deprecated]]` functions so I am suppressing that locally.

Hope that helps! :smiley: