### PR TITLE
Give the raw listener in wait_writable_INET the socket options its neighbours have

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -301,6 +301,12 @@ TEST(SocketStream, wait_writable_INET) {
   std::thread svr{[&] {
     const int s = socket(AF_INET, SOCK_STREAM, 0);
     ASSERT_LE(0, s);
+    // PORT + 1 is shared with the SSL redirect tests and with
+    // VulnerabilityTest.CRLFInjectionInHeaders, all of which set this. Without
+    // it, a TIME_WAIT one of them left behind makes bind() fail here, and
+    // because that happens on a worker thread the ASSERT does not stop the
+    // test: it runs on and fails at the disconnected_svr_sock check instead.
+    default_socket_options(s);
     ASSERT_EQ(0, ::bind(s, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)));
     ASSERT_EQ(0, listen(s, 1));
     ASSERT_LE(0, disconnected_svr_sock = accept(s, nullptr, nullptr));


### PR DESCRIPTION
`SocketStream.wait_writable_INET` failed three times during a long session and passed on every rerun, which made it look intermittent. It is not — the trigger just lives in the *previous* process.

## Cause

The test binds `PORT + 1` directly:

```cpp
std::thread svr{[&] {
  const int s = socket(AF_INET, SOCK_STREAM, 0);
  ASSERT_LE(0, s);
  ASSERT_EQ(0, ::bind(s, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)));
```

Of the ten raw `::bind` sites in `test/test.cc`, this is the only one that does not set `SO_REUSEPORT`/`SO_REUSEADDR` first — the other nine either spell out `setsockopt` or call `default_socket_options()`, and the library does the same for `Server`'s own listeners (`httplib.h:10051`).

`PORT + 1` is not private to this test. It is shared with `HttpToHttpsRedirectTest.CertFile`, `SSLClientRedirectTest.CertFile`, `UniversalClientRedirectTest.LoadCaCertStore` and `VulnerabilityTest.CRLFInjectionInHeaders`. Once any of those has run, the `TIME_WAIT` entries they leave make `bind()` fail here.

The failure then surfaced far from its cause. The bind runs on a worker thread, where a failed `ASSERT_EQ` only returns from the lambda — so the test carried on, `accept()` was never reached, and it failed at `ASSERT_NE(disconnected_svr_sock, -1)` with nothing pointing at the port.

Within a single run of the suite this test (line ~290) comes before everything that touches `PORT + 1` (line 13281 onwards), so a clean run passes. It only failed when an earlier process had left `TIME_WAIT` behind.

## Reproduction

Run any of the four tests above, then this one:

| ran first | TIME_WAIT on 1235 | before | after |
|---|---|---|---|
| `HttpToHttpsRedirectTest.CertFile` | 2 | FAILED | PASSED |
| `SSLClientRedirectTest.CertFile` | 3 → 4 | FAILED | PASSED |
| `UniversalClientRedirectTest.LoadCaCertStore` | 5 → 6 | FAILED | PASSED |
| `VulnerabilityTest.CRLFInjectionInHeaders` | 6 → 8 | FAILED | PASSED |

4 of 4 before, 4 of 4 after.

## Fix

```cpp
default_socket_options(s);
```

The library's own helper, which is what the other raw listeners in this file already use.

## Verification

Full offline suite run twice back to back — the pattern that used to fail on the second run: 729/729 both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaaXVt1CkJy7N1Mte6Lcnc