### PR TITLE
skip CN fallback for IP hosts in mbedTLS and wolfSSL verify_hostname

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -18600,10 +18600,12 @@ inline bool verify_hostname(cert_t cert, const char *hostname) {
     san = san->next;
   }
 
-  // Fallback: Check Common Name (CN) in subject
+  // Fallback: Check Common Name (CN) in subject. Skipped for IP-literal hosts:
+  // an IP identity is only valid via an iPAddress SAN, never the CN (RFC 9110;
+  // the OpenSSL backend's X509_check_ip behaves the same way).
   char cn[256];
   int ret = mbedtls_x509_dn_gets(cn, sizeof(cn), &mcert->subject);
-  if (ret > 0) {
+  if (!is_ip && ret > 0) {
     std::string cn_str(cn);
 
     // Look for "CN=" in the DN string
@@ -19762,9 +19764,11 @@ inline bool verify_hostname(cert_t cert, const char *hostname) {
     wolfSSL_sk_free(san_names);
   }
 
-  // Fallback: Check Common Name (CN) in subject
+  // Fallback: Check Common Name (CN) in subject. Skipped for IP-literal hosts:
+  // an IP identity is only valid via an iPAddress SAN, never the CN (RFC 9110;
+  // the OpenSSL backend's X509_check_ip behaves the same way).
   WOLFSSL_X509_NAME *subject = wolfSSL_X509_get_subject_name(x509);
-  if (subject) {
+  if (!is_ip && subject) {
     char cn[256] = {};
     int cn_len = wolfSSL_X509_NAME_get_text_by_NID(subject, NID_commonName, cn,
                                                    sizeof(cn));


### PR DESCRIPTION
**IP-literal hosts can be matched against the certificate CN**

On the Mbed TLS and wolfSSL backends `tls::verify_hostname` checks the iPAddress SANs for an IP host and then, when none match, falls back to comparing the IP against the certificate Common Name. RFC 9110 only allows an IP identity to come from an iPAddress SAN, and the OpenSSL backend already behaves this way (`X509_check_ip` never consults the CN), so a certificate that carries the address in its CN but omits a matching SAN is wrongly accepted here. Gated the CN fallback on the host not being an IP literal in both backends, which should bring them in line with OpenSSL and with the RFC 2818 note already in `verify_host`.