### PR TITLE
Share the query pair splitting between its two callers

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8292,6 +8292,19 @@ inline std::string params_to_query_str(const Params &params) {
   return query;
 }
 
+// Splits one "key=value" span of a query string at its first '='. A span with
+// no '=' at all lands entirely in key, leaving val empty, which is how a bare
+// "?flag" keeps its name.
+inline void divide_query_pair(const char *b, const char *e, std::string &key,
+                              std::string &val) {
+  divide(b, static_cast<std::size_t>(e - b), '=',
+         [&](const char *lhs_data, std::size_t lhs_size, const char *rhs_data,
+             std::size_t rhs_size) {
+           key.assign(lhs_data, lhs_size);
+           val.assign(rhs_data, rhs_size);
+         });
+}
+
 inline void parse_query_text(const char *data, std::size_t size,
                              Params &params) {
   std::set<std::string> cache;
@@ -8302,12 +8315,7 @@ inline void parse_query_text(const char *data, std::size_t size,
 
     std::string key;
     std::string val;
-    divide(b, static_cast<std::size_t>(e - b), '=',
-           [&](const char *lhs_data, std::size_t lhs_size, const char *rhs_data,
-               std::size_t rhs_size) {
-             key.assign(lhs_data, lhs_size);
-             val.assign(rhs_data, rhs_size);
-           });
+    divide_query_pair(b, e, key, val);
 
     if (!key.empty()) {
       params.emplace(decode_query_component(key), decode_query_component(val));
@@ -8332,12 +8340,7 @@ inline std::string normalize_query_string(const std::string &query) {
         [&](const char *b, const char *e) {
           std::string key;
           std::string val;
-          divide(b, static_cast<std::size_t>(e - b), '=',
-                 [&](const char *lhs_data, std::size_t lhs_size,
-                     const char *rhs_data, std::size_t rhs_size) {
-                   key.assign(lhs_data, lhs_size);
-                   val.assign(rhs_data, rhs_size);
-                 });
+          divide_query_pair(b, e, key, val);
 
           if (!key.empty()) {
             auto dec_key = decode_query_component(key);


### PR DESCRIPTION
Readability cleanup, no behaviour change.

`parse_query_text()` and `normalize_query_string()` both walk a query string, and both open with the same eight lines to cut one `key=value` span at its first `=`:

```cpp
std::string key;
std::string val;
divide(b, static_cast<std::size_t>(e - b), '=',
       [&](const char *lhs_data, std::size_t lhs_size, const char *rhs_data,
           std::size_t rhs_size) {
         key.assign(lhs_data, lhs_size);
         val.assign(rhs_data, rhs_size);
       });
```

Given a name:

```cpp
// Splits one "key=value" span of a query string at its first '='. A span with
// no '=' at all lands entirely in key, leaving val empty, which is how a bare
// "?flag" keeps its name.
inline void divide_query_pair(const char *b, const char *e, std::string &key,
                              std::string &val) {
  divide(b, static_cast<std::size_t>(e - b), '=', ...);
}
```

The comment records the one piece of `divide()`'s behaviour a reader needs in order to follow either caller. `divide()` puts everything before the first delimiter in the left half and the rest in the right, so a span with no `=` lands entirely in `key` and leaves `val` empty — `parse_query_text()` depends on that to record a bare `flag` with an empty value, and `normalize_query_string()` depends on it to emit that parameter back without an `=`.

The helper sits below the split border next to its two callers and needs no forward declaration, matching `normalize_query_string()` itself.

## Verification

Full offline suite: 729/729 pass. `test_split` builds and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaaXVt1CkJy7N1Mte6Lcnc