### PR TITLE
Allow extending the set of accepted HTTP methods

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -22,6 +22,18 @@
  * Configuration
  */
 
+/*
+ * Additional HTTP methods the server will accept, on top of the standard set.
+ * Define as a comma-separated list of string literals, e.g. for WebDAV:
+ *
+ *   #define CPPHTTPLIB_ADDITIONAL_METHODS "PROPFIND","PROPPATCH","MKCOL"
+ *
+ * Empty by default, so behaviour is unchanged unless it is set.
+ */
+#ifndef CPPHTTPLIB_ADDITIONAL_METHODS
+#define CPPHTTPLIB_ADDITIONAL_METHODS
+#endif
+
 #ifndef CPPHTTPLIB_KEEPALIVE_TIMEOUT_SECOND
 #define CPPHTTPLIB_KEEPALIVE_TIMEOUT_SECOND 5
 #endif
@@ -12735,7 +12747,8 @@ inline bool Server::parse_request_line(const char *s, Request &req) const {
 
   thread_local const std::set<std::string> methods{
       "GET",     "HEAD",    "POST",  "PUT",   "DELETE",
-      "CONNECT", "OPTIONS", "TRACE", "PATCH", "PRI"};
+      "CONNECT", "OPTIONS", "TRACE", "PATCH", "PRI",
+      CPPHTTPLIB_ADDITIONAL_METHODS};
 
   if (methods.find(req.method) == methods.end()) {
     output_error_log(Error::InvalidHTTPMethod, &req);


### PR DESCRIPTION
## Why the existing extension points don't help

In #847 you suggested `set_pre_routing_handler`, and that is the right shape for this — but it cannot be reached. Validation runs strictly earlier. In `process_request` the flow is:

1. `parse_request_line(...)` — rejects here, returns `400`;
2. …later `routing()` — and only *that* calls `pre_routing_handler_`.

So for an unknown method the handler is never invoked. In the same thread you then pointed at these exact lines as the ones that would need modifying, which is what this PR does.

Subclassing does not help either: `parse_request_line` is private and non-virtual.

## Use case

Serving WebDAV. `PROPFIND`, `PROPPATCH`, `MKCOL`, `COPY`, `MOVE`, `LOCK` and `UNLOCK` are ordinary HTTP methods defined by RFC 4918. Everything else a DAV endpoint needs — the `207 Multi-Status` XML, the `DAV:` headers — is perfectly implementable on cpp-httplib today; the method check is the single blocker.

We currently ship a one-line patch for exactly this, applied at build time and guarded so an upstream refresh cannot silently drop it. It works, but a supported knob would be better for everyone.

## The change

A configuration macro, matching the existing `CPPHTTPLIB_*` macros:

```cpp
#ifndef CPPHTTPLIB_ADDITIONAL_METHODS
#define CPPHTTPLIB_ADDITIONAL_METHODS
#endif

thread_local const std::set<std::string> methods{
    "GET",     "HEAD",    "POST",  "PUT",   "DELETE",
    "CONNECT", "OPTIONS", "TRACE", "PATCH", "PRI",
    CPPHTTPLIB_ADDITIONAL_METHODS};
```

Used as:

```cpp
#define CPPHTTPLIB_ADDITIONAL_METHODS "PROPFIND","PROPPATCH","MKCOL"
```

Empty by default, so behaviour is unchanged unless it is set. No new state, no runtime cost, header-only friendly. 14 lines added, 1 changed.

Note on the trailing comma: it is kept in the header rather than expected from the macro value. A trailing comma in a braced-init-list is well-formed, so the empty default compiles cleanly. The alternative — expecting the value to start with a comma — has a bad failure mode: omitting it makes the adjacent string literals concatenate, turning `"PRI" "PROPFIND"` into the single token `"PRIPROPFIND"`, which silently disables both methods and still compiles. With the comma in the header, the same mistake is a compile error.

## Verification

Same program, same handler — a server whose `set_pre_routing_handler` answers `PROPFIND` with `207`. Only the macro differs:

```
built without the macro:   GET /ping -> 200,   PROPFIND /dav/ -> 400
built with the macro:      GET /ping -> 200,   PROPFIND /dav/ -> 207
```

Without the macro that handler is never reached, which is the point above. An unpatched build still rejects `PROPFIND` with `400`, so existing behaviour is preserved.

Compile-checked in six configurations — default, `CPPHTTPLIB_OPENSSL_SUPPORT`, `CPPHTTPLIB_ZLIB_SUPPORT`, each with and without the macro — all clean.

`test/test.cc` contains no reference to `InvalidHTTPMethod`, so no existing test depends on the rejection behaviour.