### PR TITLE
Reject ambiguous request framing

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -12603,11 +12603,13 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
     return write_response(strm, close_connection, req, res);
   }
 
-  // RFC 9112 §6.3: Reject requests with both a non-zero Content-Length and
-  // any Transfer-Encoding to prevent request smuggling. Content-Length: 0 is
-  // tolerated for compatibility with existing clients.
-  if (req.get_header_value_u64("Content-Length") > 0 &&
-      req.has_header("Transfer-Encoding")) {
+  // RFC 9112 §6.3: ambiguous request framing can desynchronize this parser
+  // from an intermediary and enable request smuggling. Reject both framing
+  // headers together, even when Content-Length is zero, and reject a
+  // Transfer-Encoding whose final coding is not chunked.
+  if (req.has_header("Transfer-Encoding") &&
+      (req.has_header("Content-Length") ||
+       !detail::is_chunked_transfer_encoding(req.headers))) {
     connection_closed = true;
     res.status = StatusCode::BadRequest_400;
     return write_response(strm, close_connection, req, res);
@@ -13293,7 +13295,7 @@ inline void ClientImpl::prepare_default_headers(Request &r, bool for_stream,
     if (!ct.empty() && !r.has_header("Content-Type")) {
       r.headers.emplace("Content-Type", ct);
     }
-    if (!r.has_header("Content-Length")) {
+    if (!r.has_header("Content-Length") && !r.has_header("Transfer-Encoding")) {
       r.headers.emplace("Content-Length", std::to_string(r.body.size()));
     }
   }
@@ -13916,8 +13918,9 @@ inline bool ClientImpl::write_request(Stream &strm, Request &req,
         }
       }
     } else {
-      if (req.method == "POST" || req.method == "PUT" ||
-          req.method == "PATCH") {
+      if ((req.method == "POST" || req.method == "PUT" ||
+           req.method == "PATCH") &&
+          !req.has_header("Transfer-Encoding")) {
         req.set_header("Content-Length", "0");
       }
     }

--- a/test/test.cc
+++ b/test/test.cc
@@ -4546,10 +4546,12 @@ protected:
              })
         .Post("/chunked",
               [&](const Request &req, Response & /*res*/) {
+                EXPECT_FALSE(req.has_header("Content-Length"));
                 EXPECT_EQ(req.body, "dechunked post body");
               })
         .Post("/large-chunked",
               [&](const Request &req, Response & /*res*/) {
+                EXPECT_FALSE(req.has_header("Content-Length"));
                 std::string expected(6 * 30 * 1024u, 'a');
                 EXPECT_EQ(req.body, expected);
               })
