### PR TITLE
reject crlf in the request target in write_request_line

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7504,6 +7504,13 @@ bool read_content(Stream &strm, T &x, size_t payload_max_length, int &status,
 
 inline ssize_t write_request_line(Stream &strm, const std::string &method,
                                   const std::string &path) {
+  // A request target must not carry CR/LF (or other control octets); otherwise
+  // a value smuggled into it splits the request line and injects headers or a
+  // whole request. The same field-value check already guards header values in
+  // check_and_write_headers and the request target in
+  // perform_websocket_handshake; apply it here too.
+  if (!fields::is_field_value(path)) { return -1; }
+
   std::string s = method;
   s += ' ';
   s += path;

--- a/test/test.cc
+++ b/test/test.cc
@@ -7896,6 +7896,33 @@ TEST(ServerResponseSplittingTest, ChunkedTrailerCRLFInjection) {
   EXPECT_NE(std::string::npos, res.find("X-Safe: safe"));
 }
 
+TEST(RequestLineInjectionTest, RejectsCRLFInTarget) {
+  // A well-formed target is written verbatim.
+  {
+    detail::BufferStream strm;
+    auto n = detail::write_request_line(strm, "GET", "/path?a=b");
+    EXPECT_GT(n, 0);
+    EXPECT_EQ("GET /path?a=b HTTP/1.1\r\n", strm.get_buffer());
+  }
+
+  // A target carrying CR/LF must be rejected before anything reaches the wire,
+  // otherwise it splits the request line and injects a header or a whole
+  // request. This is what a decoded redirect Location ("%0D%0A") turns into
+  // when path encoding is disabled.
+  const std::string evil_targets[] = {
+      "/a\r\nInjected: pwned",
+      "/a\rInjected",
+      "/a\nInjected",
+      "/a\r\n\r\nGET /evil HTTP/1.1\r\nHost: victim\r\n\r\n",
+  };
+  for (const auto &evil : evil_targets) {
+    detail::BufferStream strm;
+    auto n = detail::write_request_line(strm, "GET", evil);
+    EXPECT_LT(n, 0);
+    EXPECT_TRUE(strm.get_buffer().empty());
+  }
+}
+
 // Sends a raw request and verifies that there isn't a crash or exception.
 static void test_raw_request(const std::string &req,
                              std::string *out = nullptr) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -7896,6 +7896,17 @@ TEST(ServerResponseSplittingTest, ChunkedTrailerCRLFInjection) {
   EXPECT_NE(std::string::npos, res.find("X-Safe: safe"));
 }
 
+// Forward declaration: in split builds split.py strips `inline` and moves the
+// definition into httplib.cc, so detail::write_request_line is not visible from
+// the public httplib.h. Re-declaring it here lets the tests link against the
+// symbol in both header-only and split builds.
+namespace httplib {
+namespace detail {
+ssize_t write_request_line(Stream &strm, const std::string &method,
+                           const std::string &path);
+} // namespace detail
+} // namespace httplib
+
 TEST(RequestLineInjectionTest, RejectsCRLFInTarget) {
   // A well-formed target is written verbatim.
   {


### PR DESCRIPTION
the client builds each request line in write_request_line by concatenating the method, the target and " HTTP/1.1\r\n" and writing it to the socket with no check on the target, so a target carrying CR/LF splits the request line and injects a header or a whole request. the neighbouring writers already guard this. check_and_write_headers runs is_field_value over every header value, and perform_websocket_handshake runs it over the path before the identical "GET " + path build, but the ordinary request path was left out. it becomes reachable when following a redirect with path encoding disabled: ClientImpl::redirect decodes the Location path through decode_path_component, so a wire-safe %0D%0A turns into a raw CR/LF, and under set_path_encode(false) that decoded target reaches write_request_line verbatim (the default encode_path re-encodes it, so only the disabled case leaks). the same writer also emits the CONNECT target, so guarding it once covers every request line the client sends. the change rejects a target that fails is_field_value there, matching the other two writers; a valid target is always field-value-clean, so i don't think anything legitimate is refused. added RequestLineInjectionTest.RejectsCRLFInTarget.
