### PR TITLE
Fix data race in SSLSocketStream causing TLS session corruption in WebSocket

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,6 +114,9 @@ jobs:
       - name: build and run WebSocket heartbeat test
         if: matrix.tls_backend == 'openssl'
         run: cd test && make test_websocket_heartbeat && ./test_websocket_heartbeat
+      - name: build and run WebSocket TLS thread safety test
+        if: matrix.tls_backend == 'openssl'
+        run: cd test && make test_websocket_thread_safety && ./test_websocket_thread_safety
       - name: build and run ThreadPool test
         run: cd test && make test_thread_pool && ./test_thread_pool
 
@@ -414,6 +417,9 @@ jobs:
       - name: build and run WebSocket heartbeat test
         if: matrix.tls_backend == 'openssl'
         run: cd test && make test_websocket_heartbeat && ./test_websocket_heartbeat
+      - name: build and run WebSocket TLS thread safety test
+        if: matrix.tls_backend == 'openssl'
+        run: cd test && make test_websocket_thread_safety && ./test_websocket_thread_safety
       - name: build and run ThreadPool test
         run: cd test && make test_thread_pool && ./test_thread_pool
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ test/test_split_mbedtls
 test/test_split_wolfssl
 test/test_split_no_tls
 test/test_websocket_heartbeat
+test/test_websocket_thread_safety
 test/test_thread_pool
 test/test_benchmark
 test/test.xcodeproj/xcuser*

--- a/httplib.h
+++ b/httplib.h
@@ -9871,6 +9871,13 @@ public:
 private:
   bool ensure_readable();
 
+  int locked_pending() const;
+  bool locked_is_peer_closed() const;
+  ssize_t locked_read(char *ptr, size_t size, tls::TlsError &err);
+  ssize_t locked_write(const char *ptr, size_t size, tls::TlsError &err);
+
+  mutable std::mutex session_mutex_;
+
   socket_t sock_;
   tls::session_t session_;
   time_t read_timeout_sec_;
