### PR TITLE
Skip request body drain when connection will close

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -12715,13 +12715,18 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
 
   // Drain any unconsumed framed body to prevent request smuggling on
   // keep-alive. Without framing there is no body to drain — reading would
-  // consume the next request (issue #2450).
+  // consume the next request (issue #2450). If the response has committed the
+  // connection to close, there is no next request to protect.
   if (!req.body_consumed_ && detail::has_framed_body(req)) {
-    int dummy_status;
-    if (!detail::read_content(
-            strm, req, payload_max_length_, dummy_status, nullptr,
-            [](const char *, size_t, size_t, size_t) { return true; }, false)) {
+    if (res.get_header_value("Connection") == "close") {
       connection_closed = true;
+    } else {
+      int dummy_status;
+      if (!detail::read_content(
+              strm, req, payload_max_length_, dummy_status, nullptr,
+              [](const char *, size_t, size_t, size_t) { return true; }, false)) {
+        connection_closed = true;
+      }
     }
   }
 

--- a/httplib.h
+++ b/httplib.h
@@ -12724,7 +12724,8 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
       int dummy_status;
       if (!detail::read_content(
               strm, req, payload_max_length_, dummy_status, nullptr,
-              [](const char *, size_t, size_t, size_t) { return true; }, false)) {
+              [](const char *, size_t, size_t, size_t) { return true; },
+              false)) {
         connection_closed = true;
       }
     }

--- a/test/test.cc
+++ b/test/test.cc
@@ -19917,6 +19917,58 @@ TEST(KeepAliveTest, DeleteWithoutContentLengthDoesNotEatNextRequest) {
   EXPECT_EQ(2, delete_count.load());
 }
 
+TEST(KeepAliveTest, UnconsumedChunkedBodyIsNotDrainedWhenResponseCloses) {
+  Server svr;
+  svr.Post("/ingest", [&](const Request &, Response &res,
+                          const ContentReader &content_reader) {
+    auto consumed =
+        content_reader([](const char *, size_t) { return false; });
+    EXPECT_FALSE(consumed);
+    res.status = StatusCode::Conflict_409;
+    res.set_header("Connection", "close");
+  });
+
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+  });
+  svr.wait_until_ready();
+
+  auto error = Error::Success;
+  auto sock = detail::create_client_socket(
+      HOST, "", port, AF_UNSPEC, false, false, nullptr,
+      /*connection_timeout_sec=*/2, 0,
+      /*read_timeout_sec=*/1, 0,
+      /*write_timeout_sec=*/2, 0, std::string(), error);
+  ASSERT_NE(INVALID_SOCKET, sock);
+  auto sock_se = detail::scope_exit([&] { detail::close_socket(sock); });
+
+  std::string request = "POST /ingest HTTP/1.1\r\n"
+                        "Host: localhost\r\n"
+                        "Transfer-Encoding: chunked\r\n"
+                        "\r\n"
+                        "4\r\n"
+                        "data\r\n";
+  auto sent = send(sock, request.data(), request.size(), 0);
+  ASSERT_EQ(static_cast<ssize_t>(request.size()), sent);
+
+  std::string response;
+  ssize_t received = 0;
+  do {
+    char buf[4096];
+    received = recv(sock, buf, sizeof(buf), 0);
+    if (received > 0) {
+      response.append(buf, static_cast<size_t>(received));
+    }
+  } while (received > 0);
+
+  EXPECT_NE(std::string::npos, response.find("HTTP/1.1 409 Conflict"));
+  EXPECT_NE(std::string::npos, response.find("Connection: close"));
+  EXPECT_EQ(0, received);
+}
+
 namespace no_proxy_test {
 
 // Server bound to 127.0.0.1:<dynamic>, listen thread spawned by listen(),

--- a/test/test.cc
+++ b/test/test.cc
@@ -19921,8 +19921,7 @@ TEST(KeepAliveTest, UnconsumedChunkedBodyIsNotDrainedWhenResponseCloses) {
   Server svr;
   svr.Post("/ingest", [&](const Request &, Response &res,
                           const ContentReader &content_reader) {
-    auto consumed =
-        content_reader([](const char *, size_t) { return false; });
+    auto consumed = content_reader([](const char *, size_t) { return false; });
     EXPECT_FALSE(consumed);
     res.status = StatusCode::Conflict_409;
     res.set_header("Connection", "close");
@@ -19959,9 +19958,7 @@ TEST(KeepAliveTest, UnconsumedChunkedBodyIsNotDrainedWhenResponseCloses) {
   do {
     char buf[4096];
     received = recv(sock, buf, sizeof(buf), 0);
-    if (received > 0) {
-      response.append(buf, static_cast<size_t>(received));
-    }
+    if (received > 0) { response.append(buf, static_cast<size_t>(received)); }
   } while (received > 0);
 
   EXPECT_NE(std::string::npos, response.find("HTTP/1.1 409 Conflict"));


### PR DESCRIPTION
## Summary

Skip draining an unconsumed framed request body when the response has already committed the connection to close.

The post-response drain prevents unread body bytes from being parsed as the next request on a keep-alive connection. When the response contains `Connection: close`, there is no next request to protect.

## Problem

If a `ContentReader` aborts an unterminated chunked upload, the current drain waits for the terminal chunk after sending the response. A client that keeps producing chunks continually resets the read timeout, so:

- the announced connection close never occurs;
- the client receives no transport-level failure signal; and
- a server worker remains occupied discarding data.

This also means the server can send `Connection: close` while continuing to consume the request indefinitely.

## Fix

Use the finalized response header as the close decision:

```cpp
if (!req.body_consumed_ && detail::has_framed_body(req)) {
  if (res.get_header_value("Connection") == "close") {
    connection_closed = true;
  } else {
    // Drain before reusing the connection.
  }
}
```

`write_response_core` already sets this header for keep-alive exhaustion, request-directed closure, handler-directed closure, and error responses. Reusable connections retain the existing drain behavior.

## Relationship to #2450

This is a follow-up to #2450:

- #2450 prevented the drain from reading an unframed request, where it could consume the next request.
- This change prevents the drain from running when the connection will close, where no next request exists.

Both changes restrict the drain to cases where it can serve its request-smuggling-prevention purpose.

## Test

A raw-socket regression test sends an unterminated chunked request whose `ContentReader` rejects the first chunk. It verifies that the client receives the `409 Connection: close` response followed by EOF.

On unpatched `master`, the final `recv` times out because the server remains in the drain. With this change, it returns `0` immediately.

The new test and the existing #2450 regression both pass on Windows with MSVC.