### PR TITLE
Gracefully drain socket before close in Server::process_and_close_socket

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6326,7 +6326,7 @@ inline int shutdown_socket(socket_t sock) noexcept {
 // (or bytes arriving after the receive side is closed) makes the stack send
 // an abortive RST instead of a graceful FIN, which can make the peer see the
 // response as a failed read even though it was fully written.
-inline void close_socket_gracefully(socket_t sock) noexcept {
+inline void drain_and_close_socket(socket_t sock) noexcept {
 #ifdef _WIN32
   shutdown(sock, SD_SEND);
 #else
@@ -13641,7 +13641,7 @@ inline bool Server::process_and_close_socket(socket_t sock) {
                                nullptr, &websocket_upgraded);
       });
 
-  detail::close_socket_gracefully(sock);
+  detail::drain_and_close_socket(sock);
   return ret;
 }
 

--- a/httplib.h
+++ b/httplib.h
@@ -6321,6 +6321,39 @@ inline int shutdown_socket(socket_t sock) noexcept {
 #endif
 }
 
+// Half-closes the write side and drains any in-flight/queued bytes before
+// the final shutdown+close. Closing with unread data in the receive queue
+// (or bytes arriving after the receive side is closed) makes the stack send
+// an abortive RST instead of a graceful FIN, which can make the peer see the
+// response as a failed read even though it was fully written.
+inline void close_socket_gracefully(socket_t sock) noexcept {
+#ifdef _WIN32
+  shutdown(sock, SD_SEND);
+#else
+  shutdown(sock, SHUT_WR);
+#endif
+
+  char buf[CPPHTTPLIB_RECV_BUFSIZ];
+  size_t total = 0;
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(100); // bound #1
+
+  while (total < size_t(1024u * 1024u)) { // bound #2
+    const auto remaining =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            deadline - std::chrono::steady_clock::now())
+            .count();
+    if (remaining <= 0) { break; }
+    if (select_read(sock, 0, static_cast<time_t>(remaining)) <= 0) { break; }
+    const auto n = read_socket(sock, buf, sizeof(buf), CPPHTTPLIB_RECV_FLAGS);
+    if (n <= 0) { break; }
+    total += static_cast<size_t>(n);
+  }
+
+  shutdown_socket(sock);
+  close_socket(sock);
+}
+
 inline std::string escape_abstract_namespace_unix_domain(const std::string &s) {
   if (s.size() > 1 && s[0] == '\0') {
     auto ret = s;
@@ -13608,8 +13641,7 @@ inline bool Server::process_and_close_socket(socket_t sock) {
                                nullptr, &websocket_upgraded);
       });
 
-  detail::shutdown_socket(sock);
-  detail::close_socket(sock);
+  detail::close_socket_gracefully(sock);
   return ret;
 }
 


### PR DESCRIPTION
## Summary

Closing a connection while the receive queue still has unread data, or while bytes are still in flight, can make the OS send an abortive RST instead of a graceful FIN. On Windows this surfaces as `WSAECONNABORTED`/`WSAECONNRESET` on the peer's read, which can make an otherwise fully-written response look like a failed request. This looks like a likely contributor to the `ServerTest.HTTP2Magic` flakiness tracked in #2533.

- Add `detail::close_socket_gracefully()`: half-closes the write side, drains any queued/in-flight bytes (bounded to 100ms / 1MB), then performs the final shutdown+close.
- Use it in `Server::process_and_close_socket` (scoped to the non-SSL server, matching the job where the flakiness was observed).

Root cause and fix mechanism identified by @Hyukya in #2533 (repro + test results comparing current behavior against a draining close on Windows).

Fixes #2533.

## Test plan

- [x] `test_no_tls`: `ServerTest.*` and `KeepAliveTest.*` (198 tests) pass, including `ServerTest.HTTP2Magic`, with no added latency
- [x] `test_split_no_tls` (header/impl split build) compiles cleanly and passes the same tests
- [ ] Confirm the `windows-without-SSL` CI job stops flaking on push (existing auto-reporting step on #2533 will surface any recurrence)