### PR TITLE
Use SO_REUSEADDR instead of SO_REUSEPORT as default

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -9134,13 +9134,7 @@ inline bool setup_client_tls_session(const std::string &host, tls::ctx_t &ctx,
  */
 
 inline void default_socket_options(socket_t sock) {
-  detail::set_socket_opt(sock, SOL_SOCKET,
-#ifdef SO_REUSEPORT
-                         SO_REUSEPORT,
-#else
-                         SO_REUSEADDR,
-#endif
-                         1);
+  detail::set_socket_opt(sock, SOL_SOCKET, SO_REUSEADDR, 1);
 }
 
 inline std::string get_bearer_token_auth(const Request &req) {


### PR DESCRIPTION
SO_REUSEPORT should be opt-in rather than opt-out to prevent silent port
sharing by default, only servers that intentionally want to share the
same port should enable it.

This is related to this issue: https://github.com/ggml-org/llama.cpp/issues/20963.
This is a proposal. If not accepted we can override the socket options in llama.cpp instead.