### PR TITLE
Make decode_uri the inverse of encode_uri

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -10603,7 +10603,19 @@ inline std::string decode_uri(const std::string &value) {
     if (value[i] == '%' && i + 2 < value.size()) {
       auto val = 0;
       if (detail::from_hex_to_i(value, i + 1, 2, val)) {
-        result += static_cast<char>(val);
+        auto c = static_cast<char>(val);
+        // Keep escapes of the reserved characters that encode_uri leaves
+        // literal, so decode_uri is the inverse of encode_uri and an escaped
+        // delimiter is not promoted into a real one (as with JS decodeURI).
+        if (c == ';' || c == '/' || c == '?' || c == ':' || c == '@' ||
+            c == '&' || c == '=' || c == '+' || c == '$' || c == ',' ||
+            c == '#') {
+          result += value[i];
+          result += value[i + 1];
+          result += value[i + 2];
+        } else {
+          result += c;
+        }
         i += 2;
       } else {
         result += value[i];

--- a/test/test.cc
+++ b/test/test.cc
@@ -719,6 +719,22 @@ TEST(DecodeUriTest, TestRoundTripWithEncodeUri) {
   EXPECT_EQ(decoded, original);
 }
 
+TEST(DecodeUriTest, KeepsReservedCharacterEscapes) {
+  // decode_uri is the inverse of encode_uri: an escaped reserved character
+  // stays encoded so it is not promoted into a real delimiter, while
+  // non-reserved escapes still decode (like JS decodeURI).
+  EXPECT_EQ(httplib::decode_uri("%2F"), "%2F");
+  EXPECT_EQ(httplib::decode_uri("%23"), "%23");
+  EXPECT_EQ(httplib::decode_uri("%3F%3A%40%26%3D%2B%24%2C%3B"),
+            "%3F%3A%40%26%3D%2B%24%2C%3B");
+  EXPECT_EQ(httplib::decode_uri("%2D"), "-");
+  EXPECT_EQ(httplib::decode_uri("%20"), " ");
+  EXPECT_EQ(httplib::decode_uri("http://example.com/a%2Fb"),
+            "http://example.com/a%2Fb");
+  // decode_uri_component still decodes the reserved character.
+  EXPECT_EQ(httplib::decode_uri_component("%2F"), "/");
+}
+
 TEST(DecodeUriComponentTest, TestRoundTripWithEncodeUriComponent) {
   string original = "Piri Tommy Villiers - on & on";
   string encoded = httplib::encode_uri_component(original);


### PR DESCRIPTION
`decode_uri` is documented as the counterpart of `encode_uri` (the JS `encodeURI`/`decodeURI` pair), but its body is byte-for-byte identical to `decode_uri_component` — it decodes every `%XX`, including escapes of the reserved characters `encode_uri` deliberately leaves literal (`;/?:@&=+$,#`).

So `decode_uri` is not the inverse of `encode_uri`, and it promotes an escaped delimiter into a real one:

```cpp
decode_uri("http://h/a%2Fb");   // returned "http://h/a/b" — invents a path separator
decode_uri("%23");              // returned "#"
```

JS `decodeURI` leaves exactly this reserved set encoded for that reason. This keeps their escapes and decodes everything else, so `decode_uri(encode_uri(s)) == s` round-trips. `decode_uri_component` is unchanged (it still decodes reserved characters). Existing `DecodeUriTest` cases still pass — none of them exercised a reserved-character escape — and a test for the reserved-escape behavior is added.
