### PR TITLE
Export set_socket_opt in detail namespace

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1565,6 +1565,8 @@ int close_socket(socket_t sock);
 
 ssize_t write_headers(Stream &strm, const Headers &headers);
 
+bool set_socket_opt(socket_t sock, int level, int optname, int optval);
+
 bool set_socket_opt_time(socket_t sock, int level, int optname, time_t sec,
                          time_t usec);
 


### PR DESCRIPTION
This allows users to set custom socket options without reimplementing platform specific wrappers