### PR TITLE
Fix #2435: allow mmap to open files held open for writing

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5319,8 +5319,9 @@ inline bool mmap::open(const char *path) {
   auto wpath = u8string_to_wstring(path);
   if (wpath.empty()) { return false; }
 
-  hFile_ = ::CreateFile2(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ,
-                         OPEN_EXISTING, NULL);
+  hFile_ =
+      ::CreateFile2(wpath.c_str(), GENERIC_READ,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING, NULL);
 
   if (hFile_ == INVALID_HANDLE_VALUE) { return false; }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -7939,6 +7939,31 @@ TEST(MountTest, MultibytesPathName) {
   EXPECT_EQ(U8("日本語コンテンツ"), res->body);
 }
 
+#ifdef _WIN32
+// Issue #2435: mmap::open() must succeed even when another handle holds
+// the file open for writing (e.g. an active log file).
+TEST(MmapTest, OpenWhileFileHeldForWriting) {
+  const char *path = "mmap_concurrent_writer_test.txt";
+  const char *content = "hello";
+
+  {
+    std::ofstream f(path, std::ios::binary);
+    f.write(content, static_cast<std::streamsize>(strlen(content)));
+  }
+  auto file_cleanup = detail::scope_exit([&] { std::remove(path); });
+
+  HANDLE writer = ::CreateFileA(path, GENERIC_WRITE, FILE_SHARE_READ, NULL,
+                                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  ASSERT_NE(INVALID_HANDLE_VALUE, writer);
+  auto handle_cleanup = detail::scope_exit([&] { ::CloseHandle(writer); });
+
+  detail::mmap m(path);
+  ASSERT_TRUE(m.is_open());
+  EXPECT_EQ(strlen(content), m.size());
+  EXPECT_EQ(0, std::memcmp(content, m.data(), strlen(content)));
+}
+#endif
+
 TEST(KeepAliveTest, ReadTimeout) {
   Server svr;
 


### PR DESCRIPTION
## Summary

- Add `FILE_SHARE_WRITE` to the share mode passed to `::CreateFile2` in `detail::mmap::open` so a file held open by another process for writing (e.g. an active log file) can still be served by the static-file mount path on Windows. Without this, `CreateFile2` fails with `ERROR_SHARING_VIOLATION` because the new opener's share mode must permit the existing handle's access mode.
- Brings the Windows path's behavior in line with the POSIX path, which uses `::open(O_RDONLY)` and is unaffected by other processes' write handles.
- Add a regression test (`MmapTest.OpenWhileFileHeldForWriting`, Windows-only via `#ifdef _WIN32`) that opens a writer handle with `GENERIC_WRITE | FILE_SHARE_READ` and verifies `detail::mmap` can subsequently open the same file.

Fixes #2435

## Verification

CI on the fix branch was used to confirm both directions:

- **Without the fix**: `MmapTest.OpenWhileFileHeldForWriting` fails on Windows — the test reaches the `m.is_open()` check and observes `false` (mmap could not open the file). [Confirmed via a temporary diagnostic that aborted on the failure path so the shard log was dumped.]
- **With the fix**: the test passes. The Windows shard test count increases by 1 (`136 → 137`) and all shards are green.

## Test plan

- [x] Local build passes on macOS (Windows-only test compiled out via `#ifdef _WIN32`)
- [x] CI Windows / macOS / Linux green for this branch
- [ ] Reviewer to spot-check the `CreateFile2` change and confirm the share-mode reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)