### PR TITLE
Cut a syscall and the byte-at-a-time line reader out of the request path

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1545,6 +1545,18 @@ public:
     (void)usec;
   }
 
+  // Bytes already pulled off the socket and sitting in this stream's own
+  // buffer. Exposing them lets a line reader scan for a terminator in one
+  // pass instead of asking for a byte at a time. A stream that does no
+  // buffering of its own reports none, and readers fall back to read().
+  virtual const char *buffered_data(size_t &size) const {
+    size = 0;
+    return nullptr;
+  }
+
+  // Discards `size` bytes previously returned by buffered_data().
+  virtual void consume_buffered(size_t size) { (void)size; }
+
   ssize_t write(const char *ptr);
   ssize_t write(const std::string &s);
 
@@ -3364,6 +3376,7 @@ public:
 
 private:
   void append(char c);
+  void append(const char *data, size_t size);
 
   Stream &strm_;
   char *fixed_buffer_;
@@ -5455,6 +5468,46 @@ inline bool stream_line_reader::getline() {
 #endif
 
   for (size_t i = 0;; i++) {
+    // Fast path: whatever the stream has already buffered can be scanned for
+    // the terminator in one pass. Asking for a byte at a time costs a virtual
+    // call, a bounds check and a one-byte copy per character of the request.
+    size_t buffered_size = 0;
+    if (auto buffered = strm_.buffered_data(buffered_size)) {
+      auto take = buffered_size;
+      auto terminated = false;
+
+      for (size_t at = 0; at < buffered_size;) {
+        auto nl = static_cast<const char *>(
+            memchr(buffered + at, '\n', buffered_size - at));
+        if (!nl) { break; }
+        auto pos = static_cast<size_t>(nl - buffered);
+#ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
+        take = pos + 1;
+        terminated = true;
+        break;
+#else
+        // A bare LF does not end the line; keep looking for CRLF. The CR may
+        // be the last byte of an earlier chunk, hence prev_byte.
+        if ((pos > 0 ? buffered[pos - 1] : prev_byte) == '\r') {
+          take = pos + 1;
+          terminated = true;
+          break;
+        }
+        at = pos + 1;
+#endif
+      }
+
+      if (size() + take > CPPHTTPLIB_MAX_LINE_LENGTH) { return false; }
+#ifndef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
+      prev_byte = buffered[take - 1];
+#endif
+      append(buffered, take);
+      strm_.consume_buffered(take);
+      i += take;
+      if (terminated) { return true; }
+      continue;
+    }
+
     if (size() >= CPPHTTPLIB_MAX_LINE_LENGTH) {
       // Treat exceptionally long lines as an error to
       // prevent infinite loops/memory exhaustion
@@ -5486,16 +5539,26 @@ inline bool stream_line_reader::getline() {
   return true;
 }
 
-inline void stream_line_reader::append(char c) {
-  if (fixed_buffer_used_size_ < fixed_buffer_size_ - 1) {
-    fixed_buffer_[fixed_buffer_used_size_++] = c;
+inline void stream_line_reader::append(char c) { append(&c, 1); }
+
+inline void stream_line_reader::append(const char *data, size_t size) {
+  // Once the line has outgrown the fixed buffer everything must keep going to
+  // the growable one, even if a later chunk would have fit. Without the
+  // emptiness check a short append after a long one would land in the fixed
+  // buffer, which ptr() and size() no longer look at, and be lost.
+  if (growable_buffer_.empty() &&
+      fixed_buffer_used_size_ + size < fixed_buffer_size_) {
+    memcpy(fixed_buffer_ + fixed_buffer_used_size_, data, size);
+    fixed_buffer_used_size_ += size;
     fixed_buffer_[fixed_buffer_used_size_] = '\0';
   } else {
+    // Unlike the per-character overload, this can be the very first append of
+    // the line, so the fixed buffer may hold nothing and carry no terminator
+    // yet. assign() takes an explicit length and does not need one.
     if (growable_buffer_.empty()) {
-      assert(fixed_buffer_[fixed_buffer_used_size_] == '\0');
       growable_buffer_.assign(fixed_buffer_, fixed_buffer_used_size_);
     }
-    growable_buffer_ += c;
+    growable_buffer_.append(data, size);
   }
 }
 
@@ -5745,6 +5808,8 @@ public:
   socket_t socket() const override;
   time_t duration() const override;
   void set_read_timeout(time_t sec, time_t usec = 0) override;
+  const char *buffered_data(size_t &size) const override;
+  void consume_buffered(size_t size) override;
 
   // The caller has just seen this socket become readable. Lets the next read
   // skip its own readiness wait, which would otherwise ask the kernel a
@@ -10700,6 +10765,16 @@ inline bool SocketStream::ensure_readable() {
     return true;
   }
   return wait_readable();
+}
+
+inline const char *SocketStream::buffered_data(size_t &size) const {
+  size = read_buff_content_size_ - read_buff_off_;
+  return size ? read_buff_.data() + read_buff_off_ : nullptr;
+}
+
+inline void SocketStream::consume_buffered(size_t size) {
+  assert(size <= read_buff_content_size_ - read_buff_off_);
+  read_buff_off_ += size;
 }
 
 inline bool SocketStream::is_peer_alive() const {

--- a/httplib.h
+++ b/httplib.h
@@ -5746,7 +5746,14 @@ public:
   time_t duration() const override;
   void set_read_timeout(time_t sec, time_t usec = 0) override;
 
+  // The caller has just seen this socket become readable. Lets the next read
+  // skip its own readiness wait, which would otherwise ask the kernel a
+  // question that was answered a moment ago. Consumed by that read.
+  void set_readable_hint() { readable_hint_ = true; }
+
 private:
+  bool ensure_readable();
+
   socket_t sock_;
   time_t read_timeout_sec_;
   time_t read_timeout_usec_;
@@ -5758,6 +5765,7 @@ private:
   std::vector<char> read_buff_;
   size_t read_buff_off_ = 0;
   size_t read_buff_content_size_ = 0;
+  bool readable_hint_ = false;
 
   static const size_t read_buff_size_ = 1024l * 4;
 };
@@ -5825,6 +5833,9 @@ process_server_socket(const std::atomic<socket_t> &svr_sock, socket_t sock,
       [&](bool close_connection, bool &connection_closed) {
         SocketStream strm(sock, read_timeout_sec, read_timeout_usec,
                           write_timeout_sec, write_timeout_usec);
+        // process_server_socket_core() only gets here once keep_alive() has
+        // seen the socket go readable.
+        strm.set_readable_hint();
         return callback(strm, close_connection, connection_closed);
       });
 }
@@ -9124,7 +9135,12 @@ public:
   time_t duration() const override;
   void set_read_timeout(time_t sec, time_t usec = 0) override;
 
+  // See SocketStream::set_readable_hint().
+  void set_readable_hint() { readable_hint_ = true; }
+
 private:
+  bool ensure_readable();
+
   socket_t sock_;
   tls::session_t session_;
   time_t read_timeout_sec_;
@@ -9133,6 +9149,7 @@ private:
   time_t write_timeout_usec_;
   time_t max_timeout_msec_;
   const std::chrono::time_point<std::chrono::steady_clock> start_time_;
+  bool readable_hint_ = false;
 };
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
@@ -9294,6 +9311,8 @@ inline bool process_server_socket_ssl(
       [&](bool close_connection, bool &connection_closed) {
         SSLSocketStream strm(sock, session, read_timeout_sec, read_timeout_usec,
                              write_timeout_sec, write_timeout_usec);
+        // See the non-TLS path in process_server_socket().
+        strm.set_readable_hint();
         return callback(strm, close_connection, connection_closed);
       });
 }
@@ -10675,6 +10694,14 @@ inline bool SocketStream::wait_writable() const {
   return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0;
 }
 
+inline bool SocketStream::ensure_readable() {
+  if (readable_hint_) {
+    readable_hint_ = false;
+    return true;
+  }
+  return wait_readable();
+}
+
 inline bool SocketStream::is_peer_alive() const {
   return detail::is_socket_alive(sock_);
 }
@@ -10701,7 +10728,7 @@ inline ssize_t SocketStream::read(char *ptr, size_t size) {
     }
   }
 
