### PR TITLE
Re-enable getaddrinfo_a with worker-completion wait (#2431)

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5906,17 +5906,65 @@ inline int getaddrinfo_with_timeout(const char *node, const char *service,
 
   *res = result_addrinfo;
   return 0;
+#elif defined(_GNU_SOURCE) && defined(__GLIBC__) &&                            \
+    (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 2))
+  // Linux implementation using getaddrinfo_a for asynchronous DNS resolution.
+  //
+  // Note on #2431: gai_cancel() is non-blocking and may return EAI_NOTCANCELED
+  // when the resolver worker is in the middle of an operation. Returning while
+  // the worker is still alive would let it write back to the now-destroyed
+  // stack-local request. After cancelling, we therefore wait for the worker
+  // to actually finish before returning.
+  struct gaicb request;
+  struct gaicb *requests[1] = {&request};
+  struct sigevent sevp;
+  struct timespec timeout;
+
+  memset(&request, 0, sizeof(request));
+  request.ar_name = node;
+  request.ar_service = service;
+  request.ar_request = hints;
+
+  timeout.tv_sec = timeout_sec;
+  timeout.tv_nsec = 0;
+
+  memset(&sevp, 0, sizeof(sevp));
+  sevp.sigev_notify = SIGEV_NONE;
+
+  int start_result = getaddrinfo_a(GAI_NOWAIT, requests, 1, &sevp);
+  if (start_result != 0) { return start_result; }
+
+  auto wait_for_request_done = [&]() {
+    // Block until the worker actually finishes touching `request`. Calling
+    // gai_suspend on an already-completed request returns immediately, so
+    // this is also safe to call after a successful gai_suspend above. The
+    // loop handles spurious EAI_INTR returns.
+    while (gai_error(&request) == EAI_INPROGRESS) {
+      gai_suspend(requests, 1, nullptr);
+    }
+  };
+
+  int wait_result =
+      gai_suspend((const struct gaicb *const *)requests, 1, &timeout);
+
+  if (wait_result == 0 || wait_result == EAI_ALLDONE) {
+    int gai_result = gai_error(&request);
+    if (gai_result == 0) {
+      *res = request.ar_result;
+      return 0;
+    }
+    if (request.ar_result) { freeaddrinfo(request.ar_result); }
+    return gai_result;
+  }
+
+  // Timeout or other suspension error: cancel and wait for the worker to
+  // release the stack-local gaicb before returning.
+  gai_cancel(&request);
+  wait_for_request_done();
+  if (request.ar_result) { freeaddrinfo(request.ar_result); }
+  return wait_result;
 #else
   // Fallback implementation using thread-based timeout for other Unix systems.
-  //
-  // The previous Linux/glibc path used getaddrinfo_a(GAI_NOWAIT) with a
-  // stack-local gaicb. On timeout it called gai_cancel(), which is non-
-  // blocking and may return EAI_NOTCANCELED -- the resolver worker would
-  // then write back to the destroyed stack frame after this function had
-  // already returned (#2431). The std::thread + shared_ptr fallback below
-  // is correct for the same reason it works on other platforms: the
-  // worker captures shared ownership of the state, so it stays alive as
-  // long as anyone (caller or worker) still holds a reference.
 
   struct GetAddrInfoState {
     ~GetAddrInfoState() {

--- a/httplib.h
+++ b/httplib.h
@@ -5908,60 +5908,47 @@ inline int getaddrinfo_with_timeout(const char *node, const char *service,
   return 0;
 #elif defined(_GNU_SOURCE) && defined(__GLIBC__) &&                            \
     (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 2))
-  // Linux implementation using getaddrinfo_a for asynchronous DNS resolution.
-  //
-  // Note on #2431: gai_cancel() is non-blocking and may return EAI_NOTCANCELED
-  // when the resolver worker is in the middle of an operation. Returning while
-  // the worker is still alive would let it write back to the now-destroyed
-  // stack-local request. After cancelling, we therefore wait for the worker
-  // to actually finish before returning.
-  struct gaicb request;
+  // #2431: gai_cancel() is non-blocking and may return EAI_NOTCANCELED while
+  // the resolver worker still references the stack-local gaicb. The cancel
+  // path therefore waits (gai_suspend with no timeout) for the worker to
+  // actually finish before letting the stack frame go. The trade-off is that
+  // a wedged DNS server can hold this thread for the system resolver timeout
+  // (~30s by default) past the caller's connection timeout.
+  struct gaicb request {};
   struct gaicb *requests[1] = {&request};
-  struct sigevent sevp;
-  struct timespec timeout;
+  struct sigevent sevp {};
+  struct timespec timeout {
+    timeout_sec, 0
+  };
 
-  memset(&request, 0, sizeof(request));
   request.ar_name = node;
   request.ar_service = service;
   request.ar_request = hints;
-
-  timeout.tv_sec = timeout_sec;
-  timeout.tv_nsec = 0;
-
-  memset(&sevp, 0, sizeof(sevp));
   sevp.sigev_notify = SIGEV_NONE;
 
-  int start_result = getaddrinfo_a(GAI_NOWAIT, requests, 1, &sevp);
-  if (start_result != 0) { return start_result; }
+  int rc = getaddrinfo_a(GAI_NOWAIT, requests, 1, &sevp);
+  if (rc != 0) { return rc; }
 
-  auto wait_for_request_done = [&]() {
-    // Block until the worker actually finishes touching `request`. Calling
-    // gai_suspend on an already-completed request returns immediately, so
-    // this is also safe to call after a successful gai_suspend above. The
-    // loop handles spurious EAI_INTR returns.
-    while (gai_error(&request) == EAI_INPROGRESS) {
-      gai_suspend(requests, 1, nullptr);
-    }
-  };
+  auto cleanup = scope_exit([&] {
+    if (request.ar_result) { freeaddrinfo(request.ar_result); }
+  });
 
-  int wait_result =
-      gai_suspend((const struct gaicb *const *)requests, 1, &timeout);
+  int wait_result = gai_suspend(requests, 1, &timeout);
 
   if (wait_result == 0 || wait_result == EAI_ALLDONE) {
     int gai_result = gai_error(&request);
     if (gai_result == 0) {
       *res = request.ar_result;
+      request.ar_result = nullptr;
       return 0;
     }
-    if (request.ar_result) { freeaddrinfo(request.ar_result); }
     return gai_result;
   }
 
-  // Timeout or other suspension error: cancel and wait for the worker to
-  // release the stack-local gaicb before returning.
   gai_cancel(&request);
-  wait_for_request_done();
-  if (request.ar_result) { freeaddrinfo(request.ar_result); }
+  while (gai_error(&request) == EAI_INPROGRESS) {
+    gai_suspend(requests, 1, nullptr);
+  }
   return wait_result;
 #else
   // Fallback implementation using thread-based timeout for other Unix systems.


### PR DESCRIPTION
## Summary

5ebbfee dropped the Linux/glibc `getaddrinfo_a` branch to eliminate the use-after-free reported in #2431. That sidestepped the bug but lost the async DNS resolution feature. This PR restores the branch with the actually-correct fix.

The use-after-free pattern was:
1. `getaddrinfo_a(GAI_NOWAIT, ...)` schedules the lookup against a stack-local `struct gaicb`
2. `gai_suspend()` returns `EAI_AGAIN` on connection timeout
3. `gai_cancel()` is called — but this is non-blocking and may return `EAI_NOTCANCELED` while the worker is still mid-operation
4. The function returns, the stack frame is destroyed
5. The worker writes back to `ar_result` on the now-destroyed frame → heap corruption

Fix: after `gai_cancel()`, wait for the worker to actually finish before returning. Implemented via `gai_suspend(timeout=NULL)` looped until `gai_error()` no longer returns `EAI_INPROGRESS`. The same wait applies to all non-success suspension paths, and `freeaddrinfo()` is called on any partially-populated `ar_result` to plug error-path leaks.

This is the approach suggested in the original issue body, with `gai_suspend` substituted for busy-polling `gai_error`.

## Verification

The existing #2431 reproducer (`GetAddrInfoAsyncCancelTest.*`, gated on `CPPHTTPLIB_TEST_ISSUE_2431=1`, run under ASAN with sinkhole DNS) is unchanged. It now drives the restored `getaddrinfo_a` path rather than the `std::thread` fallback. ASAN must remain clean — the whole point of this PR is to make that path safe under cancellation.

## Test plan

- [x] Local build passes on macOS (`#elif _GNU_SOURCE && __GLIBC__` is excluded)
- [ ] Linux + ASAN reproducer (`issue-2431-repro` job) stays green
- [ ] Full ubuntu/macos/windows test matrix stays green
- [ ] Reviewer to spot-check the cancel-and-wait sequence and confirm no path leaves the stack `gaicb` accessible to the worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)