### PR TITLE
Fix iOS build break and modernize macOS Keychain cert loading

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -250,6 +250,54 @@ jobs:
       - name: build and run ThreadPool test
         run: cd test && make test_thread_pool && ./test_thread_pool
 
+  ios-parse-check:
+    runs-on: macos-latest
+    if: >
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request'  &&
+       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.test_macos == 'true')
+    name: ios header parse check (not officially supported)
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: install OpenSSL headers
+        run: brew install openssl@3
+      - name: verify header parses on iOS target
+        run: |
+          IOS_SDK=$(xcrun --sdk iphoneos --show-sdk-path)
+          OPENSSL_INC=$(brew --prefix openssl@3)/include
+          echo "Using iOS SDK: $IOS_SDK"
+          echo '#include "httplib.h"' | clang++ \
+            -isysroot "$IOS_SDK" \
+            -target arm64-apple-ios16.0 \
+            -std=c++11 \
+            -DCPPHTTPLIB_OPENSSL_SUPPORT \
+            -I"$OPENSSL_INC" \
+            -I. -Wall -Wextra \
+            -fsyntax-only -x c++ -
+      - name: verify CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN is rejected on iOS
+        run: |
+          IOS_SDK=$(xcrun --sdk iphoneos --show-sdk-path)
+          OPENSSL_INC=$(brew --prefix openssl@3)/include
+          out=$(echo '#include "httplib.h"' | clang++ \
+            -isysroot "$IOS_SDK" \
+            -target arm64-apple-ios16.0 \
+            -std=c++11 \
+            -DCPPHTTPLIB_OPENSSL_SUPPORT \
+            -DCPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN \
+            -I"$OPENSSL_INC" \
+            -I. \
+            -fsyntax-only -x c++ - 2>&1 || true)
+          if echo "$out" | grep -q "only supported on macOS"; then
+            echo "OK: #error fired as expected"
+          else
+            echo "FAIL: expected #error did not fire"
+            echo "--- compiler output ---"
+            echo "$out"
+            exit 1
+          fi
+
   windows:
     runs-on: windows-latest
     if: >

--- a/httplib.h
+++ b/httplib.h
@@ -339,15 +339,25 @@ using socket_t = int;
 #include <utility>
 
 // On macOS with a TLS backend, enable Keychain root certificates by default
-// unless the user explicitly opts out.
+// unless the user explicitly opts out. Not enabled on iOS/tvOS/watchOS since
+// the SecTrustSettings APIs used to enumerate anchor certificates are macOS
+// only; on those platforms the user must provide a CA bundle explicitly.
 #if defined(__APPLE__) && defined(__clang__) &&                                \
     !defined(CPPHTTPLIB_DISABLE_MACOSX_AUTOMATIC_ROOT_CERTIFICATES) &&         \
     (defined(CPPHTTPLIB_OPENSSL_SUPPORT) ||                                    \
      defined(CPPHTTPLIB_MBEDTLS_SUPPORT) ||                                    \
      defined(CPPHTTPLIB_WOLFSSL_SUPPORT))
+#if TARGET_OS_OSX
 #ifndef CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN
 #define CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN
 #endif
+#endif
+#endif
+
+#if defined(CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN) &&                      \
+    defined(__APPLE__) && !TARGET_OS_OSX
+#error                                                                         \
+    "CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN is only supported on macOS. On iOS/tvOS/watchOS, supply a CA bundle via set_ca_cert_path()."
 #endif
 
 // On Windows, enable Schannel certificate verification by default
@@ -382,7 +392,7 @@ using socket_t = int;
 #endif // _WIN32
 
 #ifdef CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #include <Security/Security.h>
 #endif
 #endif
@@ -430,7 +440,7 @@ using socket_t = int;
 #endif
 #endif // _WIN32
 #ifdef CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #include <Security/Security.h>
 #endif
 #endif
@@ -473,7 +483,7 @@ using socket_t = int;
 #endif
 #endif // _WIN32
 #ifdef CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #include <Security/Security.h>
 #endif
 #endif

