### PR TITLE
Count entries with count() rather than equal_range plus distance

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7600,8 +7600,7 @@ inline const char *get_header_value(const Headers &headers,
 
 inline size_t get_header_value_count(const Headers &headers,
                                      const std::string &key) {
-  auto r = headers.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+  return headers.count(key);
 }
 
 template <typename Map>
@@ -10566,8 +10565,7 @@ inline std::string Request::get_trailer_value(const std::string &key,
 }
 
 inline size_t Request::get_trailer_value_count(const std::string &key) const {
-  auto r = trailers.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+  return trailers.count(key);
 }
 
 inline bool Request::has_param(const std::string &key) const {
@@ -10591,8 +10589,7 @@ Request::get_param_values(const std::string &key) const {
 }
 
 inline size_t Request::get_param_value_count(const std::string &key) const {
-  auto r = params.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+  return params.count(key);
 }
 
 inline bool Request::is_multipart_form_data() const {
@@ -10625,8 +10622,7 @@ inline bool MultipartFormData::has_field(const std::string &key) const {
 }
 
 inline size_t MultipartFormData::get_field_count(const std::string &key) const {
-  auto r = fields.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+  return fields.count(key);
 }
 
 inline FormData MultipartFormData::get_file(const std::string &key,
@@ -10649,8 +10645,7 @@ inline bool MultipartFormData::has_file(const std::string &key) const {
 }
 
 inline size_t MultipartFormData::get_file_count(const std::string &key) const {
-  auto r = files.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+  return files.count(key);
 }
 
 // Multipart FormData writer implementation
@@ -10729,8 +10724,7 @@ inline std::string Response::get_trailer_value(const std::string &key,
 }
 
 inline size_t Response::get_trailer_value_count(const std::string &key) const {
-  auto r = trailers.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+  return trailers.count(key);
 }
 
 inline void Response::set_redirect(const std::string &url, int stat) {
@@ -10826,8 +10820,7 @@ inline std::string Result::get_request_header_value(const std::string &key,
 
 inline size_t
 Result::get_request_header_value_count(const std::string &key) const {
-  auto r = request_headers_.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+  return request_headers_.count(key);
 }
 
 // Stream implementation


### PR DESCRIPTION
Readability cleanup made possible by #2520, #2523 and #2524.

## Change

Seven accessors each spelled the same two lines:

```cpp
auto r = x.equal_range(key);
return static_cast<size_t>(std::distance(r.first, r.second));
```

The containers behind them all became `detail::insertion_ordered_multimap` along the way, so `count()` is available and says what these functions mean:

```cpp
return x.count(key);
```

| function | container |
|---|---|
| `detail::get_header_value_count` | `Headers` |
| `Request::get_trailer_value_count` | `Headers` |
| `Response::get_trailer_value_count` | `Headers` |
| `Request::get_param_value_count` | `Params` |
| `MultipartFormData::get_field_count` | `FormFields` |
| `MultipartFormData::get_file_count` | `FormFiles` |
| `Result::get_request_header_value_count` | `Headers` |

`Request::get_header_value_count` and `Response::get_header_value_count` delegate to `detail::get_header_value_count`, so they are covered by the first row.

## This is not faster

Worth stating plainly, since "one pass instead of two" is the tempting claim and it is wrong. `equal_range()` scans to the first match, and `std::distance()` then walks the restricted iterator to the end, comparing keys at each step. That comes to roughly one pass over the entries, and `count()` is one pass too. The gain is that two lines become one and the intent is in the name.

The `std::distance()` call in `Request::get_param_values()` stays as it is — it sizes a `reserve()` and needs the range anyway.

## Verification

Full offline suite: 729/729 pass. `test_split` builds and passes.

One note: `SocketStream.wait_writable_INET` failed on one run and passed on the next, and passes 5/5 in isolation. It binds `PORT + 1` directly with no `SO_REUSEADDR`, so a lingering `TIME_WAIT` makes `::bind` fail inside a worker thread, leaving `disconnected_svr_sock` at -1 for the final assertion. Pre-existing and unrelated to this change, which touches no socket code — flagging it because it has now bitten twice in one session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaaXVt1CkJy7N1Mte6Lcnc