### PR TITLE
use an unsigned accumulator in base64_encode

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -4665,7 +4665,9 @@ inline std::string base64_encode(const std::string &in) {
   std::string out;
   out.reserve(in.size());
 
-  auto val = 0;
+  // Unsigned: once four bytes are folded in the top bit is set, so the next
+  // `val << 8` would left-shift a negative int (undefined behaviour).
+  uint32_t val = 0;
   auto valb = -6;
 
   for (auto c : in) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -420,6 +420,22 @@ TEST(SanitizeFilenameTest, VariousPatterns) {
   EXPECT_EQ("", httplib::sanitize_filename("   "));
 }
 
+TEST(Base64EncodeTest, KnownAnswers) {
+  // RFC 4648 test vectors. Inputs of four bytes or more exercise the round
+  // where the accumulator's top bit is already set before the next shift.
+  EXPECT_EQ("", detail::base64_encode(""));
+  EXPECT_EQ("Zg==", detail::base64_encode("f"));
+  EXPECT_EQ("Zm8=", detail::base64_encode("fo"));
+  EXPECT_EQ("Zm9v", detail::base64_encode("foo"));
+  EXPECT_EQ("Zm9vYg==", detail::base64_encode("foob"));
+  EXPECT_EQ("Zm9vYmE=", detail::base64_encode("fooba"));
+  EXPECT_EQ("Zm9vYmFy", detail::base64_encode("foobar"));
+
+  // High bytes keep the top bit set across several rounds.
+  EXPECT_EQ("AAECA//+wIB/", detail::base64_encode(std::string(
+                                "\x00\x01\x02\x03\xff\xfe\xc0\x80\x7f", 9)));
+}
+
 TEST(EncodeQueryParamTest, ParseUnescapedChararactersTest) {
   string unescapedCharacters = "-_.!~*'()";
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -420,6 +420,16 @@ TEST(SanitizeFilenameTest, VariousPatterns) {
   EXPECT_EQ("", httplib::sanitize_filename("   "));
 }
 
+// Forward declaration: in split builds split.py strips `inline` and moves the
+// definition into httplib.cc, so detail::base64_encode is not visible from the
+// public httplib.h. Re-declaring it here lets the tests link against the symbol
+// in both header-only and split builds.
+namespace httplib {
+namespace detail {
+std::string base64_encode(const std::string &in);
+} // namespace detail
+} // namespace httplib
+
 TEST(Base64EncodeTest, KnownAnswers) {
   // RFC 4648 test vectors. Inputs of four bytes or more exercise the round
   // where the accumulator's top bit is already set before the next shift.


### PR DESCRIPTION
base64_encode folds each input byte into a signed int and shifts it left by eight every round; once four bytes are in, the top bit is set and the next shift left-shifts a negative int, which is undefined behaviour (ubsan reports a left shift of a negative value, and the same shift recurs in the trailing six-bit fixup). the helper runs on the server's websocket accept-key path over the sha1 digest and in the basic-auth header builder, so it is reachable from request handling. making the accumulator a uint32_t removes the ub and keeps the output byte-for-byte identical, since every emitted six-bit group is masked with 0x3f and is independent of the accumulator's signedness. the added test pins the rfc 4648 vectors plus a high-byte input that keeps the top bit set across rounds.