### PR TITLE
fix: stop using PATH_MAX

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4949,9 +4949,10 @@ inline bool canonicalize_path(const char *path, std::string &resolved) {
   if (_fullpath(buf, path, _MAX_PATH) == nullptr) { return false; }
   resolved = buf;
 #else
-  char buf[PATH_MAX];
-  if (realpath(path, buf) == nullptr) { return false; }
+  char *buf = realpath(path, nullptr);
+  if (buf == nullptr) { return false; }
   resolved = buf;
+  std::free(buf);
 #endif
   return true;
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -17576,9 +17576,10 @@ TEST(SymlinkTest, SymlinkEscapeFromBaseDirectory) {
   }
 
   // Create symlink using absolute path so it resolves correctly
-  char abs_secret[PATH_MAX];
-  ASSERT_NE(nullptr, realpath(secret_dir.c_str(), abs_secret));
+  char *abs_secret = realpath(secret_dir.c_str(), nullptr);
+  ASSERT_NE(nullptr, abs_secret);
   ASSERT_EQ(0, symlink(abs_secret, symlink_path.c_str()));
+  std::free(abs_secret);
 
   auto se = detail::scope_exit([&] {
     unlink(symlink_path.c_str());


### PR DESCRIPTION
`PATH_MAX` is tricky, leads to buggy code, and isn't even defined on all platforms. For instance, GNU Hurd does not have it, and using it makes cpp-httplib incompatible with that OS.

Passing `nullptr` to `realpath()` is easier, and makes all the `PATH_MAX`-related problems go away.

For more reasoning and examples on avoiding `PATH_MAX`, see <https://github.com/HowardHinnant/date/commit/ac0c58d5da602e6387589d849f1d8d523091f4f0>