### PR TITLE
add set_hostname_addr_map to WebSocketClient

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -20411,7 +20411,8 @@ inline void WebSocketClient::set_interface(const std::string &intf) {
   interface_ = intf;
 }
 
-inline void WebSocketClient::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
+inline void WebSocketClient::set_hostname_addr_map(
+    std::map<std::string, std::string> addr_map) {
   addr_map_ = std::move(addr_map);
 }
 

--- a/httplib.h
+++ b/httplib.h
@@ -3842,6 +3842,7 @@ public:
   void set_socket_options(SocketOptions socket_options);
   void set_connection_timeout(time_t sec, time_t usec = 0);
   void set_interface(const std::string &intf);
+  void set_hostname_addr_map(std::map<std::string, std::string> addr_map);
 
 #ifdef CPPHTTPLIB_SSL_ENABLED
   void set_ca_cert_path(const std::string &path);
@@ -3875,6 +3876,9 @@ private:
   time_t connection_timeout_sec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_SECOND;
   time_t connection_timeout_usec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_USECOND;
   std::string interface_;
+
+  // Hostname-IP map
+  std::map<std::string, std::string> addr_map_;
 
 #ifdef CPPHTTPLIB_SSL_ENABLED
   bool is_ssl_ = false;
@@ -20305,9 +20309,14 @@ inline bool WebSocketClient::connect() {
   if (!is_valid_) { return false; }
   shutdown_and_close();
 
+  // Check is custom IP specified for host_
+  std::string ip;
+  auto it = addr_map_.find(host_);
+  if (it != addr_map_.end()) { ip = it->second; }
+
   Error error;
   sock_ = detail::create_client_socket(
-      host_, std::string(), port_, address_family_, tcp_nodelay_, ipv6_v6only_,
+      host_, ip, port_, address_family_, tcp_nodelay_, ipv6_v6only_,
       socket_options_, connection_timeout_sec_, connection_timeout_usec_,
       read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
       write_timeout_usec_, interface_, error);
@@ -20400,6 +20409,10 @@ inline void WebSocketClient::set_connection_timeout(time_t sec, time_t usec) {
 
 inline void WebSocketClient::set_interface(const std::string &intf) {
   interface_ = intf;
+}
+
+inline void WebSocketClient::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
+  addr_map_ = std::move(addr_map);
 }
 
 #ifdef CPPHTTPLIB_SSL_ENABLED

--- a/test/test.cc
+++ b/test/test.cc
@@ -17684,6 +17684,9 @@ TEST(WebSocketTest, SpecifyServerIPAddress_RealHostname) {
 
   ws::WebSocketClient client("ws://localhost:" + std::to_string(port) + "/ws");
   client.set_hostname_addr_map({{"localhost", wrong_ip}});
+  client.set_connection_timeout(1);
+  client.set_read_timeout(1);
+  client.set_write_timeout(1);
 
   EXPECT_FALSE(client.connect());
   EXPECT_FALSE(client.is_open());

--- a/test/test.cc
+++ b/test/test.cc
@@ -17658,8 +17658,7 @@ TEST(WebSocketTest, SpecifyServerIPAddress_AnotherHostname) {
   auto another_host = "example.com";
   auto wrong_ip = "192.0.2.1";
 
-  ws::WebSocketClient client(
-      "ws://localhost:" + std::to_string(port) + "/ws");
+  ws::WebSocketClient client("ws://localhost:" + std::to_string(port) + "/ws");
   client.set_hostname_addr_map({{another_host, wrong_ip}});
 
   ASSERT_TRUE(client.connect());
@@ -17683,8 +17682,7 @@ TEST(WebSocketTest, SpecifyServerIPAddress_RealHostname) {
 
   auto wrong_ip = "192.0.2.1";
 
-  ws::WebSocketClient client(
-      "ws://localhost:" + std::to_string(port) + "/ws");
+  ws::WebSocketClient client("ws://localhost:" + std::to_string(port) + "/ws");
   client.set_hostname_addr_map({{"localhost", wrong_ip}});
 
   EXPECT_FALSE(client.connect());

--- a/test/test.cc
+++ b/test/test.cc
@@ -17656,7 +17656,7 @@ TEST(WebSocketTest, SpecifyServerIPAddress_AnotherHostname) {
   svr.wait_until_ready();
 
   auto another_host = "example.com";
-  auto wrong_ip = "0.0.0.0";
+  auto wrong_ip = "192.0.2.1";
 
   ws::WebSocketClient client(
       "ws://localhost:" + std::to_string(port) + "/ws");
@@ -17681,7 +17681,7 @@ TEST(WebSocketTest, SpecifyServerIPAddress_RealHostname) {
   std::thread t([&]() { svr.listen_after_bind(); });
   svr.wait_until_ready();
 
-  auto wrong_ip = "0.0.0.0";
+  auto wrong_ip = "192.0.2.1";
 
   ws::WebSocketClient client(
       "ws://localhost:" + std::to_string(port) + "/ws");

--- a/test/test.cc
+++ b/test/test.cc
@@ -17644,6 +17644,56 @@ TEST(WebSocketTest, ComplexPath) {
   EXPECT_TRUE(ws2.is_valid());
 }
 
+TEST(WebSocketTest, SpecifyServerIPAddress_AnotherHostname) {
+  Server svr;
+  svr.WebSocket("/ws", [](const Request &, ws::WebSocket &ws) {
+    std::string msg;
+    while (ws.read(msg)) {}
+  });
+
+  auto port = svr.bind_to_any_port(HOST);
+  std::thread t([&]() { svr.listen_after_bind(); });
+  svr.wait_until_ready();
+
+  auto another_host = "example.com";
+  auto wrong_ip = "0.0.0.0";
+
+  ws::WebSocketClient client(
+      "ws://localhost:" + std::to_string(port) + "/ws");
+  client.set_hostname_addr_map({{another_host, wrong_ip}});
+
+  ASSERT_TRUE(client.connect());
+  EXPECT_TRUE(client.is_open());
+  client.close();
+
+  svr.stop();
+  t.join();
+}
+
+TEST(WebSocketTest, SpecifyServerIPAddress_RealHostname) {
+  Server svr;
+  svr.WebSocket("/ws", [](const Request &, ws::WebSocket &ws) {
+    std::string msg;
+    while (ws.read(msg)) {}
+  });
+
+  auto port = svr.bind_to_any_port(HOST);
+  std::thread t([&]() { svr.listen_after_bind(); });
+  svr.wait_until_ready();
+
+  auto wrong_ip = "0.0.0.0";
+
+  ws::WebSocketClient client(
+      "ws://localhost:" + std::to_string(port) + "/ws");
+  client.set_hostname_addr_map({{"localhost", wrong_ip}});
+
+  EXPECT_FALSE(client.connect());
+  EXPECT_FALSE(client.is_open());
+
+  svr.stop();
+  t.join();
+}
+
 class WebSocketIntegrationTest : public ::testing::Test {
 protected:
   void SetUp() override {


### PR DESCRIPTION
WebSockets also need the set_hostname_addr_map function when connecting.