### PR TITLE
reject trailing bytes after IPv6 host literal in parse_url

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -839,6 +839,15 @@ inline bool parse_url(const std::string &url, UrlComponents &uc) {
       }
 
       pos = close + 1;
+
+      // The IPv6 literal is the whole host, so ']' must be followed by a port,
+      // path, query or fragment delimiter (or the end of input). Otherwise the
+      // trailing bytes would be folded into the path while the connection
+      // still targets the bracketed address.
+      if (pos < url.size() && url[pos] != ':' && url[pos] != '/' &&
+          url[pos] != '?' && url[pos] != '#') {
+        return false;
+      }
     } else {
       auto end = url.find_first_of(":/?#", pos);
       if (end == std::string::npos) { end = url.size(); }

--- a/test/test.cc
+++ b/test/test.cc
@@ -15377,6 +15377,23 @@ TEST(ParseUrlTest, VariousPatterns) {
     ASSERT_FALSE(detail::parse_url("http://[::1/path", uc));
   }
   {
+    // Bytes after the IPv6 literal must be a delimiter, not folded into
+    // the path while the connection still targets the bracketed host.
+    detail::UrlComponents uc;
+    ASSERT_FALSE(detail::parse_url("http://[::1]evil.com/", uc));
+  }
+  {
+    detail::UrlComponents uc;
+    ASSERT_FALSE(detail::parse_url("http://[::1]evil", uc));
+  }
+  {
+    detail::UrlComponents uc;
+    ASSERT_TRUE(detail::parse_url("http://[::1]/path", uc));
+    EXPECT_EQ("::1", uc.host);
+    EXPECT_TRUE(uc.port.empty());
+    EXPECT_EQ("/path", uc.path);
+  }
+  {
     detail::UrlComponents uc;
     ASSERT_TRUE(detail::parse_url("//example.com/path?q=1", uc));
     EXPECT_TRUE(uc.scheme.empty());


### PR DESCRIPTION
**Malformed IPv6 authority accepted in parse_url**

After the closing bracket of an IPv6 literal the parser never checks that the next byte is a port, path, query or fragment delimiter, so an authority like `[::1]evil.com` is accepted with host `::1` and the trailing `evil.com` folded silently into the path. Following an untrusted `Location`, this connects to the bracketed address while the URL reads as another host. I made `]` require a delimiter (or end of input), which mirrors the existing rejection of an unclosed `[`, and added regression cases to `ParseUrlTest`.