### PR TITLE
Close the bound socket in ~Server() and on bind_internal() error paths

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -11327,7 +11327,12 @@ inline Server::Server()
 #endif
 }
 
-inline Server::~Server() = default;
+inline Server::~Server() {
+  // Close the listening socket for callers that bound but never stopped the
+  // server. Destroying a Server whose accept loop is still running was always
+  // undefined behavior, so this only affects the bound-but-idle case.
+  stop();
+}
 
 inline std::unique_ptr<detail::MatcherBase>
 Server::make_matcher(const std::string &pattern) {
@@ -12193,6 +12198,9 @@ inline int Server::bind_internal(const std::string &host, int port,
     if (getsockname(svr_sock_, reinterpret_cast<struct sockaddr *>(&addr),
                     &addr_len) == -1) {
       output_error_log(Error::GetSockName, nullptr);
+      // The socket is already bound and listening; close it so the failure
+      // does not leave the port held for the life of the process.
+      detail::close_socket(svr_sock_.exchange(INVALID_SOCKET));
       return -1;
     }
     if (addr.ss_family == AF_INET) {
@@ -12201,6 +12209,7 @@ inline int Server::bind_internal(const std::string &host, int port,
       return ntohs(reinterpret_cast<struct sockaddr_in6 *>(&addr)->sin6_port);
     } else {
       output_error_log(Error::UnsupportedAddressFamily, nullptr);
+      detail::close_socket(svr_sock_.exchange(INVALID_SOCKET));
       return -1;
     }
   } else {

--- a/test/test.cc
+++ b/test/test.cc
@@ -3551,6 +3551,17 @@ TEST(BindServerTest, StopClosesBoundSocketWithoutListen) {
   svr.wait_until_ready();
 }
 
+TEST(BindServerTest, DestructorClosesBoundSocket) {
+  int port = 0;
+  {
+    Server svr;
+    port = svr.bind_to_any_port("127.0.0.1");
+    ASSERT_TRUE(port > 0);
+    // Deliberately no stop(); the destructor has to release the socket.
+  }
+  EXPECT_FALSE(is_loopback_port_accepting(port));
+}
+
 #ifdef CPPHTTPLIB_SSL_ENABLED
 TEST(BindServerTest, BindAndListenSeparatelySSL) {
   SSLServer svr(SERVER_CERT_FILE, SERVER_PRIVATE_KEY_FILE, CLIENT_CA_CERT_FILE,


### PR DESCRIPTION
Follow-up to #2517. Two paths still leaked a bound-and-listening socket after stop() learned to release it:

**`~Server()`** was defaulted, so a Server that bound and was then destroyed without stop() kept the descriptor and the port — and since `create_server_socket()` has already called `listen(2)`, the abandoned port kept accepting connections into the backlog and never answering them. The destructor now calls stop(). Destroying a Server whose accept loop is still running was always undefined behavior, so this only affects the bound-but-idle case.

**`bind_internal()`** had the same problem on its own error paths: a `getsockname()` failure or an unsupported address family returned -1 with the socket already bound and listening. Those two branches now close it directly.

`BindServerTest.DestructorClosesBoundSocket` covers the destructor path with the raw-`connect()` helper from #2517 (a `Client` request against the old code would hang instead of fail). The `bind_internal()` error paths are not covered, since `getsockname()` cannot readily be made to fail.

Verified with the full suite (743/743) on both the regular and split builds.
