### PR TITLE
Reproducer test for #2431 (getaddrinfo_a use-after-free)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,9 +118,13 @@ jobs:
   # On Linux/glibc, getaddrinfo_with_timeout() schedules an asynchronous
   # DNS lookup with getaddrinfo_a(GAI_NOWAIT) using a stack-local gaicb.
   # When gai_suspend() hits the connection timeout, gai_cancel() is called
-  # but does not block; the resolver worker can keep writing into the
-  # destroyed stack frame. To exercise that path the runner blocks UDP/53
-  # so DNS hangs and the timeout branch is taken on every call.
+  # but does not block; the resolver worker can later write back into the
+  # destroyed stack frame. To make the worker actually reach that write,
+  # the test job runs a loopback UDP responder (test/dns_test_fixture.py)
+  # that delays its reply past the test's 1s timeout, and uses an iptables
+  # NAT rule so glibc's lookups land on that fixture instead of a real
+  # nameserver. With ASAN's detect_stack_use_after_return enabled, the
+  # late write-back is reported as a stack-use-after-return.
   issue-2431-repro:
     runs-on: ubuntu-latest
     if: >
@@ -129,11 +133,13 @@ jobs:
        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.test_linux == 'true')
     name: issue-2431 repro (Linux + ASAN)
-    # The bug manifests as orphan getaddrinfo_a resolver workers that prevent
-    # the runner from completing job teardown ("Cleaning up orphan processes"
-    # hangs for ~1h until forced shutdown). Cap the whole job at 5 min so the
-    # failure surfaces fast: bug present -> killed at 5min, bug fixed -> ~2min.
+    # Bound the whole job in case anything in the test harness hangs
+    # unexpectedly. With the fixture in place a normal run is well under
+    # a minute either way (ASAN abort on broken HEAD, clean pass on fix).
     timeout-minutes: 5
+    env:
+      DNS_FIXTURE_PORT: "15353"
+      DNS_FIXTURE_DELAY: "3"
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -141,23 +147,40 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev zlib1g-dev libbrotli-dev \
-            libzstd-dev libcurl4-openssl-dev iptables util-linux
-      - name: sinkhole DNS
+            libzstd-dev libcurl4-openssl-dev iptables util-linux iproute2
+      - name: start loopback DNS test fixture
         run: |
-          # Force the resolver path: Ubuntu's default nsswitch short-circuits
-          # to NOTFOUND through mdns4_minimal before glibc DNS code runs, so
-          # the gai_cancel() branch would never get exercised.
+          # Force glibc through its DNS code path: Ubuntu's default
+          # nsswitch short-circuits to NOTFOUND through mdns4_minimal,
+          # which would skip the buggy code entirely.
           sudo sed -i 's/^hosts:.*/hosts: dns/' /etc/nsswitch.conf
-          # Drop UDP/53 in both directions so DNS queries hang silently
-          # rather than failing fast with ICMP unreachable.
-          sudo iptables -I OUTPUT -p udp --dport 53 -j DROP
-          sudo iptables -I INPUT  -p udp --sport 53 -j DROP
-          # Sanity check: a real DNS lookup must hang now.
-          if timeout 2 getent hosts example.com >/dev/null 2>&1; then
-            echo "ERROR: DNS unexpectedly resolved — sinkhole is not in effect" >&2
+          # Run the loopback fixture (delayed UDP responder).
+          python3 test/dns_test_fixture.py "$DNS_FIXTURE_PORT" "$DNS_FIXTURE_DELAY" \
+            >/tmp/dns_fixture.log 2>&1 &
+          echo $! | sudo tee /tmp/dns_fixture.pid >/dev/null
+          # Wait for the fixture to start listening.
+          for _ in $(seq 1 50); do
+            if ss -lun "( sport = :$DNS_FIXTURE_PORT )" | grep -q ":$DNS_FIXTURE_PORT"; then
+              break
+            fi
+            sleep 0.1
+          done
+          ss -lun "( sport = :$DNS_FIXTURE_PORT )" | grep -q ":$DNS_FIXTURE_PORT" \
+            || { echo "fixture failed to start"; cat /tmp/dns_fixture.log; exit 1; }
+          # Send the test process's DNS lookups to the loopback fixture.
+          # NAT only the local OUTPUT chain; conntrack handles the reply path.
+          sudo iptables -t nat -I OUTPUT -p udp --dport 53 \
+            -j REDIRECT --to-port "$DNS_FIXTURE_PORT"
+          # Sanity check: a query must take at least the fixture delay
+          # and resolve to NXDOMAIN (proving traffic reaches the fixture).
+          start=$(date +%s)
+          getent hosts unresolvable-host.invalid >/dev/null 2>&1 || true
+          elapsed=$(( $(date +%s) - start ))
+          if [ "$elapsed" -lt 2 ]; then
+            echo "ERROR: lookup returned in ${elapsed}s; fixture not in path" >&2
             exit 1
           fi
