### PR TITLE
Fix #2427

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -18,6 +18,8 @@ ifneq ($(OS), Windows_NT)
 		OPENSSL_SUPPORT = -DCPPHTTPLIB_OPENSSL_SUPPORT -lssl -lcrypto
 		MBEDTLS_SUPPORT = -DCPPHTTPLIB_MBEDTLS_SUPPORT -lmbedtls -lmbedx509 -lmbedcrypto
 		WOLFSSL_SUPPORT = -DCPPHTTPLIB_WOLFSSL_SUPPORT -lwolfssl
+		# Disable ASLR for ASAN compatibility on WSL2 (high-entropy ASLR conflicts with ASAN shadow memory)
+		SETARCH = setarch $(shell uname -m) -R
 	endif
 endif
 
@@ -59,7 +61,7 @@ STYLE_CHECK_FILES = $(filter-out httplib.h httplib.cc, \
 	$(wildcard example/*.h example/*.cc fuzzing/*.h fuzzing/*.cc *.h *.cc ../httplib.h))
 
 all : test test_split
-	LSAN_OPTIONS=suppressions=lsan_suppressions.txt ./test
+	LSAN_OPTIONS=suppressions=lsan_suppressions.txt $(SETARCH) ./test
 
 SHARDS ?= 4
 
@@ -69,7 +71,7 @@ define run_parallel
 	for i in $$(seq 0 $$(($(SHARDS) - 1))); do \
 	  GTEST_TOTAL_SHARDS=$(SHARDS) GTEST_SHARD_INDEX=$$i \
 	  LSAN_OPTIONS=suppressions=lsan_suppressions.txt \
-	  ./$(1) --gtest_color=yes > $(1)_shard_$$i.log 2>&1 & \
+	  $(SETARCH) ./$(1) --gtest_color=yes > $(1)_shard_$$i.log 2>&1 & \
 	done; \
 	wait; \
 	for i in $$(seq 0 $$(($(SHARDS) - 1))); do \

--- a/test/test.cc
+++ b/test/test.cc
@@ -14275,8 +14275,23 @@ static std::thread serve_single_response(std::promise<int> &port_promise,
     auto cli = ::accept(srv, reinterpret_cast<sockaddr *>(&cli_addr), &cli_len);
 
     if (cli != INVALID_SOCKET) {
-      char buf[4096];
-      ::recv(cli, buf, sizeof(buf), 0);
+      // Read the complete HTTP request (until the blank line that terminates
+      // headers) before sending the response.  If the server closes the socket
+      // while the client's request data is still unread in the kernel receive
+      // buffer, the TCP stack sends RST instead of FIN.  That RST resets the
+      // connection on both sides: it discards the client's receive buffer
+      // (which already holds our response) and causes any in-progress write on
+      // the client to fail with ECONNRESET.  Reading all request data first
+      // ensures close() emits a graceful FIN.
+      {
+        char rbuf[256];
+        std::string req;
+        while (req.find("\r\n\r\n") == std::string::npos) {
+          auto n = ::recv(cli, rbuf, sizeof(rbuf), 0);
+          if (n <= 0) { break; }
+          req.append(rbuf, static_cast<size_t>(n));
+        }
+      }
 
       ::send(cli,
 #ifdef _WIN32


### PR DESCRIPTION
This pull request improves the reliability of the HTTP server in the test suite by ensuring that the server reads the entire HTTP request from the client before sending a response. This change prevents connection resets that can occur if the server closes the socket while unread request data remains in the kernel buffer.

**HTTP request handling improvement:**

* Updated `serve_single_response` in `test/test.cc` to read the full HTTP request headers (up to the blank line) before sending a response, ensuring a graceful connection close and preventing ECONNRESET errors on the client.