### PR TITLE
fail mmap::open when ::mmap returns MAP_FAILED

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -5568,6 +5568,15 @@ inline bool mmap::open(const char *path) {
     is_open_empty_file = true;
     return false;
   }
+
+  // A failed mapping must not be left in `addr_`: `is_open()` only compares it
+  // against nullptr, so the MAP_FAILED sentinel would pass and `data()` would
+  // hand the caller (const char *)-1.
+  if (addr_ == MAP_FAILED) {
+    addr_ = nullptr;
+    close();
+    return false;
+  }
 #endif
 
   return true;

--- a/test/test.cc
+++ b/test/test.cc
@@ -9163,6 +9163,23 @@ TEST(MmapTest, OpenWhileFileHeldForWriting) {
 }
 #endif
 
+#ifndef _WIN32
+// A failed ::mmap must not be reported as an open mapping. is_open() only
+// compares addr_ against nullptr, so the MAP_FAILED sentinel used to pass it
+// and data() handed the caller (const char *)-1. A directory opens and stats
+// fine but has no mapping, so ::mmap fails for it.
+TEST(MmapTest, FailedMappingIsNotOpen) {
+  const char *path = "./mmap_failed_mapping_test_dir";
+  ASSERT_EQ(0, ::mkdir(path, 0755));
+  auto dir_cleanup = detail::scope_exit([&] { ::rmdir(path); });
+
+  detail::mmap m(path);
+  EXPECT_FALSE(m.is_open());
+  EXPECT_NE(static_cast<const void *>(m.data()),
+            static_cast<const void *>(MAP_FAILED));
+}
+#endif
+
 TEST(KeepAliveTest, ReadTimeout) {
   Server svr;
 


### PR DESCRIPTION
the posix branch of `detail::mmap::open` only tests `MAP_FAILED` as part of the empty-file case, so a failed mapping of a non-empty file leaves the sentinel in `addr_` and `open()` still returns true. `is_open()` compares `addr_` against nullptr alone, so callers pass the guard and `data()` hands back `(const char *)-1`, which `handle_file_request` and the `set_file_content` path in `process_request` both feed to a content provider as `data() + offset`, with `offset` coming from the client's Range header and the length bounded by the fstat size rather than by any mapping. the windows branch already closes and fails on every mapping error, so this mostly brings posix into line with it. mapping a directory is the easiest way to reach the failure, since `::open` and `fstat` succeed there and `::mmap` does not, and that is what the added test uses.
