### PR TITLE
Reduce syscall volume, and/or TCP segment generation

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -172,6 +172,10 @@
 #define CPPHTTPLIB_RECV_BUFSIZ size_t(16384u)
 #endif
 
+#ifndef CPPHTTPLIB_WRITEV_MAX_BUFS
+#define CPPHTTPLIB_WRITEV_MAX_BUFS size_t(8u)
+#endif
+
 #ifndef CPPHTTPLIB_SEND_BUFSIZ
 #define CPPHTTPLIB_SEND_BUFSIZ size_t(16384u)
 #endif
@@ -314,6 +318,7 @@ using socklen_t = int;
 #include <pthread.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
+#include <sys/uio.h>
 #include <sys/un.h>
 #include <unistd.h>
 
@@ -1749,6 +1754,31 @@ namespace detail {
 // `Response` stores one.
 enum class EncodingType { None = 0, Gzip, Brotli, Zstd };
 
+class ContentResource {
+public:
+  ContentResource() = default;
+  explicit ContentResource(ContentProviderResourceReleaser releaser)
+      : state_(releaser ? std::make_shared<State>(std::move(releaser))
+                        : nullptr) {}
+
+  void set_success(bool success) {
+    if (state_) { state_->success = success; }
+  }
+
+private:
+  struct State {
+    explicit State(ContentProviderResourceReleaser r)
+        : releaser(std::move(r)) {}
+    ~State() { releaser(success); }
+    State(const State &) = delete;
+    State &operator=(const State &) = delete;
+
+    ContentProviderResourceReleaser releaser;
+    bool success = false;
+  };
+  std::shared_ptr<State> state_;
+};
+
 } // namespace detail
 
 struct Response {
@@ -1781,6 +1811,11 @@ struct Response {
   void set_content(const std::string &s, const std::string &content_type);
   void set_content(std::string &&s, const std::string &content_type);
 
+  // Zero-copy path: s is not copied, and must remain until the response
+  // completes; resource_releaser is invoked exactly once.
+  void set_content(const char *s, size_t n, const std::string &content_type,
+                   ContentProviderResourceReleaser resource_releaser);
+
   void set_content_provider(
       size_t length, const std::string &content_type, ContentProvider provider,
       ContentProviderResourceReleaser resource_releaser = nullptr);
@@ -1797,23 +1832,25 @@ struct Response {
                         const std::string &content_type);
   void set_file_content(const std::string &path);
 
-  Response() = default;
-  Response(const Response &) = default;
-  Response &operator=(const Response &) = default;
-  Response(Response &&) = default;
-  Response &operator=(Response &&) = default;
-  ~Response() {
-    if (content_provider_resource_releaser_) {
-      content_provider_resource_releaser_(content_provider_success_);
-    }
+  // Drop any pending content so the response can be replaced (e.g. on error)
+  void clear_content() {
+    body.clear();
+    content_length_ = 0;
+    content_provider_ = nullptr;
+    is_chunked_content_provider_ = false;
+    content_view_data_ = nullptr;
+    content_resource_ = detail::ContentResource();
+    file_content_encoding_ = detail::EncodingType::None;
   }
 
   // private members...
   size_t content_length_ = 0;
   ContentProvider content_provider_;
-  ContentProviderResourceReleaser content_provider_resource_releaser_;
+  detail::ContentResource content_resource_;
   bool is_chunked_content_provider_ = false;
-  bool content_provider_success_ = false;
+  // Borrowed content of content_length_ bytes; see the zero-copy
+  // set_content() overload.
+  const char *content_view_data_ = nullptr;
   std::string file_content_path_;
   std::string file_content_content_type_;
 
@@ -1881,6 +1918,15 @@ public:
 
   virtual ssize_t read(char *ptr, size_t size) = 0;
   virtual ssize_t write(const char *ptr, size_t size) = 0;
+
+  // Gather write: all buffers leave in as few syscalls as possible
+  // (normally one), minimizing both syscall overhead and TCP segments.
+  struct WriteBuffer {
+    const char *data;
+    size_t size;
+  };
+  virtual ssize_t writev(const WriteBuffer *bufs, size_t count);
+
   virtual void get_remote_ip_and_port(std::string &ip, int &port) const = 0;
   virtual void get_local_ip_and_port(std::string &ip, int &port) const = 0;
   virtual socket_t socket() const = 0;
@@ -6387,6 +6433,7 @@ public:
   bool is_peer_alive() const override;
   ssize_t read(char *ptr, size_t size) override;
   ssize_t write(const char *ptr, size_t size) override;
+  ssize_t writev(const WriteBuffer *bufs, size_t count) override;
   void get_remote_ip_and_port(std::string &ip, int &port) const override;
   void get_local_ip_and_port(std::string &ip, int &port) const override;
   socket_t socket() const override;
@@ -8615,13 +8662,20 @@ inline bool compress_content_provider(const ContentProvider &content_provider,
   return cmp.compress(nullptr, 0, true, append);
 }
 
-// Serves `m` as the response body. `set_content_provider()` clears the coding,
-// so recording it has to come after; keeping both here means a third
-// file-serving path cannot get that order wrong.
+// Serves `m` as the response body. `set_content()` and
+// `set_content_provider()` clear the coding, so recording
+// it has to come after; keeping it all here means no file-serving path can
+// get that wrong.
 inline void set_file_content_provider(Response &res,
                                       const std::shared_ptr<mmap> &m,
                                       const std::string &content_type,
                                       EncodingType encoding) {
+  if (encoding == EncodingType::None) {
+    // Unencoded responses can borrow the file mapping directly.
+    res.set_content(m->data(), m->size(), content_type, [m](bool) {});
+    return;
+  }
+
   res.set_content_provider(
       m->size(), content_type,
       [m](size_t offset, size_t length, DataSink &sink) -> bool {
@@ -11491,12 +11545,9 @@ inline void Response::set_redirect(const std::string &url, int stat) {
 
 inline void Response::set_content(const char *s, size_t n,
                                   const std::string &content_type) {
-  body.assign(s, n);
-
-  auto rng = headers.equal_range("Content-Type");
-  headers.erase(rng.first, rng.second);
-  set_header("Content-Type", content_type);
-  file_content_encoding_ = detail::EncodingType::None;
+  // The copy must be taken before clear_content() fires any previous
+  // releaser: s may point into the borrowed view being replaced.
+  set_content(std::string(s, n), content_type);
 }
 
 inline void Response::set_content(const std::string &s,
@@ -11506,45 +11557,60 @@ inline void Response::set_content(const std::string &s,
 
 inline void Response::set_content(std::string &&s,
                                   const std::string &content_type) {
-  body = std::move(s);
+  // Take ownership before clear_content(), since `s` may be `body` itself.
+  auto content = std::move(s);
+  clear_content();
+  body = std::move(content);
 
   auto rng = headers.equal_range("Content-Type");
   headers.erase(rng.first, rng.second);
   set_header("Content-Type", content_type);
-  file_content_encoding_ = detail::EncodingType::None;
+}
+
+inline void
+Response::set_content(const char *s, size_t n, const std::string &content_type,
+                      ContentProviderResourceReleaser resource_releaser) {
+  // Borrow the buffer as-is. write_response_core() emits it together with
+  // the response headers in a single gather write; a ranged request, which
+  // needs (offset, length) slices instead, wraps it in a content provider.
+  clear_content();
+  content_length_ = n;
+  if (n > 0) { content_view_data_ = s; }
+  content_resource_ = detail::ContentResource(std::move(resource_releaser));
+
+  // Header handling matches set_content_provider(), whose call sites this
+  // overload serves: append, don't replace, so a Content-Type set earlier
+  // (e.g. via mount headers) stays first and keeps winning.
+  set_header("Content-Type", content_type);
 }
 
 inline void Response::set_content_provider(
     size_t in_length, const std::string &content_type, ContentProvider provider,
     ContentProviderResourceReleaser resource_releaser) {
+  clear_content();
   set_header("Content-Type", content_type);
   content_length_ = in_length;
   if (in_length > 0) { content_provider_ = std::move(provider); }
-  content_provider_resource_releaser_ = std::move(resource_releaser);
-  is_chunked_content_provider_ = false;
-  file_content_encoding_ = detail::EncodingType::None;
+  content_resource_ = detail::ContentResource(std::move(resource_releaser));
 }
 
 inline void Response::set_content_provider(
     const std::string &content_type, ContentProviderWithoutLength provider,
     ContentProviderResourceReleaser resource_releaser) {
+  clear_content();
   set_header("Content-Type", content_type);
-  content_length_ = 0;
   content_provider_ = detail::ContentProviderAdapter(std::move(provider));
-  content_provider_resource_releaser_ = std::move(resource_releaser);
-  is_chunked_content_provider_ = false;
-  file_content_encoding_ = detail::EncodingType::None;
+  content_resource_ = detail::ContentResource(std::move(resource_releaser));
 }
 
 inline void Response::set_chunked_content_provider(
     const std::string &content_type, ContentProviderWithoutLength provider,
     ContentProviderResourceReleaser resource_releaser) {
+  clear_content();
   set_header("Content-Type", content_type);
-  content_length_ = 0;
   content_provider_ = detail::ContentProviderAdapter(std::move(provider));
-  content_provider_resource_releaser_ = std::move(resource_releaser);
+  content_resource_ = detail::ContentResource(std::move(resource_releaser));
   is_chunked_content_provider_ = true;
-  file_content_encoding_ = detail::EncodingType::None;
 }
 
 inline void Response::set_file_content(const std::string &path,
@@ -11586,6 +11652,29 @@ inline ssize_t Stream::write(const char *ptr) {
 
 inline ssize_t Stream::write(const std::string &s) {
   return write(s.data(), s.size());
+}
+
+inline ssize_t Stream::writev(const WriteBuffer *bufs, size_t count) {
+  size_t total = 0;
+  for (size_t i = 0; i < count; i++) {
+    total += bufs[i].size;
+  }
+
+  if (total < CPPHTTPLIB_SEND_BUFSIZ) {
+    // Flatten into a staging buffer to minimize write() syscalls
+    std::string flat;
+    flat.reserve(total);
+    for (size_t i = 0; i < count; i++) {
+      if (bufs[i].size > 0) { flat.append(bufs[i].data, bufs[i].size); }
+    }
+    if (!detail::write_data(*this, flat.data(), flat.size())) { return -1; }
+  } else {
+    // Write individually to avoid large copies
+    for (size_t i = 0; i < count; i++) {
+      if (!detail::write_data(*this, bufs[i].data, bufs[i].size)) { return -1; }
+    }
+  }
+  return static_cast<ssize_t>(total);
 }
 
 // BodyReader implementation
@@ -11957,6 +12046,92 @@ inline ssize_t SocketStream::write(const char *ptr, size_t size) {
 #endif
 
   return send_socket(sock_, ptr, size, CPPHTTPLIB_SEND_FLAGS);
+}
+
+inline ssize_t SocketStream::writev(const WriteBuffer *bufs, size_t count) {
+  // Gather write: all buffers leave in as few syscalls as the kernel
+  // allows (normally one, but limited to batches of fixed size to bound
+  // stack use)
+  if (count > CPPHTTPLIB_WRITEV_MAX_BUFS) {
+    size_t total = 0;
+    while (count > 0) {
+      auto batch = (std::min)(count, CPPHTTPLIB_WRITEV_MAX_BUFS);
+      auto n = writev(bufs, batch);
+      if (n < 0) { return -1; }
+      total += static_cast<size_t>(n);
+      bufs += batch;
+      count -= batch;
+    }
+    return static_cast<ssize_t>(total);
+  }
+
+  // In-progress state in portable form
+  WriteBuffer rest[CPPHTTPLIB_WRITEV_MAX_BUFS];
+  size_t total = 0;
+  for (size_t i = 0; i < count; i++) {
+    rest[i] = bufs[i];
+    total += bufs[i].size;
+  }
+
+  size_t written = 0;
+  size_t first = 0; // first span not yet fully written
+  while (written < total) {
+    if (!wait_writable()) { return -1; }
+
+#ifdef _WIN32
+    WSABUF iov[CPPHTTPLIB_WRITEV_MAX_BUFS];
+    DWORD niov = 0;
+    // WSABUF::len and the completion count `sent` are ULONGs, so a single
+    // batch must cover at most ULONG_MAX bytes in TOTAL - a larger send
+    // would complete with `sent` truncated mod 2^32 and desync the resume
+    // logic below. A span that does not fit goes out in clamped pieces,
+    // with the resume logic advancing through it. Later spans must not
+    // ride along in the same call - they would land ahead of the clamped
+    // span's remainder - so the batch ends there.
+    auto batch_room = static_cast<size_t>((std::numeric_limits<ULONG>::max)());
+    for (size_t i = first; i < count && batch_room > 0; i++) {
+      iov[i].buf = const_cast<char *>(rest[i].data);
+      iov[i].len = static_cast<ULONG>((std::min)(rest[i].size, batch_room));
+      batch_room -= iov[i].len;
+      niov++;
+      if (iov[i].len < rest[i].size) { break; }
+    }
+    DWORD sent = 0;
+    auto ret = handle_EINTR([&]() {
+      return ::WSASend(sock_, iov + first, niov, &sent, 0, nullptr, nullptr);
+    });
+    if (ret != 0) { return -1; }
+    size_t n = sent;
+#else
+    struct iovec iov[CPPHTTPLIB_WRITEV_MAX_BUFS];
+    for (size_t i = first; i < count; i++) {
+      iov[i].iov_base = const_cast<char *>(rest[i].data);
+      iov[i].iov_len = rest[i].size;
+    }
+    struct msghdr msg = {};
+    msg.msg_iov = iov + first;
+    msg.msg_iovlen = static_cast<decltype(msg.msg_iovlen)>(count - first);
+    auto n_or_err = handle_EINTR(
+        [&]() { return ::sendmsg(sock_, &msg, CPPHTTPLIB_SEND_FLAGS); });
+    if (n_or_err < 0) { return -1; }
+    size_t n = static_cast<size_t>(n_or_err);
+#endif
+
+    written += n;
+
+    // Advance past whole spans the kernel consumed, then trim the
+    // partially-consumed one.
+    while (first < count && n >= rest[first].size) {
+      n -= rest[first].size;
+      first++;
+    }
+    if (first < count && n > 0) {
+      rest[first].data += n;
+      rest[first].size -= n;
+    }
+  }
+
+  return static_cast<ssize_t>(total);
 }
 
 inline void SocketStream::get_remote_ip_and_port(std::string &ip,
@@ -13187,30 +13362,60 @@ inline bool Server::write_response_core(Stream &strm, bool close_connection,
   if (!detail::write_response_line(bstrm, res.status)) { return false; }
   if (header_writer_(bstrm, res.headers) <= 0) { return false; }
 
-  // Combine small body with headers to reduce write syscalls
-  if (req.method != "HEAD" && !res.body.empty() && !res.content_provider_) {
-    bstrm.write(res.body.data(), res.body.size());
-  }
-
   // Log before writing to avoid race condition with client-side code that
   // accesses logger-captured data immediately after receiving the response.
   output_log(req, res);
 
-  // Flush buffer
   auto &data = bstrm.get_buffer();
-  if (!detail::write_data(strm, data.data(), data.size())) { return false; }
 
-  // Streaming body
-  auto ret = true;
-  if (req.method != "HEAD" && res.content_provider_) {
-    if (write_content_with_provider(strm, req, res, boundary, content_type)) {
-      res.content_provider_success_ = true;
-    } else {
-      ret = false;
+  // Owned (res.body) and borrowed (content_view_*) bodies compose at this
+  // point. Both are a stable span for the duration of the write - an owned
+  // body is simply borrowed from ourselves - and leave with the headers in a
+  // single gather write. A borrowed view with a ranged request needs (offset,
+  // length) slices instead, and falls through to the provider machinery; an
+  // owned body was already sliced by apply_ranges() above.
+  //
+  // A non-empty body always wins over a view: `body` is a public member, so a
+  // handler (or the error handler, which ran before apply_ranges() above) may
+  // have assigned it directly without going through a setter that would have
+  // cleared the view - and apply_ranges() has already sized the response to
+  // the body, so serving the stale view here would read the wrong bytes.
+  const char *span_data = nullptr;
+  size_t span_size = 0;
+  auto span_is_view = false;
+  if (req.method != "HEAD") {
+    if (res.content_view_data_ != nullptr && res.body.empty() &&
+        req.ranges.empty()) {
+      span_data = res.content_view_data_;
+      span_size = res.content_length_;
+      span_is_view = true;
+    } else if (!res.body.empty() && !res.content_provider_) {
+      span_data = res.body.data();
+      span_size = res.body.size();
     }
   }
 
-  return ret;
+  if (span_data != nullptr) {
+    const Stream::WriteBuffer bufs[2] = {{data.data(), data.size()},
+                                         {span_data, span_size}};
+    if (strm.writev(bufs, 2) < 0) { return false; }
+    res.content_resource_.set_success(span_is_view);
+    return true;
+  }
+
+  // Header-only responses, HEAD, and streamed bodies
+  if (!detail::write_data(strm, data.data(), data.size())) { return false; }
+
+  if (req.method != "HEAD" &&
+      (res.content_provider_ || res.content_view_data_ != nullptr)) {
+    if (write_content_with_provider(strm, req, res, boundary, content_type)) {
+      res.content_resource_.set_success(true);
+      return true;
+    }
+    return false;
+  }
+
+  return true;
 }
 
 inline bool
@@ -13220,6 +13425,18 @@ Server::write_content_with_provider(Stream &strm, const Request &req,
   auto is_shutting_down = [this]() {
     return this->svr_sock_ == INVALID_SOCKET;
   };
+
+  // A borrowed buffer only arrives here for ranged requests - the unranged
+  // case already left with the headers in one gather write. Wrap it in a
+  // provider so the range machinery below can serve slices of it like any
+  // other known-length body.
+  if (!res.content_provider_ && res.content_view_data_ != nullptr) {
+    auto data = res.content_view_data_;
+    res.content_provider_ = [data](size_t offset, size_t length,
+                                   DataSink &sink) {
+      return sink.write(data + offset, length);
+    };
+  }
 
   if (res.content_length_ > 0) {
     // Only a 206 response is served as a partial representation, matching the
@@ -13819,9 +14036,7 @@ inline bool Server::routing(Request &req, Response &res, Stream &strm) {
           // Enforce the limit: override any status the handler may have set
           // and return false so the error path sends a plain 413 response.
           res.status = StatusCode::PayloadTooLarge_413;
-          res.body.clear();
-          res.content_length_ = 0;
-          res.content_provider_ = nullptr;
+          res.clear_content();
           return false;
         }
         return true;
@@ -13944,7 +14159,7 @@ inline bool Server::apply_static_file_compression(const Request &req,
 
   // The provider was consumed in full, so a resource releaser registered with
   // it should hear about a success when the response goes away.
-  res.content_provider_success_ = true;
+  res.content_resource_.set_success(true);
   res.content_provider_ = nullptr;
   res.content_length_ = 0;
   res.file_content_encoding_ = detail::EncodingType::None;
@@ -14362,6 +14577,8 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
       exception_handler_(req, res, ep);
       routed = true;
     } else {
+      // The handler died; its content must not leak into the 500.
+      res.clear_content();
       res.status = StatusCode::InternalServerError_500;
     }
   } catch (...) {
@@ -14370,6 +14587,8 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
       exception_handler_(req, res, ep);
       routed = true;
     } else {
+      // The handler died; its content must not leak into the 500.
+      res.clear_content();
       res.status = StatusCode::InternalServerError_500;
     }
   }
@@ -14387,9 +14606,7 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
       const auto &path = res.file_content_path_;
       auto mm = std::make_shared<detail::mmap>(path.c_str());
       if (!mm->is_open()) {
-        res.body.clear();
-        res.content_length_ = 0;
-        res.content_provider_ = nullptr;
+        res.clear_content();
         res.status = StatusCode::NotFound_404;
         output_error_log(Error::OpenFile, &req);
         file_open_error = true;
@@ -14409,9 +14626,7 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
     if (file_open_error) {
       ret = write_response(strm, close_connection, req, res);
     } else if (detail::range_error(req, res)) {
-      res.body.clear();
-      res.content_length_ = 0;
-      res.content_provider_ = nullptr;
+      res.clear_content();
       res.status = StatusCode::RangeNotSatisfiable_416;
       ret = write_response(strm, close_connection, req, res);
     } else {

--- a/test/test.cc
+++ b/test/test.cc
@@ -290,6 +290,47 @@ TEST(SocketStream, wait_writable_UNIX) {
   EXPECT_EQ(0, close(fds[0]));
 }
 
+TEST(SocketStream, writev_UNIX) {
+  int fds[2];
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+
+  // More spans than CPPHTTPLIB_WRITEV_MAX_BUFS exercises batching; a total
+  // several times the socket buffer exercises the partial-send resume logic.
+  std::vector<std::string> spans;
+  for (size_t i = 0; i < 2 * CPPHTTPLIB_WRITEV_MAX_BUFS + 3; i++) {
+    spans.emplace_back(1 + i * 25000, static_cast<char>('a' + i % 26));
+  }
+  std::vector<Stream::WriteBuffer> bufs;
+  std::string expected;
+  for (const auto &s : spans) {
+    bufs.push_back({s.data(), s.size()});
+    expected += s;
+  }
+
+  std::string received;
+  std::thread reader{[&] {
+    char buf[4096];
+    ssize_t n;
+    while ((n = ::recv(fds[1], buf, sizeof(buf), 0)) > 0) {
+      received.append(buf, static_cast<size_t>(n));
+    }
+  }};
+
+  detail::process_client_socket(
+      fds[0], 5, 0, 5, 0, 0, std::chrono::steady_clock::time_point::min(),
+      [&](Stream &strm) {
+        EXPECT_EQ(static_cast<ssize_t>(expected.size()),
+                  strm.writev(bufs.data(), bufs.size()));
+        return true;
+      });
+  EXPECT_EQ(0, close(fds[0])); // EOF ends the reader
+  reader.join();
+  EXPECT_EQ(0, close(fds[1]));
+
+  ASSERT_EQ(expected.size(), received.size());
+  EXPECT_TRUE(expected == received);
+}
+
 TEST(SocketStream, wait_writable_INET) {
   sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));
@@ -2173,6 +2214,89 @@ TEST(BufferStreamTest, read) {
   EXPECT_EQ('o', buf[0]);
 
   EXPECT_EQ(0, strm.read(buf, 1));
+}
+
+namespace {
+// Records write() calls into the generic Stream::writev() fallback. The call
+// count matters beyond syscall volume: for streams like TLS, every write() is
+// at least one record on the wire.
+struct WriteRecordingStream final : public Stream {
+  std::string buffer;
+  std::vector<size_t> write_sizes;
+
+  bool is_readable() const override { return false; }
+  bool wait_readable() const override { return false; }
+  bool wait_writable() const override { return true; }
+  ssize_t read(char *, size_t) override { return -1; }
+  ssize_t write(const char *ptr, size_t size) override {
+    write_sizes.push_back(size);
+    buffer.append(ptr, size);
+    return static_cast<ssize_t>(size);
+  }
+  void get_remote_ip_and_port(std::string &, int &) const override {}
+  void get_local_ip_and_port(std::string &, int &) const override {}
+  socket_t socket() const override { return INVALID_SOCKET; }
+  time_t duration() const override { return 0; }
+};
+} // namespace
+
+// Small totals coalesce into a single write.
+TEST(StreamWritevFallbackTest, coalesced) {
+  WriteRecordingStream strm;
+
+  const Stream::WriteBuffer bufs[3] = {{"foo", 3}, {"", 0}, {"barbaz", 6}};
+  EXPECT_EQ(9, strm.writev(bufs, 3));
+  EXPECT_EQ("foobarbaz", strm.buffer);
+  EXPECT_EQ(std::vector<size_t>{9}, strm.write_sizes);
+}
+
+// A total of at least a full staging buffer is written span by span, with
+// no flattening copy. (Many small spans summing large would emit one write
+// each; no caller produces that shape.)
+TEST(StreamWritevFallbackTest, largeTotalWritesPerSpan) {
+  WriteRecordingStream strm;
+
+  const std::string a(CPPHTTPLIB_SEND_BUFSIZ - 10, 'a');
+  const std::string b(CPPHTTPLIB_SEND_BUFSIZ - 10, 'b');
+  const Stream::WriteBuffer bufs[2] = {{a.data(), a.size()},
+                                       {b.data(), b.size()}};
+  EXPECT_EQ(static_cast<ssize_t>(a.size() + b.size()), strm.writev(bufs, 2));
+  EXPECT_EQ(a + b, strm.buffer);
+  EXPECT_EQ((std::vector<size_t>{CPPHTTPLIB_SEND_BUFSIZ - 10,
+                                 CPPHTTPLIB_SEND_BUFSIZ - 10}),
+            strm.write_sizes);
+}
+
+// A large span reaches write() whole, so the stream (e.g. OpenSSL) can
+// fragment it internally instead of taking a copy and a write() per
+// staging-buffer sized piece.
+TEST(StreamWritevFallbackTest, passthrough) {
+  WriteRecordingStream strm;
+
+  const std::string a(CPPHTTPLIB_SEND_BUFSIZ + 10, 'a');
+  const std::string b(20, 'b');
+  const Stream::WriteBuffer bufs[2] = {{a.data(), a.size()},
+                                       {b.data(), b.size()}};
+  EXPECT_EQ(static_cast<ssize_t>(a.size() + b.size()), strm.writev(bufs, 2));
+  EXPECT_EQ(a + b, strm.buffer);
+  EXPECT_EQ((std::vector<size_t>{CPPHTTPLIB_SEND_BUFSIZ + 10, 20}),
+            strm.write_sizes);
+}
+
+// The gather-write shape: small headers, then a large body. The headers go
+// out first on their own; the body reaches write() untouched.
+TEST(StreamWritevFallbackTest, headersThenLargeBody) {
+  WriteRecordingStream strm;
+
+  const std::string headers(100, 'h');
+  const std::string body(2 * CPPHTTPLIB_SEND_BUFSIZ, 'b');
+  const Stream::WriteBuffer bufs[2] = {{headers.data(), headers.size()},
+                                       {body.data(), body.size()}};
+  EXPECT_EQ(static_cast<ssize_t>(headers.size() + body.size()),
+            strm.writev(bufs, 2));
+  EXPECT_EQ(headers + body, strm.buffer);
+  EXPECT_EQ((std::vector<size_t>{100, 2 * CPPHTTPLIB_SEND_BUFSIZ}),
+            strm.write_sizes);
 }
 
 TEST(HostnameToIPConversionTest, HTTPWatch_Online) {
@@ -6387,6 +6511,15 @@ TEST_F(ServerTest, GetMethodDirTest) {
   EXPECT_EQ(StatusCode::OK_200, res->status);
   EXPECT_EQ("text/html", res->get_header_value("Content-Type"));
   EXPECT_EQ("test.html", res->body);
+}
+
+TEST_F(ServerTest, GetMethodDirTestRangeNotSatisfiable) {
+  Headers headers = {make_range_header({{100, 199}})};
+  auto res = cli_.Get("/dir/test.html", headers);
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::RangeNotSatisfiable_416, res->status);
+  EXPECT_EQ("0", res->get_header_value("Content-Length"));
+  EXPECT_EQ("", res->body);
 }
 
 TEST_F(ServerTest, GetMethodDirTestWithDoubleDots) {
@@ -10945,6 +11078,273 @@ TEST(MountTest, Unmount) {
   res = cli.Get("/mount2/dir/test.html");
   ASSERT_TRUE(res) << "Error: " << to_string(res.error());
   EXPECT_EQ(StatusCode::NotFound_404, res->status);
+}
+
+TEST(BorrowedContentTest, ServeAndRelease) {
+  Server svr;
+
+  const std::string data = "0123456789abcdefghij";
+  std::atomic<int> released{0};
+  std::atomic<int> released_ok{0};
+
+  svr.Get("/view", [&](const Request & /*req*/, Response &res) {
+    res.set_content(data.data(), data.size(), "text/plain", [&](bool ok) {
+      released++;
+      if (ok) { released_ok++; }
+    });
+  });
+
+  auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
+  svr.wait_until_ready();
+
+  {
+    Client cli("localhost", PORT);
+    cli.set_keep_alive(true);
+
+    auto res = cli.Get("/view");
+    ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+    EXPECT_EQ(StatusCode::OK_200, res->status);
+    EXPECT_EQ("text/plain", res->get_header_value("Content-Type"));
+    EXPECT_EQ("20", res->get_header_value("Content-Length"));
+    EXPECT_EQ(data, res->body);
+
+    res = cli.Head("/view");
+    ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+    EXPECT_EQ(StatusCode::OK_200, res->status);
+    EXPECT_EQ("20", res->get_header_value("Content-Length"));
+    EXPECT_EQ("", res->body);
+
+    Headers range_headers = {make_range_header({{5, 8}})};
+    res = cli.Get("/view", range_headers);
+    ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+    EXPECT_EQ(StatusCode::PartialContent_206, res->status);
+    EXPECT_EQ("bytes 5-8/20", res->get_header_value("Content-Range"));
+    EXPECT_EQ("5678", res->body);
+
+    // An unsatisfiable range drops the borrowed view; nothing may trail the
+    // 416 on this kept-alive connection.
+    Headers bad_range_headers = {make_range_header({{100, 199}})};
+    res = cli.Get("/view", bad_range_headers);
+    ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+    EXPECT_EQ(StatusCode::RangeNotSatisfiable_416, res->status);
+    EXPECT_EQ("", res->body);
+
+    res = cli.Get("/view");
+    ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+    EXPECT_EQ(data, res->body);
+  }
+
+  svr.stop();
+  listen_thread.join();
+
+  // One release per response; the flag reports whether the borrowed bytes
+  // were delivered (HEAD and the 416 never send them).
+  EXPECT_EQ(5, released.load());
+  EXPECT_EQ(3, released_ok.load());
+}
+
+#ifndef _WIN32
+// A Content-Length-honoring client cannot see bytes leaked after the header
+// block (a 416 always closes the connection), so verify at the socket level
+// that the 416 for a borrowed view carries no body at all.
+TEST(BorrowedContentTest, RangeNotSatisfiableLeavesNoStrayBytes) {
+  Server svr;
+
+  const std::string data = "0123456789abcdefghij";
+  svr.Get("/view", [&](const Request & /*req*/, Response &res) {
+    res.set_content(data.data(), data.size(), "text/plain", nullptr);
+  });
+
+  // Bind the loopback IPv4 address explicitly; the raw client below
+  // connects to INADDR_LOOPBACK.
+  auto listen_thread = std::thread([&svr]() { svr.listen("127.0.0.1", PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    listen_thread.join();
+  });
+  svr.wait_until_ready();
+
+  const int sock = socket(AF_INET, SOCK_STREAM, 0);
+  ASSERT_LE(0, sock);
+  sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(static_cast<uint16_t>(PORT));
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  ASSERT_EQ(0,
+            connect(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)));
+
+  const std::string request = "GET /view HTTP/1.1\r\n"
+                              "Host: localhost\r\n"
+                              "Range: bytes=100-199\r\n"
+                              "Connection: close\r\n"
+                              "\r\n";
+  ASSERT_EQ(static_cast<ssize_t>(request.size()),
+            send(sock, request.data(), request.size(), 0));
+
+  std::string response;
+  char buf[4096];
+  ssize_t n;
+  while ((n = recv(sock, buf, sizeof(buf), 0)) > 0) {
+    response.append(buf, static_cast<size_t>(n));
+  }
+  close(sock);
+
+  EXPECT_EQ(0u, response.find("HTTP/1.1 416 "));
+  const auto header_end = response.find("\r\n\r\n");
+  ASSERT_NE(std::string::npos, header_end);
+  EXPECT_EQ(response.size(), header_end + 4);
+}
+#endif
+
+TEST(BorrowedContentTest, ErrorHandlerReplacesBorrowedContent) {
+  Server svr;
+
+  const std::string data = "borrowed bytes";
+  svr.Get("/fail", [&](const Request & /*req*/, Response &res) {
+    res.set_content(data.data(), data.size(), "text/plain", nullptr);
+    res.status = StatusCode::InternalServerError_500;
+  });
+  svr.set_error_handler([](const Request & /*req*/, Response &res) {
+    res.set_content("error body", "text/html");
+    return Server::HandlerResponse::Handled;
+  });
+
+  auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    listen_thread.join();
+  });
+  svr.wait_until_ready();
+
+  Client cli("localhost", PORT);
+  auto res = cli.Get("/fail");
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::InternalServerError_500, res->status);
+  EXPECT_EQ("error body", res->body);
+}
+
+#ifndef CPPHTTPLIB_NO_EXCEPTIONS
+TEST(BorrowedContentTest, ExceptionDropsBorrowedContent) {
+  Server svr;
+
+  const std::string data = "borrowed bytes";
+  svr.Get("/throw", [&](const Request & /*req*/, Response &res) {
+    res.set_content(data.data(), data.size(), "text/plain", nullptr);
+    throw std::runtime_error("boom");
+  });
+
+  auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    listen_thread.join();
+  });
+  svr.wait_until_ready();
+
+  Client cli("localhost", PORT);
+  auto res = cli.Get("/throw");
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::InternalServerError_500, res->status);
+  EXPECT_EQ("0", res->get_header_value("Content-Length"));
+  EXPECT_EQ("", res->body);
+}
+#endif
+
+TEST(BorrowedContentTest, ReplacingViewWithEmptyBodyClearsContentLength) {
+  Server svr;
+
+  const std::string data = "0123456789abcdefghij"; // 20 bytes
+  svr.Get("/replaced", [&](const Request & /*req*/, Response &res) {
+    res.set_content(data.data(), data.size(), "text/plain", nullptr);
+    res.set_content("", "text/plain"); // drop it again
+  });
+
+  auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    listen_thread.join();
+  });
+  svr.wait_until_ready();
+
+  Client cli("localhost", PORT);
+  cli.set_read_timeout(1, 0);
+
+  auto res = cli.Get("/replaced");
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ("0", res->get_header_value("Content-Length"));
+  EXPECT_EQ("", res->body);
+}
+
+TEST(BorrowedContentTest, ReplacingContentReleasesTheOldView) {
+  Server svr;
+
+  const std::string a = "AAAA";
+  const std::string b = "BBBB";
+  std::atomic<int> released_a{0};
+
+  svr.Get("/twice", [&](const Request & /*req*/, Response &res) {
+    res.set_content(a.data(), a.size(), "text/plain",
+                    [&](bool) { released_a++; });
+    res.set_content(b.data(), b.size(), "text/plain", nullptr);
+  });
+
+  auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    listen_thread.join();
+  });
+  svr.wait_until_ready();
+
+  Client cli("localhost", PORT);
+  auto res = cli.Get("/twice");
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ("BBBB", res->body);
+  EXPECT_EQ(1, released_a.load()); // the discarded view is still released
+}
+
+TEST(BorrowedContentTest, ReplacingViewWithProviderReleasesTheOldView) {
+  Server svr;
+
+  const std::string a = "AAAA";
+  std::atomic<int> released_a{0};
+
+  svr.Get("/provided", [&](const Request & /*req*/, Response &res) {
+    res.set_content(a.data(), a.size(), "text/plain",
+                    [&](bool) { released_a++; });
+    res.set_content_provider(4, "text/plain",
+                             [](size_t offset, size_t length, DataSink &sink) {
+                               return sink.write("BBBB" + offset, length);
+                             });
+  });
+
+  auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    listen_thread.join();
+  });
+  svr.wait_until_ready();
+
+  Client cli("localhost", PORT);
+  auto res = cli.Get("/provided");
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ("BBBB", res->body);
+  EXPECT_EQ(1, released_a.load()); // the discarded view is still released
+}
+
+TEST(BorrowedContentTest, CopiedResponseSharesTheReleaser) {
+  int released = 0;
+  {
+    Response res;
+    const std::string data = "AAAA";
+    res.set_content(data.data(), data.size(), "text/plain",
+                    [&](bool) { released++; });
+    {
+      Response copy = res; // copies share ownership; no double-release
+      EXPECT_EQ(0, released);
+    }
+    EXPECT_EQ(0, released); // still owned by the original
+  }
+  EXPECT_EQ(1, released); // released exactly once, by the last owner
 }
 
 TEST(MountTest, PathSegmentBoundary) {


### PR DESCRIPTION
Normally, httplib generates one TCP segment for headers and at least one more for body content. This is awful without TCP_NODELAY ("It's always TCP_NODELAY. Every damn time." [[1]](https://brooker.co.za/blog/2024/05/09/nagle.html)). Even with TCP_NODELAY, small responses can become unnecessarily segmented and throughput can suffer on deeply embedded hosts due to syscall overhead.

This patch series threads a vectorized write syscall (writev() on Linux/MacOS, something else under Win32) through httplib just enough to combine headers and body content into a single, zero-copy syscall under "happy path" conditions (chiefly, no ranged requests).

- New Response::set_content() allows callers to provide a copy-free "borrowed view" into C arrays. The existing std::move-based set_content() call isn't useful for non-std::string arguments, and the existing Response::set_content(char*, size_t) call required copying. This new call requires some pointer-lifetime effort but allows copy-free responses to come from non-strings (e.g. mmap'd files); both static-mount and set_file_content() responses now use it.

- Server::write_response_core uses writev() and "borrowed view" content to entirely combine most Responses into a single syscall. This avoids excess TCP segment generation (a good thing with or without NODELAY), and on resource-constrained systems, the avoided syscall overhead itself can be meaningful.

- A new Response::clear_content() drops all pending content representations at the error-reset sites and uncaught handler exceptions, and every content setter clears a previously set borrowed view, so stale borrowed bytes can never trail a response whose headers no longer describe them.

The abidiff test fails (because the ABI did change, and I haven't modified anything to match). I'm uncertain how you handle ABI changes but happy to follow your lead.