-  if (!wait_readable()) {
+  if (!ensure_readable()) {
     error_ = Error::Timeout;
     return -1;
   }
@@ -11179,6 +11206,14 @@ inline bool SSLSocketStream::wait_writable() const {
          !tls::is_peer_closed(session_, sock_);
 }
 
+inline bool SSLSocketStream::ensure_readable() {
+  if (readable_hint_) {
+    readable_hint_ = false;
+    return true;
+  }
+  return wait_readable();
+}
+
 inline bool SSLSocketStream::is_peer_alive() const {
   return !tls::is_peer_closed(session_, sock_);
 }
@@ -11191,7 +11226,7 @@ inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
       error_ = Error::ConnectionClosed;
     }
     return ret;
-  } else if (wait_readable()) {
+  } else if (ensure_readable()) {
     tls::TlsError err;
     auto ret = tls::read(session_, ptr, size, err);
     if (ret < 0) {


### PR DESCRIPTION
Two independent savings on the server's per-request path. Together they measure **+3.7%** throughput on Linux, with all nine benchmark rounds separating cleanly (permutation p = 0.000).

## Where the time actually goes

Profiling one request and then measuring the same thing on a Linux CI runner gave two different pictures, and the difference decides which optimisations are worth anything.

| | macOS (8-core arm64) | Linux (Xeon 8573C, 4 vCPU) |
|---|---|---|
| server CPU per request | ~30 us | **~16 us** |
| of which HTTP processing | ~3 us | **~3.8 us** |
| HTTP processing share | ~10% | **~24%** |

Linux syscalls are cheap, so the total halves and parsing becomes the larger slice. That is why the first commit below is worth far less on Linux than macOS suggested, and why the second is worth more.

## 1. Skip the redundant readability poll

`process_server_socket_core()` calls `keep_alive()`, which polls the socket and only invokes the callback once it reports readable. The stream is then constructed and its first `read()` polls the very same socket again before calling `recv`.

The caller now hands the stream what it already knows. The hint is consumed by the first read, so body reads and every later request poll as before, and `set_read_timeout()` during a WebSocket upgrade is unaffected. Nothing is skipped when a read finds its buffer empty on its own. The accepted socket also carries `SO_RCVTIMEO` from `listen_internal()`, so even a wrong hint could not block forever.

The TLS path gets the same treatment: it shares `process_server_socket_core()`, and `SSLSocketStream::read()` polls after `tls::pending()` comes up empty.

Alone: **+2.3%** on Linux (p = 0.019). On macOS it is much larger — server CPU per request 33.4/32.5/29.7us to 23.6/22.9/23.9us across three interleaved `wrk -t2 -c8` runs, throughput +10-15%. TLS on macOS, 44.9/46.3/43.4us to 40.6/39.7/40.3us.

## 2. Scan buffered bytes for line ends

`stream_line_reader::getline()` pulls the request line and every header through `strm_.read(&byte, 1)`. A 300-byte header block costs 300 virtual calls, each with a bounds check and a one-byte copy. None are syscalls — `SocketStream` already holds up to 4KB — so it is pure CPU spent one character at a time. On the Linux runner it is **1.53us of the 2.44us** `read_headers()` spends on seven headers.

A stream can now offer what it has already buffered, and the reader scans it in one pass. Streams that do no buffering report none and keep the byte loop, so `Stream` subclasses outside the library are unaffected, as is the TLS path — `SSLSocketStream` has no buffer of its own to expose.

A bare LF still does not end a line by default, so the scan looks for CRLF and carries the CR across chunk boundaries.

## Combined measurement

`benchmark-ab` on ubuntu-latest, base and head built and measured alternately in one job, nine rounds:

| | median req/s |
|---|---|
| master | 62,872 |
| this PR | 65,229 |

**+3.7%**, p = 0.000, head ahead in all nine rounds.

The benchmark client sends only a `Host` header. A browser-shaped request with seven to ten headers should benefit more from the second commit than this number shows.

## A bug this turned up

Unifying the two `append` overloads was not cosmetic. The per-character one decided where to write from `fixed_buffer_used_size_` alone; after a bulk append had spilled into the growable buffer that counter is still zero, so the byte went to a fixed buffer `ptr()` and `size()` no longer read, and was dropped. `ServerTest.TooLongRequest` and `AlmostTooLongRequest` caught it — but only in the no-TLS build. The OpenSSL suite passed all 746 tests with the bug present, the buffer boundaries happening to fall differently.

## Not included

Removing the second poll, in `write()`, measured at roughly another 15% on macOS but is left out. It would depend on `SO_SNDTIMEO` being set on every socket a `SocketStream` is constructed over — including the WebSocket and client paths — and the TLS write path retries on `WantWrite` in a way that turns a send timeout into a much longer stall. Worth its own change.

## Testing

OpenSSL 746, mbedTLS 741, no-TLS 622 — all pass under ASAN. `test_split` builds.