-          echo "[ok] DNS UDP/53 is being dropped"
+          echo "[ok] DNS lookups are routed to the test fixture (took ${elapsed}s)"
       - name: build test binary
         run: cd test && make test
       - name: run GetAddrInfoAsyncCancelTest
@@ -165,9 +188,17 @@ jobs:
           cd test
           ARCH=$(uname -m)
           CPPHTTPLIB_TEST_ISSUE_2431=1 \
+          ASAN_OPTIONS=detect_stack_use_after_return=1 \
           LSAN_OPTIONS=suppressions=lsan_suppressions.txt \
           setarch "$ARCH" -R \
             ./test --gtest_filter='GetAddrInfoAsyncCancelTest.*'
+      - name: tear down test fixture
+        if: always()
+        run: |
+          sudo iptables -t nat -F OUTPUT || true
+          if [ -f /tmp/dns_fixture.pid ]; then
+            sudo kill "$(cat /tmp/dns_fixture.pid)" 2>/dev/null || true
+          fi
 
   macos:
     runs-on: macos-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -129,6 +129,11 @@ jobs:
        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.test_linux == 'true')
     name: issue-2431 repro (Linux + ASAN)
+    # The bug manifests as orphan getaddrinfo_a resolver workers that prevent
+    # the runner from completing job teardown ("Cleaning up orphan processes"
+    # hangs for ~1h until forced shutdown). Cap the whole job at 5 min so the
+    # failure surfaces fast: bug present -> killed at 5min, bug fixed -> ~2min.
+    timeout-minutes: 5
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -164,7 +164,13 @@ jobs:
         run: |
           cd test
           ARCH=$(uname -m)
+          # detect_stack_use_after_return=1 is the direct detector for this
+          # bug: when the resolver worker writes back to the destroyed
+          # stack-local gaicb, ASAN aborts immediately with a stack trace
+          # naming getaddrinfo_with_timeout. Without it the bug only shows
+          # up as an orphan-process hang at job teardown.
           CPPHTTPLIB_TEST_ISSUE_2431=1 \
+          ASAN_OPTIONS=detect_stack_use_after_return=1 \
           LSAN_OPTIONS=suppressions=lsan_suppressions.txt \
           setarch "$ARCH" -R \
             ./test --gtest_filter='GetAddrInfoAsyncCancelTest.*'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -164,13 +164,7 @@ jobs:
         run: |
           cd test
           ARCH=$(uname -m)
-          # detect_stack_use_after_return=1 is the direct detector for this
-          # bug: when the resolver worker writes back to the destroyed
-          # stack-local gaicb, ASAN aborts immediately with a stack trace
-          # naming getaddrinfo_with_timeout. Without it the bug only shows
-          # up as an orphan-process hang at job teardown.
           CPPHTTPLIB_TEST_ISSUE_2431=1 \
-          ASAN_OPTIONS=detect_stack_use_after_return=1 \
           LSAN_OPTIONS=suppressions=lsan_suppressions.txt \
           setarch "$ARCH" -R \
             ./test --gtest_filter='GetAddrInfoAsyncCancelTest.*'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,6 +114,56 @@ jobs:
       - name: build and run ThreadPool test
         run: cd test && make test_thread_pool && ./test_thread_pool
 
