### PR TITLE
use strict hex parsing in decode_query_component

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -9734,11 +9734,9 @@ inline std::string decode_query_component(const std::string &component,
 
   for (size_t i = 0; i < component.size(); i++) {
     if (component[i] == '%' && i + 2 < component.size()) {
-      std::string hex = component.substr(i + 1, 2);
-      char *end;
-      unsigned long value = std::strtoul(hex.c_str(), &end, 16);
-      if (end == hex.c_str() + 2) {
-        result += static_cast<char>(value);
+      auto val = 0;
+      if (detail::from_hex_to_i(component, i + 1, 2, val)) {
+        result += static_cast<char>(val);
         i += 2;
       } else {
         result += component[i];

--- a/test/test.cc
+++ b/test/test.cc
@@ -386,6 +386,19 @@ TEST(DecodePathTest, UnicodeEncoding) {
   EXPECT_EQ("", decode_path_component("%uD800"));
 }
 
+TEST(DecodeQueryTest, RejectsNonHexEscapes) {
+  // A sign or whitespace inside the two-character escape window must not be
+  // accepted as a valid percent-encoding; the sequence is passed through
+  // literally, matching decode_uri_component / decode_path_component.
+  EXPECT_EQ("%-1", decode_query_component("%-1", false));
+  EXPECT_EQ("%-0", decode_query_component("%-0", false));
+  EXPECT_EQ("%+5", decode_query_component("%+5", false));
+  EXPECT_EQ("% 5", decode_query_component("% 5", false));
+  // Well-formed escapes still decode.
+  EXPECT_EQ("-", decode_query_component("%2D", false));
+  EXPECT_EQ("A", decode_query_component("%41", false));
+}
+
 TEST(SanitizeFilenameTest, VariousPatterns) {
   // Path traversal
   EXPECT_EQ("passwd", httplib::sanitize_filename("../../../etc/passwd"));


### PR DESCRIPTION
decode_query_component decodes each percent escape by handing a two character substring to std::strtoul, which tolerates a leading sign or whitespace, so input that is not valid hex still parses. reached from untrusted query strings through parse_query_text, "%-0" decodes to a NUL byte, "%-1" to 0xFF and "%+5" or "% 5" to 0x05, whereas decode_uri_component and decode_path_component reject the same sequences via detail::from_hex_to_i and leave them literal. switching this helper to from_hex_to_i brings the three decoders back into agreement and drops the throwaway substring allocation; well formed escapes are untouched, so it should read as a strictness fix rather than a behaviour change.