### PR TITLE
Match the Connection "Upgrade" token exactly in WebSocket handshakes

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -3500,8 +3500,35 @@ void split(const char *b, const char *e, char d,
 void split(const char *b, const char *e, char d, size_t m,
            std::function<void(const char *, const char *)> fn);
 
-bool has_header_token(const Headers &headers, const std::string &key,
-                      const std::string &token);
+bool split_find(const char *b, const char *e, char d,
+                std::function<bool(const char *, const char *)> fn);
+
+// Defined here rather than beside the other header-field helpers because both
+// call sites sit in the implementation section below. Kept static so that an
+// internal helper does not become an exported symbol of the shared library.
+static inline bool has_header_token(const Headers &headers,
+                                    const std::string &key,
+                                    const std::string &token) {
+  // RFC 9110 7.6.1: a comma-separated token list field such as Connection may
+  // carry several tokens, and RFC 9110 5.3 lets that list be split across
+  // several lines. Match complete tokens rather than searching the raw value,
+  // so that a value such as "notupgrade" is not read as the token "upgrade".
+  auto rng = headers.equal_range(key);
+  for (auto it = rng.first; it != rng.second; ++it) {
+    const auto &value = it->second;
+    if (split_find(value.data(), value.data() + value.size(), ',',
+                   [&](const char *b, const char *e) {
+                     return case_ignore::equal(std::string(b, e), token);
+                   })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string websocket_accept_key(const std::string &client_key);
+
+bool is_websocket_upgrade(const Request &req);
 
 bool process_client_socket(
     socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
@@ -8012,25 +8039,6 @@ inline ReadContentResult read_content_chunked(Stream &strm, T &x,
 
     total_len += static_cast<size_t>(n);
   }
-}
-
-inline bool has_header_token(const Headers &headers, const std::string &key,
-                             const std::string &token) {
-  // RFC 9110 7.6.1: a comma-separated token list field such as Connection may
-  // carry several tokens, and RFC 9110 5.3 lets that list be split across
-  // several lines. Match complete tokens rather than searching the raw value,
-  // so that a value such as "notupgrade" is not read as the token "upgrade".
-  auto rng = headers.equal_range(key);
-  for (auto it = rng.first; it != rng.second; ++it) {
-    const auto &value = it->second;
-    if (split_find(value.data(), value.data() + value.size(), ',',
-                   [&](const char *b, const char *e) {
-                     return case_ignore::equal(std::string(b, e), token);
-                   })) {
-      return true;
-    }
-  }
-  return false;
 }
 
 inline bool is_chunked_transfer_encoding(const Headers &headers) {

--- a/httplib.h
+++ b/httplib.h
@@ -3500,6 +3500,9 @@ void split(const char *b, const char *e, char d,
 void split(const char *b, const char *e, char d, size_t m,
            std::function<void(const char *, const char *)> fn);
 
+bool has_header_token(const Headers &headers, const std::string &key,
+                      const std::string &token);
+
 bool process_client_socket(
     socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
     time_t write_timeout_sec, time_t write_timeout_usec,
@@ -5280,25 +5283,6 @@ inline std::string websocket_accept_key(const std::string &client_key) {
   return base64_encode(sha1(client_key + magic));
 }
 
-inline bool has_header_token(const Headers &headers, const std::string &key,
-                             const std::string &token) {
-  // RFC 9110 7.6.1: a Connection field value is a comma-separated list of
-  // tokens, and RFC 9110 5.3 lets that list be split across several lines.
-  // Match complete tokens rather than searching the raw value, so that a
-  // value such as "notupgrade" is not read as the token "upgrade".
-  auto rng = headers.equal_range(key);
-  for (auto it = rng.first; it != rng.second; ++it) {
-    const auto &value = it->second;
-    auto found = false;
-    split(value.data(), value.data() + value.size(), ',',
-          [&](const char *b, const char *e) {
-            if (case_ignore::equal(std::string(b, e), token)) { found = true; }
-          });
-    if (found) { return true; }
-  }
-  return false;
-}
-
 inline bool is_websocket_upgrade(const Request &req) {
   if (req.method != "GET") { return false; }
 
@@ -5308,7 +5292,7 @@ inline bool is_websocket_upgrade(const Request &req) {
   auto upgrade_val = case_ignore::to_lower(upgrade_it->second);
   if (upgrade_val != "websocket") { return false; }
 
-  // Check Connection carries the "Upgrade" token
+  // Check Connection: Upgrade
   if (!has_header_token(req.headers, "Connection", "upgrade")) { return false; }
 
   // Check Sec-WebSocket-Key is a valid base64-encoded 16-byte value (24 chars)
@@ -7901,7 +7885,7 @@ inline bool read_websocket_upgrade_response(Stream &strm,
     return false;
   }
 
-  // Verify Connection carries the "Upgrade" token (case-insensitive)
+  // Verify Connection: Upgrade
   if (!has_header_token(headers, "Connection", "upgrade")) {
     upgrade.error = Error::WebSocketHandshake;
     return false;
@@ -8028,6 +8012,25 @@ inline ReadContentResult read_content_chunked(Stream &strm, T &x,
 
     total_len += static_cast<size_t>(n);
   }
+}
+
+inline bool has_header_token(const Headers &headers, const std::string &key,
+                             const std::string &token) {
+  // RFC 9110 7.6.1: a comma-separated token list field such as Connection may
+  // carry several tokens, and RFC 9110 5.3 lets that list be split across
+  // several lines. Match complete tokens rather than searching the raw value,
+  // so that a value such as "notupgrade" is not read as the token "upgrade".
+  auto rng = headers.equal_range(key);
+  for (auto it = rng.first; it != rng.second; ++it) {
+    const auto &value = it->second;
+    if (split_find(value.data(), value.data() + value.size(), ',',
+                   [&](const char *b, const char *e) {
+                     return case_ignore::equal(std::string(b, e), token);
+                   })) {
+      return true;
+    }
+  }
+  return false;
 }
 
 inline bool is_chunked_transfer_encoding(const Headers &headers) {

--- a/httplib.h
+++ b/httplib.h
@@ -5280,6 +5280,25 @@ inline std::string websocket_accept_key(const std::string &client_key) {
   return base64_encode(sha1(client_key + magic));
 }
 
+inline bool has_header_token(const Headers &headers, const std::string &key,
+                             const std::string &token) {
+  // RFC 9110 7.6.1: a Connection field value is a comma-separated list of
+  // tokens, and RFC 9110 5.3 lets that list be split across several lines.
+  // Match complete tokens rather than searching the raw value, so that a
+  // value such as "notupgrade" is not read as the token "upgrade".
+  auto rng = headers.equal_range(key);
+  for (auto it = rng.first; it != rng.second; ++it) {
+    const auto &value = it->second;
+    auto found = false;
+    split(value.data(), value.data() + value.size(), ',',
+          [&](const char *b, const char *e) {
+            if (case_ignore::equal(std::string(b, e), token)) { found = true; }
+          });
+    if (found) { return true; }
+  }
+  return false;
+}
+
 inline bool is_websocket_upgrade(const Request &req) {
   if (req.method != "GET") { return false; }
 
@@ -5289,11 +5308,8 @@ inline bool is_websocket_upgrade(const Request &req) {
   auto upgrade_val = case_ignore::to_lower(upgrade_it->second);
   if (upgrade_val != "websocket") { return false; }
 
-  // Check Connection header contains "Upgrade"
-  auto connection_it = req.headers.find("Connection");
-  if (connection_it == req.headers.end()) { return false; }
-  auto connection_val = case_ignore::to_lower(connection_it->second);
-  if (connection_val.find("upgrade") == std::string::npos) { return false; }
+  // Check Connection carries the "Upgrade" token
+  if (!has_header_token(req.headers, "Connection", "upgrade")) { return false; }
 
   // Check Sec-WebSocket-Key is a valid base64-encoded 16-byte value (24 chars)
   // RFC 6455 Section 4.2.1
@@ -7885,11 +7901,8 @@ inline bool read_websocket_upgrade_response(Stream &strm,
     return false;
   }
 
-  // Verify Connection header contains "Upgrade" (case-insensitive)
-  auto connection_it = headers.find("Connection");
-  if (connection_it == headers.end() ||
-      case_ignore::to_lower(connection_it->second).find("upgrade") ==
-          std::string::npos) {
+  // Verify Connection carries the "Upgrade" token (case-insensitive)
+  if (!has_header_token(headers, "Connection", "upgrade")) {
     upgrade.error = Error::WebSocketHandshake;
     return false;
   }

--- a/test/test.cc
+++ b/test/test.cc
@@ -20983,6 +20983,146 @@ TEST(WebSocketTest, InvalidHeaderInHandshakeWritesNothing) {
   EXPECT_EQ(0, received);
 }
 
+TEST(WebSocketTest, ConnectionHeaderNeedsCompleteUpgradeToken) {
+  // RFC 6455 4.2.1: Connection is a token list, so a value that merely
+  // contains "upgrade" as a substring is a different token and must not
+  // start a WebSocket handshake.
+  auto make_request = [](const std::vector<std::string> &connection_values) {
+    Request req;
+    req.method = "GET";
+    req.headers.emplace("Upgrade", "websocket");
+    for (const auto &value : connection_values) {
+      req.headers.emplace("Connection", value);
+    }
+    req.headers.emplace("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+    req.headers.emplace("Sec-WebSocket-Version", "13");
+    return req;
+  };
+
+  EXPECT_TRUE(detail::is_websocket_upgrade(make_request({"Upgrade"})));
+  EXPECT_TRUE(detail::is_websocket_upgrade(make_request({"upgrade"})));
+  EXPECT_TRUE(
+      detail::is_websocket_upgrade(make_request({"keep-alive, Upgrade"})));
+  EXPECT_TRUE(
+      detail::is_websocket_upgrade(make_request({"Upgrade , keep-alive"})));
+  EXPECT_TRUE(
+      detail::is_websocket_upgrade(make_request({"keep-alive", "Upgrade"})));
+
+  EXPECT_FALSE(detail::is_websocket_upgrade(make_request({"notupgrade"})));
+  EXPECT_FALSE(detail::is_websocket_upgrade(make_request({"upgrade-not"})));
+  EXPECT_FALSE(detail::is_websocket_upgrade(make_request({"xupgrade"})));
+  EXPECT_FALSE(
+      detail::is_websocket_upgrade(make_request({"keep-alive, notupgrade"})));
+  EXPECT_FALSE(detail::is_websocket_upgrade(make_request({"close"})));
+  EXPECT_FALSE(detail::is_websocket_upgrade(make_request({})));
+}
+
+TEST(WebSocketTest, ServerRejectsHandshakeWithoutUpgradeToken) {
+  Server svr;
+  svr.WebSocket("/ws", [](const Request &, ws::WebSocket &) {});
+
+  auto port = svr.bind_to_any_port("localhost");
+  std::thread t([&]() { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+  });
+  svr.wait_until_ready();
+
+  Headers headers = {{"Upgrade", "websocket"},
+                     {"Connection", "notupgrade"},
+                     {"Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ=="},
+                     {"Sec-WebSocket-Version", "13"}};
+
+  Client cli("localhost", port);
+  auto res = cli.Get("/ws", headers);
+
+  // The route exists only as a WebSocket route, so a request that fails the
+  // handshake check falls through to ordinary routing.
+  ASSERT_TRUE(res);
+  EXPECT_EQ(StatusCode::NotFound_404, res->status);
+}
+
+TEST(WebSocketTest, ClientRejectsResponseWithoutUpgradeToken) {
+  // The peer answers 101 with a correct Sec-WebSocket-Accept, so the
+  // Connection value is the only thing left for the client to reject.
+  auto srv = ::socket(AF_INET, SOCK_STREAM, 0);
+  ASSERT_NE(INVALID_SOCKET, srv);
+  auto se_srv = detail::scope_exit([&] { detail::close_socket(srv); });
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = 0; // ephemeral, so parallel shards don't collide
+  ::inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+  ASSERT_EQ(0, ::bind(srv, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)));
+  ASSERT_EQ(0, ::listen(srv, 1));
+
+  sockaddr_in bound{};
+  socklen_t bound_len = sizeof(bound);
+  ASSERT_EQ(
+      0, ::getsockname(srv, reinterpret_cast<sockaddr *>(&bound), &bound_len));
+  auto port = ntohs(bound.sin_port);
+
+  std::thread t([&] {
+    // Bound every blocking call so a regression fails the test instead of
+    // hanging the suite.
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(srv, &rfds);
+    timeval tv{5, 0};
+    if (::select(static_cast<int>(srv + 1), &rfds, nullptr, nullptr, &tv) <=
+        0) {
+      return;
+    }
+
+    sockaddr_in cli_addr{};
+    socklen_t cli_len = sizeof(cli_addr);
+    auto cli = ::accept(srv, reinterpret_cast<sockaddr *>(&cli_addr), &cli_len);
+    if (cli == INVALID_SOCKET) { return; }
+    auto se_cli = detail::scope_exit([&] { detail::close_socket(cli); });
+
+    detail::set_socket_opt_time(cli, SOL_SOCKET, SO_RCVTIMEO, 5, 0);
+    std::string req;
+    char buf[4096];
+    while (req.find("\r\n\r\n") == std::string::npos) {
+      auto n = ::recv(cli, buf, sizeof(buf), 0);
+      if (n <= 0) { return; }
+      req.append(buf, static_cast<size_t>(n));
+    }
+
+    const std::string name = "Sec-WebSocket-Key: ";
+    auto beg = req.find(name);
+    if (beg == std::string::npos) { return; }
+    beg += name.size();
+    auto end = req.find("\r\n", beg);
+    auto key = req.substr(beg, end - beg);
+
+    auto res = std::string("HTTP/1.1 101 Switching Protocols\r\n"
+                           "Upgrade: websocket\r\n"
+                           "Connection: notupgrade\r\n"
+                           "Sec-WebSocket-Accept: ") +
+               detail::websocket_accept_key(key) + "\r\n\r\n";
+    ::send(cli,
+#ifdef _WIN32
+           static_cast<const char *>(res.c_str()), static_cast<int>(res.size()),
+#else
+           res.c_str(), res.size(),
+#endif
+           0);
+  });
+
+  ws::WebSocketClient client("ws://127.0.0.1:" + std::to_string(port) + "/ws");
+  client.set_connection_timeout(5, 0);
+  client.set_read_timeout(5, 0);
+
+  auto res = client.connect();
+  EXPECT_FALSE(res);
+  EXPECT_EQ(Error::WebSocketHandshake, res.error());
+  EXPECT_FALSE(client.is_open());
+
+  t.join();
+}
+
 TEST(WebSocketTest, HostHeaderOverUnixSocket) {
   // The socket path doubles as the URL host, so it must not contain '/'.
   const char *shard = getenv("GTEST_SHARD_INDEX");

--- a/test/test.cc
+++ b/test/test.cc
@@ -21046,81 +21046,30 @@ TEST(WebSocketTest, ServerRejectsHandshakeWithoutUpgradeToken) {
 TEST(WebSocketTest, ClientRejectsResponseWithoutUpgradeToken) {
   // The peer answers 101 with a correct Sec-WebSocket-Accept, so the
   // Connection value is the only thing left for the client to reject.
-  auto srv = ::socket(AF_INET, SOCK_STREAM, 0);
-  ASSERT_NE(INVALID_SOCKET, srv);
-  auto se_srv = detail::scope_exit([&] { detail::close_socket(srv); });
-
-  sockaddr_in addr{};
-  addr.sin_family = AF_INET;
-  addr.sin_port = 0; // ephemeral, so parallel shards don't collide
-  ::inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
-  ASSERT_EQ(0, ::bind(srv, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)));
-  ASSERT_EQ(0, ::listen(srv, 1));
-
-  sockaddr_in bound{};
-  socklen_t bound_len = sizeof(bound);
-  ASSERT_EQ(
-      0, ::getsockname(srv, reinterpret_cast<sockaddr *>(&bound), &bound_len));
-  auto port = ntohs(bound.sin_port);
-
-  std::thread t([&] {
-    // Bound every blocking call so a regression fails the test instead of
-    // hanging the suite.
-    fd_set rfds;
-    FD_ZERO(&rfds);
-    FD_SET(srv, &rfds);
-    timeval tv{5, 0};
-    if (::select(static_cast<int>(srv + 1), &rfds, nullptr, nullptr, &tv) <=
-        0) {
-      return;
-    }
-
-    sockaddr_in cli_addr{};
-    socklen_t cli_len = sizeof(cli_addr);
-    auto cli = ::accept(srv, reinterpret_cast<sockaddr *>(&cli_addr), &cli_len);
-    if (cli == INVALID_SOCKET) { return; }
-    auto se_cli = detail::scope_exit([&] { detail::close_socket(cli); });
-
-    detail::set_socket_opt_time(cli, SOL_SOCKET, SO_RCVTIMEO, 5, 0);
-    std::string req;
-    char buf[4096];
-    while (req.find("\r\n\r\n") == std::string::npos) {
-      auto n = ::recv(cli, buf, sizeof(buf), 0);
-      if (n <= 0) { return; }
-      req.append(buf, static_cast<size_t>(n));
-    }
-
-    const std::string name = "Sec-WebSocket-Key: ";
-    auto beg = req.find(name);
-    if (beg == std::string::npos) { return; }
-    beg += name.size();
-    auto end = req.find("\r\n", beg);
-    auto key = req.substr(beg, end - beg);
-
-    auto res = std::string("HTTP/1.1 101 Switching Protocols\r\n"
-                           "Upgrade: websocket\r\n"
-                           "Connection: notupgrade\r\n"
-                           "Sec-WebSocket-Accept: ") +
-               detail::websocket_accept_key(key) + "\r\n\r\n";
-    ::send(cli,
-#ifdef _WIN32
-           static_cast<const char *>(res.c_str()), static_cast<int>(res.size()),
-#else
-           res.c_str(), res.size(),
-#endif
-           0);
+  Server svr;
+  svr.Get("/ws", [](const Request &req, Response &res) {
+    res.status = StatusCode::SwitchingProtocol_101;
+    res.set_header("Upgrade", "websocket");
+    res.set_header("Connection", "notupgrade");
+    res.set_header("Sec-WebSocket-Accept",
+                   detail::websocket_accept_key(
+                       req.get_header_value("Sec-WebSocket-Key")));
   });
 
-  ws::WebSocketClient client("ws://127.0.0.1:" + std::to_string(port) + "/ws");
-  client.set_connection_timeout(5, 0);
-  client.set_read_timeout(5, 0);
+  auto port = svr.bind_to_any_port("localhost");
+  std::thread t([&]() { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+  });
+  svr.wait_until_ready();
+
+  ws::WebSocketClient client("ws://localhost:" + std::to_string(port) + "/ws");
 
   auto res = client.connect();
   EXPECT_FALSE(res);
   EXPECT_EQ(Error::WebSocketHandshake, res.error());
   EXPECT_FALSE(client.is_open());
-
-  t.join();
 }
 
 TEST(WebSocketTest, HostHeaderOverUnixSocket) {


### PR DESCRIPTION
## Problem

Both the server-side handshake check and the client-side response check looked for `upgrade` as a substring of the `Connection` field value:

```cpp
if (connection_val.find("upgrade") == std::string::npos) { return false; }
```

`Connection` is a comma-separated token list (RFC 9110 7.6.1), and RFC 6455 4.2.1 asks for an ASCII case-insensitive match on the complete `Upgrade` token. The substring check has two consequences:

- values that merely contain the letters, such as `notupgrade`, `upgrade-not` and `xupgrade`, are accepted and the request enters the WebSocket handler;
- the list may be split across several `Connection` lines (RFC 9110 5.3), and only the first line was looked at, so `Connection: keep-alive` followed by `Connection: Upgrade` was rejected.

## Change

Added `detail::has_header_token()`, which walks every line of a header and compares complete comma-separated tokens case-insensitively, reusing the existing `split()` (it already trims optional whitespace). Both the server request check and the client response check now go through it.

## Tests

- `WebSocketTest.ConnectionHeaderNeedsCompleteUpgradeToken` covers accept (`Upgrade`, `upgrade`, `keep-alive, Upgrade`, `Upgrade , keep-alive`, two `Connection` lines) and reject (`notupgrade`, `upgrade-not`, `xupgrade`, `keep-alive, notupgrade`, `close`, absent).
- `WebSocketTest.ServerRejectsHandshakeWithoutUpgradeToken` sends a full handshake with `Connection: notupgrade` and expects the request to fall through to ordinary routing (404).
- `WebSocketTest.ClientRejectsResponseWithoutUpgradeToken` answers a real handshake with a 101 carrying a correct `Sec-WebSocket-Accept` but `Connection: notupgrade`, and expects `Error::WebSocketHandshake`.

All three fail on master and pass with the fix.

Reported by @gb1dev via a private advisory. Handled as an ordinary conformance bug: cpp-httplib's own authentication hooks are not bypassed, there is no smuggling primitive, and a well-formed `Connection: Upgrade` costs an attacker the same as the malformed one.