--- a/httplib.h
+++ b/httplib.h
@@ -16143,9 +16143,18 @@ inline bool enumerate_windows_system_certs(Callback cb) {
 template <typename Callback>
 inline bool enumerate_macos_keychain_certs(Callback cb) {
   bool loaded = false;
-  CFArrayRef certs = nullptr;
-  OSStatus status = SecTrustCopyAnchorCertificates(&certs);
-  if (status == errSecSuccess && certs) {
+  const SecTrustSettingsDomain domains[] = {
+      kSecTrustSettingsDomainSystem,
+      kSecTrustSettingsDomainAdmin,
+      kSecTrustSettingsDomainUser,
+  };
+  for (auto domain : domains) {
+    CFArrayRef certs = nullptr;
+    OSStatus status = SecTrustSettingsCopyCertificates(domain, &certs);
+    if (status != errSecSuccess || !certs) {
+      if (certs) CFRelease(certs);
+      continue;
+    }
     CFIndex count = CFArrayGetCount(certs);
     for (CFIndex i = 0; i < count; i++) {
       SecCertificateRef cert =
@@ -16508,28 +16517,36 @@ inline bool load_system_certs(ctx_t ctx) {
   auto store = SSL_CTX_get_cert_store(ssl_ctx);
   if (!store) return false;
 
-  CFArrayRef certs = nullptr;
-  if (SecTrustCopyAnchorCertificates(&certs) != errSecSuccess || !certs) {
-    return SSL_CTX_set_default_verify_paths(ssl_ctx) == 1;
-  }
-
   bool loaded_any = false;
-  auto count = CFArrayGetCount(certs);
-  for (CFIndex i = 0; i < count; i++) {
-    auto cert = reinterpret_cast<SecCertificateRef>(
-        const_cast<void *>(CFArrayGetValueAtIndex(certs, i)));
-    CFDataRef der = SecCertificateCopyData(cert);
-    if (der) {
-      const unsigned char *data = CFDataGetBytePtr(der);
-      auto x509 = d2i_X509(nullptr, &data, CFDataGetLength(der));
-      if (x509) {
-        if (X509_STORE_add_cert(store, x509) == 1) { loaded_any = true; }
-        X509_free(x509);
-      }
-      CFRelease(der);
+  const SecTrustSettingsDomain domains[] = {
+      kSecTrustSettingsDomainSystem,
+      kSecTrustSettingsDomainAdmin,
+      kSecTrustSettingsDomainUser,
+  };
+  for (auto domain : domains) {
+    CFArrayRef certs = nullptr;
+    if (SecTrustSettingsCopyCertificates(domain, &certs) != errSecSuccess ||
+        !certs) {
+      if (certs) CFRelease(certs);
+      continue;
     }
+    auto count = CFArrayGetCount(certs);
+    for (CFIndex i = 0; i < count; i++) {
+      auto cert = reinterpret_cast<SecCertificateRef>(
+          const_cast<void *>(CFArrayGetValueAtIndex(certs, i)));
+      CFDataRef der = SecCertificateCopyData(cert);
+      if (der) {
+        const unsigned char *data = CFDataGetBytePtr(der);
+        auto x509 = d2i_X509(nullptr, &data, CFDataGetLength(der));
+        if (x509) {
+          if (X509_STORE_add_cert(store, x509) == 1) { loaded_any = true; }
+          X509_free(x509);
+        }
+        CFRelease(der);
+      }
+    }
+    CFRelease(certs);
   }
-  CFRelease(certs);
   return loaded_any || SSL_CTX_set_default_verify_paths(ssl_ctx) == 1;
 #else
   return SSL_CTX_set_default_verify_paths(ssl_ctx) == 1;


### PR DESCRIPTION
## Summary
- Replace deprecated `SecTrustCopyAnchorCertificates` with `SecTrustSettingsCopyCertificates`, iterating over the System/Admin/User trust domains
- Restrict the `CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN` auto-enable and `Security.h` include guards from `TARGET_OS_MAC` (true on all Apple platforms) to `TARGET_OS_OSX` (macOS only). Emit an explicit `#error` if the user defines the macro on iOS/tvOS/watchOS
- Add a lightweight iOS header parse check to CI (cross-compile syntax-only, not a runtime support promise)

Addresses the iOS build break reported in #2454, with a different approach (root cause fix rather than `#ifdef` wrapping).

## Test plan
- [x] `make test` and `make test_split` pass on macOS with all SSL backends
- [x] `SSLClientTest.ServerCertificateVerification1_Online` confirms Keychain loading still works via the new API
- [x] Cross-compiled `-fsyntax-only` against iOS SDK 26.2 with `arm64-apple-ios16.0`:
  - Without explicit `CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN` → clean compile
  - With it defined → expected `#error` fires
- [x] New CI job exercises both cases on `macos-latest`