@@ -12053,8 +12060,30 @@ inline SSLSocketStream::SSLSocketStream(
 
 inline SSLSocketStream::~SSLSocketStream() = default;
 
+inline int SSLSocketStream::locked_pending() const {
+  std::lock_guard<std::mutex> guard(this->session_mutex_);
+  return tls::pending(session_);
+}
+
+inline bool SSLSocketStream::locked_is_peer_closed() const {
+  std::lock_guard<std::mutex> guard(this->session_mutex_);
+  return tls::is_peer_closed(session_, sock_);
+}
+
+inline ssize_t SSLSocketStream::locked_read(char *ptr, size_t size,
+                                            tls::TlsError &err) {
+  std::lock_guard<std::mutex> guard(this->session_mutex_);
+  return tls::read(session_, ptr, size, err);
+}
+
+inline ssize_t SSLSocketStream::locked_write(const char *ptr, size_t size,
+                                             tls::TlsError &err) {
+  std::lock_guard<std::mutex> guard(this->session_mutex_);
+  return tls::write(session_, ptr, size, err);
+}
+
 inline bool SSLSocketStream::is_readable() const {
-  return tls::pending(session_) > 0;
+  return this->locked_pending() > 0;
 }
 
 inline bool SSLSocketStream::wait_readable() const {
@@ -12072,7 +12101,7 @@ inline bool SSLSocketStream::wait_readable() const {
 
 inline bool SSLSocketStream::wait_writable() const {
   return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 &&
-         !tls::is_peer_closed(session_, sock_);
+         !this->locked_is_peer_closed();
 }
 
 inline bool SSLSocketStream::ensure_readable() {
@@ -12084,20 +12113,20 @@ inline bool SSLSocketStream::ensure_readable() {
 }
 
 inline bool SSLSocketStream::is_peer_alive() const {
-  return !tls::is_peer_closed(session_, sock_);
+  return !this->locked_is_peer_closed();
 }
 
 inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
-  if (tls::pending(session_) > 0) {
+  if (this->locked_pending() > 0) {
     tls::TlsError err;
-    auto ret = tls::read(session_, ptr, size, err);
+    auto ret = this->locked_read(ptr, size, err);
     if (ret == 0 || err.code == tls::ErrorCode::PeerClosed) {
       error_ = Error::ConnectionClosed;
     }
     return ret;
   } else if (ensure_readable()) {
     tls::TlsError err;
-    auto ret = tls::read(session_, ptr, size, err);
+    auto ret = this->locked_read(ptr, size, err);
     if (ret < 0) {
       auto n = 1000;
 #ifdef _WIN32
@@ -12107,11 +12136,11 @@ inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
 #else
       while (--n >= 0 && err.code == tls::ErrorCode::WantRead) {
 #endif
-        if (tls::pending(session_) > 0) {
-          return tls::read(session_, ptr, size, err);
+        if (this->locked_pending() > 0) {
+          return this->locked_read(ptr, size, err);
         } else if (wait_readable()) {
           std::this_thread::sleep_for(std::chrono::microseconds{10});
-          ret = tls::read(session_, ptr, size, err);
+          ret = this->locked_read(ptr, size, err);
           if (ret >= 0) { return ret; }
         } else {
           break;
@@ -12134,7 +12163,7 @@ inline ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
         std::min<size_t>(size, (std::numeric_limits<int>::max)());
 
     tls::TlsError err;
-    auto ret = tls::write(session_, ptr, handle_size, err);
+    auto ret = this->locked_write(ptr, handle_size, err);
     if (ret < 0) {
       auto n = 1000;
 #ifdef _WIN32
@@ -12146,7 +12175,7 @@ inline ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
 #endif
         if (wait_writable()) {
           std::this_thread::sleep_for(std::chrono::microseconds{10});
-          ret = tls::write(session_, ptr, handle_size, err);
+          ret = this->locked_write(ptr, handle_size, err);
           if (ret >= 0) { return ret; }
         } else {
           break;

--- a/test/Makefile
+++ b/test/Makefile
@@ -264,6 +264,10 @@ test_websocket_heartbeat : test_websocket_heartbeat.cc ../httplib.h Makefile
 	$(CXX) -o $@ -I.. $(CXXFLAGS) test_websocket_heartbeat.cc $(TEST_ARGS)
 	@file $@
 
+test_websocket_thread_safety : test_websocket_thread_safety.cc ../httplib.h Makefile cert.pem
+	$(CXX) -o $@ -I.. $(CXXFLAGS) test_websocket_thread_safety.cc $(TEST_ARGS)
+	@file $@
+
 test_proxy : test_proxy.cc ../httplib.h Makefile cert.pem
 	$(CXX) -o $@ -I.. $(CXXFLAGS) test_proxy.cc $(TEST_ARGS)
 

--- a/test/test_websocket_thread_safety.cc
+++ b/test/test_websocket_thread_safety.cc
@@ -1,0 +1,114 @@
+﻿#define CPPHTTPLIB_WEBSOCKET_PING_INTERVAL_SECOND 1
+#include <httplib.h>
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <string>
+#include <thread>
+
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+
+using namespace httplib;
+
+namespace {
+
+const size_t kPayloadBytes = 2048;
+const size_t kSendCount = 2000;
+const size_t kBurstPerFrame = 100;
+const int kCloseCycles = 20;
+
+} // namespace
+
+TEST(WebSocketTlsThreadSafetyTest, SendWhileAnotherThreadReads) {
+  SSLServer svr("cert.pem", "key.pem");
+  ASSERT_TRUE(svr.is_valid());
+
+  svr.set_websocket_ping_interval(0);
+
+  svr.WebSocket("/ws", [](const Request &, ws::WebSocket &sock) {
+    std::string msg;
+    while (sock.read(msg) != ws::ReadResult::Fail) {
+      if (!sock.send(msg.data(), msg.size())) { break; }
+    }
+  });
+
+  auto port = svr.bind_to_any_port("localhost");
+  ASSERT_GT(port, 0);
+  auto listen_thread = std::thread([&]() { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&]() {
+    svr.stop();
+    listen_thread.join();
+  });
+  svr.wait_until_ready();
+
+  ws::WebSocketClient cli("wss://localhost:" + std::to_string(port) + "/ws");
+  cli.enable_server_certificate_verification(false);
+  ASSERT_TRUE(cli.connect());
+
+  std::atomic<size_t> frames_read(0);
+  std::thread reader([&]() {
+    std::string msg;
+    while (cli.read(msg) != ws::ReadResult::Fail) {
+      frames_read++;
+    }
+  });
+
+  const std::string payload(kPayloadBytes, 'x');
+  size_t sent = 0;
+  for (size_t i = 0; i < kSendCount; i++) {
+    if (!cli.send(payload.data(), payload.size())) { break; }
+    sent++;
+  }
+
+  cli.close();
+  reader.join();
+
+  EXPECT_EQ(kSendCount, sent);
+  EXPECT_GT(frames_read.load(), static_cast<size_t>(0));
+}
+
+TEST(WebSocketTlsThreadSafetyTest, CloseWhileAnotherThreadReads) {
+  SSLServer svr("cert.pem", "key.pem");
+  ASSERT_TRUE(svr.is_valid());
+
+  svr.set_websocket_ping_interval(0);
+
+  svr.WebSocket("/ws", [](const Request &, ws::WebSocket &sock) {
+    const std::string burst(64, 'p');
+    std::string msg;
+    while (sock.read(msg) != ws::ReadResult::Fail) {
+      for (size_t i = 0; i < kBurstPerFrame; i++) {
+        if (!sock.send(burst.data(), burst.size())) { return; }
+      }
+    }
+  });
+
+  auto port = svr.bind_to_any_port("localhost");
+  ASSERT_GT(port, 0);
+  auto listen_thread = std::thread([&]() { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&]() {
+    svr.stop();
+    listen_thread.join();
+  });
+  svr.wait_until_ready();
+
+  for (int cycle = 0; cycle < kCloseCycles; cycle++) {
+    ws::WebSocketClient cli("wss://localhost:" + std::to_string(port) + "/ws");
+    cli.enable_server_certificate_verification(false);
+    ASSERT_TRUE(cli.connect()) << "cycle " << cycle;
+
+    std::thread reader([&]() {
+      std::string msg;
+      while (cli.read(msg) != ws::ReadResult::Fail) {}
+    });
+
+    const std::string trigger(64, 't');
+    ASSERT_TRUE(cli.send(trigger.data(), trigger.size()));
+
+    cli.close();
+    reader.join();
+  }
+}
+
+#endif // CPPHTTPLIB_OPENSSL_SUPPORT


### PR DESCRIPTION
## Problem

`SSLSocketStream` can be shared across threads, allowing concurrent access to the same TLS session.
The WebSocket ping thread, the application's `send()`, and `close()`'s wait-for-response read all enter the same session.
The write path also reads (`wait_writable() -> is_peer_closed() -> SSL_peek`), so `SSL_read` and `SSL_peek` collide on the same record layer buffer, causing a buffer overflow.

This only affects `wss://`. `ws://` doesn't use a TLS session, so it's unaffected.

## Reproduction

Added `test_websocket_thread_safety.cc`. One thread loops `read()` while another calls `send()` / `close()`.

- **`CloseWhileAnotherThreadReads`** (macOS, ASan): heap-buffer-overflow via
  `WebSocketClient::close() -> read_websocket_frame() ->
  SSLSocketStream::read() -> SSL_read()` (during OpenSSL GCM cipher param handling).
- **`SendWhileAnotherThreadReads`** (macOS/Linux): `sent` falls far short of the expected 2000 (macOS: 7, Linux: 19).
  On Linux, `frames_read == 0` also   failed.
  No crash — messages are silently dropped.

Being a race, the exact failure point varies per run; a single pass doesn't
prove safety.

## Fix

Add one mutex per `SSLSocketStream`, held around every call that enters the
session: `tls::pending`, `tls::read`, `tls::write`, `tls::is_peer_closed`.
`select_read`/`select_write` stay outside the lock since they're socket
operations, not session operations. Locking is not applied at the WebSocket
layer, so an idle reader doesn't block a sender for the whole read timeout.

## Out of scope

- This mutex is a safety net around TLS calls, not a redesign of WebSocket
  I/O. `std::mutex` doesn't guarantee fairness, so send starvation under
  heavy read load is still possible. A single I/O owner with an outbound
  queue would be a better long-term structure.
- The stack traces are from the OpenSSL backend; no claim is made about
  identical internal corruption on other backends.