### PR TITLE
Guard nullptr res in KeepAliveTest proxy template

### DIFF
--- a/test/test_proxy.cc
+++ b/test/test_proxy.cc
@@ -291,10 +291,12 @@ template <typename T> void KeepAliveTest(T &cli, bool basic) {
 
   {
     auto res = cli.Get("/get");
+    ASSERT_TRUE(res != nullptr);
     EXPECT_EQ(StatusCode::OK_200, res->status);
   }
   {
     auto res = cli.Get("/redirect/2");
+    ASSERT_TRUE(res != nullptr);
     EXPECT_EQ(StatusCode::OK_200, res->status);
   }
 
@@ -306,6 +308,7 @@ template <typename T> void KeepAliveTest(T &cli, bool basic) {
 
     for (auto path : paths) {
       auto res = cli.Get(path.c_str());
+      ASSERT_TRUE(res != nullptr);
       auto body = normalizeJson(res->body);
       EXPECT_TRUE(body.find("\"authenticated\":true") != std::string::npos);
       EXPECT_TRUE(body.find("\"user\":\"hello\"") != std::string::npos);
@@ -317,6 +320,7 @@ template <typename T> void KeepAliveTest(T &cli, bool basic) {
     int count = 10;
     while (count--) {
       auto res = cli.Get("/get");
+      ASSERT_TRUE(res != nullptr);
       EXPECT_EQ(StatusCode::OK_200, res->status);
     }
   }


### PR DESCRIPTION
## Summary

`KeepAliveTest` (template in `test/test_proxy.cc`) calls `cli.Get(...)` and immediately dereferences `res` without a `nullptr` check. When the upstream request to `httpbingo.org` transiently fails (network blip / proxy hiccup), `res` is `nullptr` and the next line crashes the test process with a SEGV inside `std::__cxx11::basic_string<...>::begin()` under ASan, taking the whole proxy test job down.

Observed in https://github.com/yhirose/cpp-httplib/actions/runs/25435118501/job/74610932675 — the same source SHA had passed proxy tests on the PR run minutes earlier, confirming flakiness rather than a real regression.

Add `ASSERT_TRUE(res != nullptr);` to the four `Get()` call sites inside the `KeepAliveTest` template. The sibling templates in the same file (`ProxyTest`, line 19) already use this pattern.

## Test plan

- [ ] CI: `proxy (openssl)` job passes
- [ ] CI: `proxy (mbedtls)` job passes