+  # Reproducer for https://github.com/yhirose/cpp-httplib/issues/2431.
+  # On Linux/glibc, getaddrinfo_with_timeout() schedules an asynchronous
+  # DNS lookup with getaddrinfo_a(GAI_NOWAIT) using a stack-local gaicb.
+  # When gai_suspend() hits the connection timeout, gai_cancel() is called
+  # but does not block; the resolver worker can keep writing into the
+  # destroyed stack frame. To exercise that path the runner blocks UDP/53
+  # so DNS hangs and the timeout branch is taken on every call.
+  issue-2431-repro:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request'  &&
+       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.test_linux == 'true')
+    name: issue-2431 repro (Linux + ASAN)
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: install libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev zlib1g-dev libbrotli-dev \
+            libzstd-dev libcurl4-openssl-dev iptables util-linux
+      - name: sinkhole DNS
+        run: |
+          # Force the resolver path: Ubuntu's default nsswitch short-circuits
+          # to NOTFOUND through mdns4_minimal before glibc DNS code runs, so
+          # the gai_cancel() branch would never get exercised.
+          sudo sed -i 's/^hosts:.*/hosts: dns/' /etc/nsswitch.conf
+          # Drop UDP/53 in both directions so DNS queries hang silently
+          # rather than failing fast with ICMP unreachable.
+          sudo iptables -I OUTPUT -p udp --dport 53 -j DROP
+          sudo iptables -I INPUT  -p udp --sport 53 -j DROP
+          # Sanity check: a real DNS lookup must hang now.
+          if timeout 2 getent hosts example.com >/dev/null 2>&1; then
+            echo "ERROR: DNS unexpectedly resolved — sinkhole is not in effect" >&2
+            exit 1
+          fi
+          echo "[ok] DNS UDP/53 is being dropped"
+      - name: build test binary
+        run: cd test && make test
+      - name: run GetAddrInfoAsyncCancelTest
+        run: |
+          cd test
+          ARCH=$(uname -m)
+          CPPHTTPLIB_TEST_ISSUE_2431=1 \
+          LSAN_OPTIONS=suppressions=lsan_suppressions.txt \
+          setarch "$ARCH" -R \
+            ./test --gtest_filter='GetAddrInfoAsyncCancelTest.*'
+
   macos:
     runs-on: macos-latest
     if: >

