### PR TITLE
Bind the ordering tests to an ephemeral port

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -1302,7 +1302,8 @@ TEST(ParamsOrderTest, ServerSeesTheOrderTheClientSent) {
     res.set_content("ok", "text/plain");
   });
 
-  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
   auto se = detail::scope_exit([&] {
     svr.stop();
     t.join();
@@ -1310,7 +1311,7 @@ TEST(ParamsOrderTest, ServerSeesTheOrderTheClientSent) {
   });
   svr.wait_until_ready();
 
-  Client cli(HOST, PORT);
+  Client cli(HOST, port);
   auto res = cli.Get("/order?zulu=1&alpha=2&tag=x&mike=3&tag=y");
   ASSERT_TRUE(res);
   EXPECT_EQ("zulu=1 alpha=2 tag=x mike=3 tag=y ", order);
@@ -1329,7 +1330,8 @@ TEST(MultipartOrderTest, PartsKeepTheOrderSent) {
     res.set_content("ok", "text/plain");
   });
 
-  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
   auto se = detail::scope_exit([&] {
     svr.stop();
     t.join();
@@ -1345,7 +1347,7 @@ TEST(MultipartOrderTest, PartsKeepTheOrderSent) {
       {"apple", "a", "a.txt", "text/plain"},
   };
 
-  Client cli(HOST, PORT);
+  Client cli(HOST, port);
   auto res = cli.Post("/order", items);
   ASSERT_TRUE(res);
   EXPECT_EQ("zulu=1 alpha=2 mike=3 ", field_order);
@@ -1367,7 +1369,8 @@ TEST(MultipartOrderTest, RepeatedNamesKeepTheirOrder) {
     res.set_content("ok", "text/plain");
   });
 
-  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
   auto se = detail::scope_exit([&] {
     svr.stop();
     t.join();
@@ -1383,7 +1386,7 @@ TEST(MultipartOrderTest, RepeatedNamesKeepTheirOrder) {
       {"tag", "second", "", ""},
   };
 
-  Client cli(HOST, PORT);
+  Client cli(HOST, port);
   auto res = cli.Post("/repeated", items);
   ASSERT_TRUE(res);
   ASSERT_EQ(2U, values.size());
@@ -1427,7 +1430,8 @@ TEST(MultipartOrderTest, ContentSurvivesContainerGrowth) {
     res.set_content("ok", "text/plain");
   });
 
-  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
   auto se = detail::scope_exit([&] {
     svr.stop();
     t.join();
@@ -1440,7 +1444,7 @@ TEST(MultipartOrderTest, ContentSurvivesContainerGrowth) {
     items.push_back({name_of(i), content_of(i), "", ""});
   }
 
-  Client cli(HOST, PORT);
+  Client cli(HOST, port);
   auto res = cli.Post("/many", items);
   ASSERT_TRUE(res);
   ASSERT_EQ(part_count, received.size());
@@ -8535,11 +8539,11 @@ TEST(ZstdDecompressor, Decompress) {
 
 // Sends a raw request to a server listening at HOST:PORT.
 static bool send_request(time_t read_timeout_sec, const std::string &req,
-                         std::string *resp = nullptr) {
+                         std::string *resp = nullptr, int port = PORT) {
   auto error = Error::Success;
 
   auto client_sock = detail::create_client_socket(
-      HOST, "", PORT, AF_UNSPEC, false, false, nullptr,
+      HOST, "", port, AF_UNSPEC, false, false, nullptr,
       /*connection_timeout_sec=*/5, 0,
       /*read_timeout_sec=*/5, 0,
       /*write_timeout_sec=*/5, 0, std::string(), error);
@@ -8606,7 +8610,8 @@ TEST(HeadersOrderTest, ReceivedFieldsKeepTheirOrder) {
     res.set_content("ok", "text/plain");
   });
 
-  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
   auto se = detail::scope_exit([&] {
     svr.stop();
     t.join();
@@ -8624,7 +8629,7 @@ TEST(HeadersOrderTest, ReceivedFieldsKeepTheirOrder) {
                           "\r\n";
 
   std::string res;
-  ASSERT_TRUE(send_request(5, req, &res));
+  ASSERT_TRUE(send_request(5, req, &res, port));
   EXPECT_EQ("HTTP/1.1 200 OK", res.substr(0, 15));
   EXPECT_EQ("X-First=1 X-Dup=a X-Second=2 X-Dup=b Connection=close ", received);
 }
@@ -8638,7 +8643,8 @@ TEST(HeadersOrderTest, SentFieldsKeepTheirOrder) {
     res.set_content("ok", "text/plain");
   });
 
-  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
   auto se = detail::scope_exit([&] {
     svr.stop();
     t.join();
@@ -8647,7 +8653,7 @@ TEST(HeadersOrderTest, SentFieldsKeepTheirOrder) {
 
   svr.wait_until_ready();
 
-  Client cli(HOST, PORT);
+  Client cli(HOST, port);
   auto res = cli.Get("/cookies");
   ASSERT_TRUE(res);
   EXPECT_EQ(2U, res->get_header_value_count("Set-Cookie"));


### PR DESCRIPTION
`test/test.cc` says this right above the constant:

```cpp
// NOTE: PORT is only for legacy fixtures (ServerTest, etc.).
// New standalone tests MUST use svr.bind_to_any_port() instead.
const int PORT = get_base_port();
```

The six tests added with the insertion-order work in #2520, #2523 and #2524 all took the shared `PORT` anyway — I followed the surrounding standalone tests and missed the note. That made them one more thing contending for it, in a file where #2527 has just shown what contention over a shared port costs.

## Change

```cpp
auto port = svr.bind_to_any_port(HOST);
thread t = thread([&] { svr.listen_after_bind(); });
...
Client cli(HOST, port);
```

for:

- `HeadersOrderTest.ReceivedFieldsKeepTheirOrder`
- `HeadersOrderTest.SentFieldsKeepTheirOrder`
- `ParamsOrderTest.ServerSeesTheOrderTheClientSent`
- `MultipartOrderTest.PartsKeepTheOrderSent`
- `MultipartOrderTest.RepeatedNamesKeepTheirOrder`
- `MultipartOrderTest.ContentSurvivesContainerGrowth`

`HeadersOrderTest.ReceivedFieldsKeepTheirOrder` sends a raw request rather than going through `Client`, because it pins what the server does with the bytes on the wire independently of how a client would order them. `send_request()` therefore gains an optional port:

```cpp
static bool send_request(time_t read_timeout_sec, const std::string &req,
                         std::string *resp = nullptr, int port = PORT) {
```

The default leaves its other 36 callers untouched.

## Verification

Held `PORT` open from a separate process and ran the six: 17/17 pass (the three suites together). Before the change `listen(HOST, PORT)` would have failed there — and it does: running the full suite while the port was still held made the pre-existing `BindServerTest.BindDualStack` fail, which is the failure mode these six no longer have.

Full offline suite with the port free: 729/729 pass. `test_split` builds and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaaXVt1CkJy7N1Mte6Lcnc