### PR TITLE
Use vswhere to locate VS install in 32-bit Windows CI

### DIFF
--- a/.github/workflows/test-32bit.yml
+++ b/.github/workflows/test-32bit.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Build (Win32)
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set VSDIR=%%i
+          call "%VSDIR%\VC\Auxiliary\Build\vcvarsall.bat" x86 || exit /b 1
           cl /std:c++14 /EHsc /W4 /WX /c /Fo:NUL test\test_32bit_build.cpp
 
   test-arm32:


### PR DESCRIPTION
## Summary

- The hosted `windows-latest` runner is being migrated from VS 2022 to VS 2026 (annotation in current runs: *NOTICE: windows-2025 requests are being redirected to windows-2025-vs2026 by 2026-05-12*).
- `.github/workflows/test-32bit.yml` hardcoded `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat`. On the new image that path no longer exists, `vcvarsall.bat` silently fails, and the next line errors with `'cl' is not recognized`.
- Resolve the VS install path at runtime via `vswhere.exe` (stable location, version agnostic), and add `|| exit /b 1` so a failed `vcvarsall.bat` surfaces immediately instead of as a confusing `cl not recognized` error downstream.

## Failing run

Confirmed against https://github.com/yhirose/cpp-httplib/actions/runs/25428005183/job/74586508145 — same workflow, same source, succeeded on 2026-05-04 and failed on 2026-05-06 once the runner image flipped over.

## Test plan

- [ ] CI: `Windows 32-bit (MSVC x86)` job passes on this PR
- [ ] No regression on `ARM 32-bit (cross-compile)` job