### PR TITLE
Ignore range requests for unknown-length streaming responses

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8362,6 +8362,14 @@ inline void coalesce_ranges(Ranges &ranges, size_t content_length) {
 
 inline bool range_error(Request &req, Response &res) {
   if (!req.ranges.empty() && 200 <= res.status && res.status < 300) {
+    if (res.body.empty() && res.content_provider_ && res.content_length_ == 0) {
+      req.ranges.clear();
+      if (res.status == StatusCode::PartialContent_206) {
+        res.status = StatusCode::OK_200;
+      }
+      return false;
+    }
+
     ssize_t content_len = static_cast<ssize_t>(
         res.content_length_ ? res.content_length_ : res.body.size());
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -3589,6 +3589,23 @@ protected:
                      return true;
                    });
              })
+        .Get("/streamed-without-length",
+             [&](const Request & /*req*/, Response &res) {
+               auto data = new std::string("abcdefg");
+               res.set_content_provider(
+                   "text/plain",
+                   [data](size_t offset, DataSink &sink) {
+                     if (offset < data->size()) {
+                       sink.os << data->substr(offset);
+                     }
+                     sink.done();
+                     return true;
+                   },
+                   [data](bool success) {
+                     EXPECT_TRUE(success);
+                     delete data;
+                   });
+             })
         .Get("/streamed-with-range",
              [&](const Request &req, Response &res) {
                auto data = new std::string("abcdefg");
@@ -5022,6 +5039,16 @@ TEST_F(ServerTest, GetStreamed) {
   EXPECT_EQ(StatusCode::OK_200, res->status);
   EXPECT_EQ("6", res->get_header_value("Content-Length"));
   EXPECT_EQ(std::string("aaabbb"), res->body);
+}
+
+TEST_F(ServerTest, GetStreamedWithoutLengthWithRange) {
+  auto res =
+      cli_.Get("/streamed-without-length", {make_range_header({{0, -1}})});
+  ASSERT_TRUE(res);
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ(false, res->has_header("Content-Length"));
+  EXPECT_EQ(false, res->has_header("Content-Range"));
+  EXPECT_EQ(std::string("abcdefg"), res->body);
 }
 
 TEST_F(ServerTest, GetStreamedWithRange1) {


### PR DESCRIPTION
Clients like ffmpeg/browser-like clients may send `Range: bytes=0-` for live multipart streams. A concrete example is a live MJPEG stream served as multipart/x-mixed-replace.

In such a scenario the resource is not meaningfully byte-range addressable: there is no known total length and no stable "complete representation" to range over. 
What happens currently, is that the range validation will fail and result in  HTTP 416 (Range Not Satisfiable).

The cleaner response shape is a normal streaming response (since 206 doesnt really make much sense) and ignoring the range erquest in this particular case, e.g.:

```
HTTP/1.1 200 OK
Content-Type: multipart/x-mixed-replace; boundary=frame
Cache-Control: no-store
etc
```

This should be permissible and correct, because HTTP range handling [1] is optional as a request modifier, i.e. it is legal to simply respond with 200 OK and the complete representation. 206 is only appropriate when the server honors the range request.

[1] https://httpwg.org/specs/rfc7233.html#rfc.section.3