@@ -5910,7 +5912,6 @@ TEST_F(ServerTest, CaseInsensitiveTransferEncoding) {
   req.headers.emplace("Accept", "*/*");
   req.headers.emplace("User-Agent", "cpp-httplib/0.1");
   req.headers.emplace("Content-Type", "text/plain");
-  req.headers.emplace("Content-Length", "0");
   req.headers.emplace(
       "Transfer-Encoding",
       "Chunked"); // Note, "Chunked" rather than typical "chunked".
@@ -6383,7 +6384,6 @@ TEST_F(ServerTest, LargeChunkedPost) {
   req.headers.emplace("Accept", "*/*");
   req.headers.emplace("User-Agent", "cpp-httplib/0.1");
   req.headers.emplace("Content-Type", "text/plain");
-  req.headers.emplace("Content-Length", "0");
   req.headers.emplace("Transfer-Encoding", "chunked");
 
   std::string long_string(30 * 1024u, 'a');
@@ -20522,6 +20522,61 @@ TEST(RequestSmugglingTest, ContentLengthAndTransferEncodingRejected) {
     EXPECT_EQ("HTTP/1.1 400 Bad Request",
               response.substr(0, response.find("\r\n")));
   }
+
+  // A zero Content-Length is still ambiguous when Transfer-Encoding is
+  // present and must not keep the connection reusable.
+  {
+    auto req = "POST /test HTTP/1.1\r\n"
+               "Host: localhost\r\n"
+               "Content-Length: 0\r\n"
+               "Transfer-Encoding: chunked\r\n"
+               "Connection: close\r\n"
+               "\r\n"
+               "0\r\n\r\n";
+
+    std::string response;
+    ASSERT_TRUE(send_request(1, req, &response));
+    EXPECT_EQ("HTTP/1.1 400 Bad Request",
+              response.substr(0, response.find("\r\n")));
+  }
+}
+
+TEST(RequestSmugglingTest, NonFinalChunkedTransferEncodingRejected) {
+  Server svr;
+  svr.Post("/test", [&](const Request &, Response &res) {
+    res.set_content("ok", "text/plain");
+  });
+
+  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+    ASSERT_FALSE(svr.is_running());
+  });
+  svr.wait_until_ready();
+
+  for (const auto &transfer_encoding : {"gzip", "chunked, gzip"}) {
+    auto req = std::string("POST /test HTTP/1.1\r\n") + "Host: localhost\r\n" +
+               "Transfer-Encoding: " + transfer_encoding + "\r\n" + "\r\n";
+
+    std::string response;
+    ASSERT_TRUE(send_request(1, req, &response));
+    EXPECT_EQ("HTTP/1.1 400 Bad Request",
+              response.substr(0, response.find("\r\n")))
+        << transfer_encoding;
+  }
+
+  // A supported sequence ending in chunked remains valid.
+  auto req = "POST /test HTTP/1.1\r\n"
+             "Host: localhost\r\n"
+             "Transfer-Encoding: gzip, chunked\r\n"
+             "Connection: close\r\n"
+             "\r\n"
+             "0\r\n\r\n";
+
+  std::string response;
+  ASSERT_TRUE(send_request(1, req, &response));
+  EXPECT_EQ("HTTP/1.1 200 OK", response.substr(0, response.find("\r\n")));
 }
 
 // Regression for issue #2450: a DELETE without Content-Length on a


### PR DESCRIPTION
## Summary

- Reject server requests that contain both `Content-Length` and
  `Transfer-Encoding`, including `Content-Length: 0`.
- Reject request `Transfer-Encoding` values whose final coding is not
  `chunked`.
- Prevent the client from automatically adding `Content-Length` when a caller
  explicitly supplies `Transfer-Encoding`.

## Why

RFC 9112 section 6.3 requires a server to return 400 and close the connection
when a request has `Transfer-Encoding` without `chunked` as the final coding.
It also identifies messages containing both framing headers as potential
request smuggling attempts.

Current `master` classifies `Transfer-Encoding: chunked, gzip` as not chunked,
but then treats the request as having no body. On a persistent connection,
bytes intended as that indeterminate body can consequently be parsed as a new
request. The existing `Content-Length` conflict check also uses a numeric
`> 0` test, so `Content-Length: 0` bypasses it.

A two-stage raw-socket proof sends the malformed outer request, waits for its
response, and then sends a request-shaped byte sequence. Before this patch,
both requests receive 200 responses and the hidden route executes once. With
the patch, the outer request receives 400, the connection closes, and the
hidden route is never executed.

This builds on #2500's final-coding detection. That change correctly returns
false for a non-final `chunked` token; this patch enforces the required server
error at the caller and keeps valid `gzip, chunked` behavior as a negative
control.

## Validation

- Full OpenSSL test suite: 755 tests passed across four shards.
- Header-only and split-library builds passed.
- Targeted tests passed in both OpenSSL and no-TLS configurations.
- The official server, client, and header-parser fuzz regression corpora
  replayed successfully.
- The two-stage proof passed under Linux AddressSanitizer and
  UndefinedBehaviorSanitizer.
- Changed lines pass clang-format and `git diff --check`.