### PR TITLE
Fix: "warning : missing field * initializer"

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5730,7 +5730,7 @@ inline int getaddrinfo_with_timeout(const char *node, const char *service,
 
 #ifdef _WIN32
   // Windows-specific implementation using GetAddrInfoEx with overlapped I/O
-  OVERLAPPED overlapped = {0};
+  OVERLAPPED overlapped = {};
   HANDLE event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
   if (!event) { return EAI_FAIL; }
 
@@ -5739,7 +5739,7 @@ inline int getaddrinfo_with_timeout(const char *node, const char *service,
   PADDRINFOEXW result_addrinfo = nullptr;
   HANDLE cancel_handle = nullptr;
 
-  ADDRINFOEXW hints_ex = {0};
+  ADDRINFOEXW hints_ex = {};
   if (hints) {
     hints_ex.ai_flags = hints->ai_flags;
     hints_ex.ai_family = hints->ai_family;


### PR DESCRIPTION
When compiling on Windows using clang 22 (C++20) with "Warning Level 4" (/W4), the following warning appears:
"httplib.h(5733,29): warning : missing field 'InternalHigh' initializer [-Wmissing-field-initializers]"
"httplib.h(5742,28): warning : missing field 'ai_family' initializer [-Wmissing-field-initializers]"
<img width="823" height="32" alt="image" src="https://github.com/user-attachments/assets/c8a27d4b-8057-4741-8bed-64d216ca7b4f" />

Initializing the structure using "= {};" solves this problem.