### PR TITLE
make from_chars(double) parsing locale-independent

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -312,6 +312,7 @@ using socket_t = int;
 #include <cctype>
 #include <chrono>
 #include <climits>
+#include <clocale>
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
@@ -686,10 +687,21 @@ inline from_chars_result<T> from_chars(const char *first, const char *last,
   return {p, std::errc{}};
 }
 
-// from_chars for double (simple wrapper for strtod)
+// from_chars for double (locale-independent wrapper for strtod)
 inline from_chars_result<double> from_chars(const char *first, const char *last,
                                             double &value) {
   std::string s(first, last);
+  // strtod reads the decimal point according to the global C locale, but the
+  // textual numbers parsed here (e.g. HTTP quality values) always use '.'.
+  // When the active locale uses a different single-character separator,
+  // translate '.' to it so the result does not depend on the host locale,
+  // matching the integer overload above. A one-for-one substitution keeps the
+  // byte offsets used below valid.
+  const char *point = std::localeconv()->decimal_point;
+  if (point != nullptr && point[0] != '\0' && point[1] == '\0' &&
+      point[0] != '.') {
+    std::replace(s.begin(), s.end(), '.', point[0]);
+  }
   char *endptr = nullptr;
   errno = 0;
   value = std::strtod(s.c_str(), &endptr);

--- a/test/test.cc
+++ b/test/test.cc
@@ -745,6 +745,41 @@ TEST(ParseAcceptHeaderTest, SpecialCases) {
   EXPECT_EQ(no_space_result[2], "text/plain");
 }
 
+TEST(ParseAcceptHeaderTest, QualityValueLocaleIndependence) {
+  // Quality values always use '.' as the decimal separator, so parsing must
+  // not depend on the process locale. An embedding application may have
+  // switched to a locale that uses ',' via setlocale(LC_ALL, "").
+  const char *cur = std::setlocale(LC_NUMERIC, nullptr);
+  std::string saved = cur ? cur : "C";
+
+  const char *comma_locales[] = {"de_DE.UTF-8", "de_DE.utf8", "nl_NL.UTF-8",
+                                 "fr_FR.UTF-8"};
+  bool switched = false;
+  for (const auto loc : comma_locales) {
+    if (std::setlocale(LC_NUMERIC, loc) != nullptr &&
+        std::localeconv()->decimal_point[0] == ',') {
+      switched = true;
+      break;
+    }
+  }
+  if (!switched) {
+    std::setlocale(LC_NUMERIC, saved.c_str());
+    GTEST_SKIP() << "no comma-decimal locale available on this host";
+  }
+
+  // The higher-weighted type appears later in the list, so a correct parse
+  // must reorder it ahead of the earlier, lower-weighted one. A locale-
+  // sensitive parse reads both weights as 0 and leaves the original order.
+  std::vector<std::string> result;
+  EXPECT_TRUE(detail::parse_accept_header(
+      "application/json;q=0.1,text/html;q=0.9", result));
+  ASSERT_EQ(result.size(), 2U);
+  EXPECT_EQ(result[0], "text/html");
+  EXPECT_EQ(result[1], "application/json");
+
+  std::setlocale(LC_NUMERIC, saved.c_str());
+}
+
 TEST(ParseAcceptHeaderTest, InvalidCases) {
   std::vector<std::string> result;
 


### PR DESCRIPTION
**Locale-dependent quality value parsing**

`detail::from_chars(double)` hands off to `std::strtod`, which reads the decimal point from the global C locale, whereas the integer overload beside it is written to stay locale-independent. Once an embedding process has run `setlocale(LC_ALL, "")` into a locale that uses ',' (de, fr and others), an untrusted `Accept`/`Accept-Encoding` header such as `gzip;q=0.8` is parsed as `q=0` because `strtod` stops at the '.', so the weight collapses to "not acceptable" and the server quietly drops gzip and skews content negotiation. The fix translates '.' to the active locale's separator before the call, restoring the locale-independent intent without pulling in a different parser. The regression test pins q-value ordering under a comma-decimal locale and skips where none is installed.