--- a/test/dns_test_fixture.py
+++ b/test/dns_test_fixture.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Delayed UDP responder used as a loopback test fixture.
+
+This is a self-contained test fixture for the GetAddrInfoAsyncCancelTest
+cases (reproducer for cpp-httplib issue #2431). It is NOT a general-purpose
+nameserver and is only intended to run on 127.0.0.1 inside the test job's
+own runner / container.
+
+What it does
+------------
+Binds a UDP socket on 127.0.0.1:<port>, accepts well-formed DNS queries
+from the test process, waits <delay_seconds>, then sends back a minimal
+NXDOMAIN reply. The deliberate delay is what makes the bug reproducible:
+
+  * The test calls getaddrinfo_with_timeout() with timeout_sec=1.
+  * gai_suspend() returns EAI_AGAIN after 1s; the function returns and
+    its stack frame is destroyed.
+  * The fixture replies after <delay_seconds> (= 3s by default), so the
+    glibc resolver worker thread receives the response *after* the
+    caller's frame is gone and writes back into freed stack memory.
+  * AddressSanitizer (with detect_stack_use_after_return=1) catches the
+    write and aborts with a stack-use-after-return diagnostic.
+
+Without this fixture the bug is hard to surface: dropping UDP/53 makes
+the resolver hang forever, so the worker never receives anything and
+never reaches the buggy write-back path.
+
+Usage
+-----
+    python3 test/dns_test_fixture.py <port> [<delay_seconds>]
+
+Only standard library; no third-party dependencies.
+"""
+
+import socket
+import struct
+import sys
+import threading
+import time
+
+
+def serve(port: int, delay_sec: float) -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", port))
+    print(
+        f"[dns_test_fixture] listening on 127.0.0.1:{port}, "
+        f"reply delay={delay_sec}s",
+        flush=True,
+    )
+    while True:
+        try:
+            data, addr = sock.recvfrom(2048)
+        except OSError:
+            return
+        threading.Thread(
+            target=_reply_after_delay,
+            args=(sock, data, addr, delay_sec),
+            daemon=True,
+        ).start()
+
+
+def _reply_after_delay(sock, query: bytes, addr, delay_sec: float) -> None:
+    time.sleep(delay_sec)
+    if len(query) < 12:
+        return
+    # Header: copy transaction id, set QR=1 RA=1 RCODE=3 (NXDOMAIN),
+    # preserve the requester's RD bit, then echo the question section so
+    # glibc's resolver accepts the reply as matching its outstanding query.
+    txid = query[:2]
+    rd_bit = query[2] & 0x01
+    flags = struct.pack(">H", 0x8003 | (rd_bit << 8))
+    counts = struct.pack(">HHHH", 1, 0, 0, 0)
+    question = query[12:]
+    reply = txid + flags + counts + question
+    try:
+        sock.sendto(reply, addr)
+    except OSError:
+        pass
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    port_arg = int(sys.argv[1])
+    delay_arg = float(sys.argv[2]) if len(sys.argv) > 2 else 3.0
+    serve(port_arg, delay_arg)

--- a/test/run_issue_2431_repro.sh
+++ b/test/run_issue_2431_repro.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Reproducer runner for Issue #2431
+# (https://github.com/yhirose/cpp-httplib/issues/2431).
+#
+# Spins up an Ubuntu container, points the resolver at a fake nameserver
+# that never replies (so getaddrinfo_a actually hits its timeout), builds
+# the test suite with g++ + ASAN, and runs the GetAddrInfoAsyncCancelTest
+# cases.
+#
+# Expected outcomes:
+#   - HEAD prior to the fix: ASAN reports a use-after-free / heap-buffer
+#     overflow during one of the GetAddrInfoAsyncCancelTest cases.
+#   - HEAD with the fix applied: all three cases PASS.
+#
+# Usage:
+#   bash test/run_issue_2431_repro.sh
+#
+# Requirements: Docker (Linux container support). The container needs
+# --privileged because the test binary uses `setarch -R` to disable ASLR
+# for ASAN compatibility, and because the script binds UDP/53 inside the
+# container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+docker run --rm --privileged \
+  -v "$REPO_ROOT:/work" \
+  -w /work/test \
+  ubuntu:24.04 bash -c '
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -qq
+apt-get install -y -qq --no-install-recommends \
+  ca-certificates g++ make pkg-config iptables util-linux coreutils file \
+  libssl-dev zlib1g-dev libbrotli-dev libzstd-dev libcurl4-openssl-dev \
+  >/dev/null
+
+# Force DNS-only resolution: Ubuntu defaults nsswitch.conf to
+# "hosts: files mdns4_minimal [NOTFOUND=return] dns ...", which
+# short-circuits to NOTFOUND before reaching glibc DNS code, so the
+# gai_cancel() branch never gets exercised.
+sed -i "s/^hosts:.*/hosts: dns/" /etc/nsswitch.conf
+
+# Drop all outbound UDP/53 traffic so DNS queries hang silently — this
+# matches the iptables-based setup in the original reproducer for
+# Issue #2431. Drop incoming responses too, in case anything sneaks
+# through (defense in depth).
+iptables -I OUTPUT -p udp --dport 53 -j DROP
+iptables -I INPUT  -p udp --sport 53 -j DROP
+trap "iptables -D OUTPUT -p udp --dport 53 -j DROP 2>/dev/null; iptables -D INPUT -p udp --sport 53 -j DROP 2>/dev/null" EXIT
+
+# Sanity check: a real DNS lookup must hang (and time out) now.
+if timeout 2 getent hosts example.com >/dev/null 2>&1; then
+  echo "ERROR: DNS unexpectedly resolved — DROP / nsswitch is not in effect" >&2
+  exit 1
+fi
+echo "[ok] DNS UDP/53 is being dropped (expected for the repro)"
+
+cd /work/test
+echo "=== building test binary (g++ + ASAN) ==="
+make CXX=g++ test 2>&1 | tail -5
+
+ARCH=$(uname -m)
+echo "=== running GetAddrInfoAsyncCancelTest with CPPHTTPLIB_TEST_ISSUE_2431=1 ==="
+set +e
+CPPHTTPLIB_TEST_ISSUE_2431=1 setarch "$ARCH" -R \
+  ./test --gtest_filter="GetAddrInfoAsyncCancelTest.*" 2>&1
+rc=$?
+set -e
+echo "=== test exit: $rc ==="
+exit $rc
+'

--- a/test/run_issue_2431_repro.sh
+++ b/test/run_issue_2431_repro.sh
@@ -2,14 +2,15 @@
 # Reproducer runner for Issue #2431
 # (https://github.com/yhirose/cpp-httplib/issues/2431).
 #
-# Spins up an Ubuntu container, points the resolver at a fake nameserver
-# that never replies (so getaddrinfo_a actually hits its timeout), builds
-# the test suite with g++ + ASAN, and runs the GetAddrInfoAsyncCancelTest
-# cases.
+# Spins up an Ubuntu container, runs the loopback DNS test fixture
+# (test/dns_test_fixture.py), routes the container's DNS lookups to
+# that fixture via an iptables NAT rule, builds the test suite with
+# g++ + ASAN, and runs the GetAddrInfoAsyncCancelTest cases.
 #
 # Expected outcomes:
-#   - HEAD prior to the fix: ASAN reports a use-after-free / heap-buffer
-#     overflow during one of the GetAddrInfoAsyncCancelTest cases.
+#   - HEAD prior to the fix: ASAN reports stack-use-after-return inside
+#     getaddrinfo_with_timeout's getaddrinfo_a path during one of the
+#     GetAddrInfoAsyncCancelTest cases.
 #   - HEAD with the fix applied: all three cases PASS.
 #
 # Usage:
@@ -17,8 +18,8 @@
 #
 # Requirements: Docker (Linux container support). The container needs
 # --privileged because the test binary uses `setarch -R` to disable ASLR
-# for ASAN compatibility, and because the script binds UDP/53 inside the
-# container.
+# for ASAN compatibility, and because the test job manages iptables
+# rules inside the container.
 
 set -euo pipefail
 
@@ -34,7 +35,8 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update -qq
 apt-get install -y -qq --no-install-recommends \
-  ca-certificates g++ make pkg-config iptables util-linux coreutils file \
+  ca-certificates g++ make pkg-config iptables iproute2 util-linux coreutils file \
+  python3 \
   libssl-dev zlib1g-dev libbrotli-dev libzstd-dev libcurl4-openssl-dev \
   >/dev/null
 
@@ -44,20 +46,43 @@ apt-get install -y -qq --no-install-recommends \
 # gai_cancel() branch never gets exercised.
 sed -i "s/^hosts:.*/hosts: dns/" /etc/nsswitch.conf
 
-# Drop all outbound UDP/53 traffic so DNS queries hang silently — this
-# matches the iptables-based setup in the original reproducer for
-# Issue #2431. Drop incoming responses too, in case anything sneaks
-# through (defense in depth).
-iptables -I OUTPUT -p udp --dport 53 -j DROP
-iptables -I INPUT  -p udp --sport 53 -j DROP
-trap "iptables -D OUTPUT -p udp --dport 53 -j DROP 2>/dev/null; iptables -D INPUT -p udp --sport 53 -j DROP 2>/dev/null" EXIT
+# Start the loopback DNS test fixture (delayed UDP responder).
+DNS_FIXTURE_PORT=15353
+DNS_FIXTURE_DELAY=3
+python3 /work/test/dns_test_fixture.py "$DNS_FIXTURE_PORT" "$DNS_FIXTURE_DELAY" \
+  >/tmp/dns_fixture.log 2>&1 &
+FIXTURE_PID=$!
 
-# Sanity check: a real DNS lookup must hang (and time out) now.
-if timeout 2 getent hosts example.com >/dev/null 2>&1; then
-  echo "ERROR: DNS unexpectedly resolved — DROP / nsswitch is not in effect" >&2
+# Route the container DNS lookups to the fixture; conntrack handles the
+# reply path automatically. /etc/resolv.conf is left untouched.
+iptables -t nat -I OUTPUT -p udp --dport 53 \
+  -j REDIRECT --to-port "$DNS_FIXTURE_PORT"
+
+trap '"'"'iptables -t nat -F OUTPUT 2>/dev/null || true; kill "$FIXTURE_PID" 2>/dev/null || true'"'"' EXIT
+
+# Wait for the fixture to start listening.
+for _ in $(seq 1 50); do
+  if ss -lun "( sport = :$DNS_FIXTURE_PORT )" | grep -q ":$DNS_FIXTURE_PORT"; then
+    break
+  fi
+  sleep 0.1
+done
+ss -lun "( sport = :$DNS_FIXTURE_PORT )" | grep -q ":$DNS_FIXTURE_PORT" || {
+  echo "ERROR: dns_test_fixture failed to start" >&2
+  cat /tmp/dns_fixture.log >&2 || true
+  exit 1
+}
+
+# Sanity check: a DNS lookup must take at least the fixture delay
+# (proving the NAT rule routes the query to the fixture).
+start=$(date +%s)
+getent hosts unresolvable-host.invalid >/dev/null 2>&1 || true
+elapsed=$(( $(date +%s) - start ))
+if [ "$elapsed" -lt 2 ]; then
+  echo "ERROR: lookup returned in ${elapsed}s; fixture not in DNS path" >&2
   exit 1
 fi
-echo "[ok] DNS UDP/53 is being dropped (expected for the repro)"
+echo "[ok] DNS lookups are routed to the test fixture (took ${elapsed}s)"
 
 cd /work/test
 echo "=== building test binary (g++ + ASAN) ==="
@@ -66,7 +91,9 @@ make CXX=g++ test 2>&1 | tail -5
 ARCH=$(uname -m)
 echo "=== running GetAddrInfoAsyncCancelTest with CPPHTTPLIB_TEST_ISSUE_2431=1 ==="
 set +e
-CPPHTTPLIB_TEST_ISSUE_2431=1 setarch "$ARCH" -R \
+CPPHTTPLIB_TEST_ISSUE_2431=1 \
+ASAN_OPTIONS=detect_stack_use_after_return=1 \
+setarch "$ARCH" -R \
   ./test --gtest_filter="GetAddrInfoAsyncCancelTest.*" 2>&1
 rc=$?
 set -e

--- a/test/test.cc
+++ b/test/test.cc
@@ -1549,6 +1549,128 @@ TEST(GetAddrInfoDanglingRefTest, LongTimeout) {
   std::this_thread::sleep_for(std::chrono::seconds(8));
 }
 
+#if defined(__linux__) && defined(__GLIBC__) &&                                \
+    defined(CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO)
+
+// Reproducer for https://github.com/yhirose/cpp-httplib/issues/2431.
+//
+// On Linux/glibc, getaddrinfo_with_timeout() runs the lookup via
+// getaddrinfo_a(GAI_NOWAIT) using a stack-local `struct gaicb`. When the
+// gai_suspend() call hits the connection timeout the function calls
+// gai_cancel() and returns immediately. gai_cancel() is non-blocking and
+// can return EAI_NOTCANCELED, in which case the resolver worker thread is
+// still alive and still references the now-destroyed stack frame.
+//
+// Triggering the bug requires DNS to actually hang (UDP/53 dropped, etc.),
+// so these tests are gated on CPPHTTPLIB_TEST_ISSUE_2431=1 and are skipped
+// during normal runs. test/run_issue_2431_repro.sh sets up the environment
+// and runs them in a container.
+namespace {
+bool should_run_issue_2431_tests() {
+  const char *v = getenv("CPPHTTPLIB_TEST_ISSUE_2431");
+  return v && *v && std::string(v) != "0";
+}
+
+std::string unique_unresolvable_host(int n) {
+  // .invalid is reserved (RFC 6761) and is never served by real DNS, but
+  // glibc still asks the configured nameserver — which is exactly the path
+  // we want to exercise. A unique label per call avoids the resolver cache.
+  auto t = std::chrono::steady_clock::now().time_since_epoch().count();
+  return "h-" + std::to_string(::getpid()) + "-" + std::to_string(t) + "-" +
+         std::to_string(n) + ".invalid";
+}
+} // namespace
+
+TEST(GetAddrInfoAsyncCancelTest, DirectCallSingleThread) {
+  if (!should_run_issue_2431_tests()) {
+    GTEST_SKIP()
+        << "Set CPPHTTPLIB_TEST_ISSUE_2431=1 (and sinkhole DNS) to run";
+  }
+
+  for (int i = 0; i < 8; ++i) {
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    auto host = unique_unresolvable_host(i);
+    struct addrinfo *result = nullptr;
+    int rc = detail::getaddrinfo_with_timeout(host.c_str(), "80", &hints,
+                                              &result, /*timeout_sec=*/1);
+    if (rc == 0 && result) { freeaddrinfo(result); }
+  }
+
+  // Give orphaned getaddrinfo_a worker threads a chance to write into the
+  // stack region they still believe holds their gaicb.
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+}
+
+TEST(GetAddrInfoAsyncCancelTest, DirectCallMultiThread) {
+  if (!should_run_issue_2431_tests()) {
+    GTEST_SKIP()
+        << "Set CPPHTTPLIB_TEST_ISSUE_2431=1 (and sinkhole DNS) to run";
+  }
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> threads;
+  for (int t = 0; t < 8; ++t) {
+    threads.emplace_back([t, &stop] {
+      int i = 0;
+      while (!stop.load(std::memory_order_relaxed)) {
+        struct addrinfo hints;
+        memset(&hints, 0, sizeof(hints));
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+
+        auto host = unique_unresolvable_host(t * 100000 + i++);
+        struct addrinfo *result = nullptr;
+        int rc = detail::getaddrinfo_with_timeout(host.c_str(), "80", &hints,
+                                                  &result, /*timeout_sec=*/1);
+        if (rc == 0 && result) { freeaddrinfo(result); }
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds(8));
+  stop.store(true, std::memory_order_relaxed);
+  for (auto &th : threads) {
+    th.join();
+  }
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+}
+
+TEST(GetAddrInfoAsyncCancelTest, ClientGetMultiThread) {
+  if (!should_run_issue_2431_tests()) {
+    GTEST_SKIP()
+        << "Set CPPHTTPLIB_TEST_ISSUE_2431=1 (and sinkhole DNS) to run";
+  }
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> threads;
+  for (int t = 0; t < 8; ++t) {
+    threads.emplace_back([t, &stop] {
+      int i = 0;
+      while (!stop.load(std::memory_order_relaxed)) {
+        auto host = unique_unresolvable_host(t * 100000 + i++);
+        Client cli(host, 80);
+        cli.set_connection_timeout(1, 0);
+        cli.set_read_timeout(1, 0);
+        cli.set_write_timeout(1, 0);
+        (void)cli.Get("/");
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds(8));
+  stop.store(true, std::memory_order_relaxed);
+  for (auto &th : threads) {
+    th.join();
+  }
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+}
+
+#endif // __linux__ && __GLIBC__ && CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO
+
 TEST(ConnectionErrorTest, InvalidHost) {
   auto host = "-abcde.com";
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -1552,6 +1552,18 @@ TEST(GetAddrInfoDanglingRefTest, LongTimeout) {
 #if defined(__linux__) && defined(__GLIBC__) &&                                \
     defined(CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO)
 
+// Forward declaration: in split builds split.py strips `inline` and moves the
+// definition into httplib.cc, so detail::getaddrinfo_with_timeout is not
+// visible from the public httplib.h. Re-declaring it here lets the tests link
+// against the symbol in both header-only and split builds.
+namespace httplib {
+namespace detail {
+int getaddrinfo_with_timeout(const char *node, const char *service,
+                             const struct addrinfo *hints,
+                             struct addrinfo **res, time_t timeout_sec);
+} // namespace detail
+} // namespace httplib
+
 // Reproducer for https://github.com/yhirose/cpp-httplib/issues/2431.
 //
 // On Linux/glibc, getaddrinfo_with_timeout() runs the lookup via


### PR DESCRIPTION
## Summary

Adds a CI-gated reproducer for #2431 — the use-after-free in `detail::getaddrinfo_with_timeout()` on Linux/glibc when `gai_suspend()` hits the connection timeout and the non-blocking `gai_cancel()` returns `EAI_NOTCANCELED`, leaving the resolver worker thread writing into the destroyed stack frame after the function has already returned.

This PR **only adds the reproducer**, not the fix. The new `issue-2431 repro (Linux + ASAN)` Linux CI job is expected to **fail** on this branch — that failure is the proof the test exercises the bug. The follow-up fix lives in #2434, where the same job goes green.

### What's included

- `test/test.cc` — three opt-in gtest cases under `GetAddrInfoAsyncCancelTest.*`:
  - `DirectCallSingleThread` — tight loop calling `detail::getaddrinfo_with_timeout()` with a 1s timeout against unique unresolvable hostnames.
  - `DirectCallMultiThread` — same, but from 8 worker threads concurrently.
  - `ClientGetMultiThread` — exercises the same path through the high-level `Client::Get()` API (matching the original repro from #2431).
  - All three are guarded by `#if defined(__linux__) && defined(__GLIBC__) && defined(CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO)` and skipped at runtime unless `CPPHTTPLIB_TEST_ISSUE_2431=1` is set, so normal `make test` runs are unaffected.
- `test/dns_test_fixture.py` — small (~50 line, stdlib-only) loopback UDP responder that answers DNS queries after a 3s delay. The deliberate delay (longer than the test's 1s timeout) is what gives the resolver worker thread something to write back *after* the caller's stack frame is gone.
- `.github/workflows/test.yaml` — new `issue-2431-repro` job on `ubuntu-latest`. It starts the test fixture on `127.0.0.1:15353`, installs an `iptables -t nat OUTPUT -p udp --dport 53 -j REDIRECT --to-port 15353` rule so glibc's lookups land on the fixture (without touching `/etc/resolv.conf`), and runs the gtest filter under `setarch -R` with `ASAN_OPTIONS=detect_stack_use_after_return=1`. A `tear down test fixture` step (`if: always()`) flushes the iptables rule and stops the fixture.
- `test/run_issue_2431_repro.sh` — Docker-based runner with the same fixture wiring so the failure can be reproduced locally on macOS / non-Linux dev machines.

### Why a delayed-reply fixture, not a DNS sinkhole

Earlier iterations of this PR dropped UDP/53 outright. That made glibc hang waiting for an answer that would never arrive — the worker never reached the buggy write-back path, so the broken HEAD and any candidate fix produced the same CI behaviour (tests pass + `Cleaning up orphan processes` hangs ~1h). Replacing the sinkhole with a fixture that **answers after the test's timeout** is what actually exercises the bug.

### Expected CI outcome on this branch

- ✗ `issue-2431 repro (Linux + ASAN)` — **fails fast** at the test step itself (~2 min total). Currently surfaces as `DirectCallMultiThread` exiting with SIGSEGV (exit 139) when the resolver worker writes back into reused stack memory; depending on the runner's stack reuse pattern ASAN may instead emit a `stack-use-after-return` diagnostic. Either signal is a clear test-step failure, not a job-level timeout.
- ✓ All other jobs unaffected (the new tests are skipped without the env var).

## Test plan

- [x] CI: `issue-2431 repro (Linux + ASAN)` job fails at the test step in ~2 min (proof the test exercises the bug).
- [x] CI: `ubuntu (openssl|mbedtls|wolfssl|no-tls)`, `macos`, `windows`, `test-no-exceptions`, etc. all pass unchanged.
- [ ] Local: `bash test/run_issue_2431_repro.sh` reproduces the failure inside Docker on a dev machine.

Refs: #2431. Fix: #2434.