### PR TITLE
Fix accept() error handling on Windows

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -6925,6 +6925,30 @@ inline bool is_connection_error() {
 #endif
 }
 
+// accept() failed because the process or the network stack is temporarily out
+// of resources. The listening socket is still good; retry after a short pause.
+inline bool is_accept_resource_error() {
+#ifdef _WIN32
+  auto err = WSAGetLastError();
+  return err == WSAEMFILE || err == WSAENOBUFS;
+#else
+  return errno == EMFILE;
+#endif
+}
+
+// accept() failed for a reason that says nothing about the listening socket:
+// the pending connection went away before it could be accepted, or the call
+// was interrupted. Retry immediately.
+inline bool is_accept_transient_error() {
+#ifdef _WIN32
+  auto err = WSAGetLastError();
+  return err == WSAECONNRESET || err == WSAECONNABORTED || err == WSAEINTR ||
+         err == WSAEWOULDBLOCK;
+#else
+  return errno == EINTR || errno == EAGAIN;
+#endif
+}
+
 inline bool bind_ip_address(socket_t sock, const std::string &host) {
   struct addrinfo hints;
   struct addrinfo *result;
@@ -13400,12 +13424,18 @@ inline bool Server::listen_internal() {
 #endif
 
       if (sock == INVALID_SOCKET) {
-        if (errno == EMFILE) {
-          // The per-process limit of open file descriptors has been reached.
-          // Try to accept new connections after a short sleep.
+        // NOTE: Winsock reports failures through WSAGetLastError(), never
+        // through the CRT errno, so these have to be asked platform by
+        // platform. Testing errno directly here made both retry branches dead
+        // code on Windows and turned every transient accept() failure into a
+        // fatal one.
+        if (detail::is_accept_resource_error()) {
+          // The per-process limit of open file descriptors, or the network
+          // stack's buffer space, has been reached. Try to accept new
+          // connections after a short sleep.
           std::this_thread::sleep_for(std::chrono::microseconds{1});
           continue;
-        } else if (errno == EINTR || errno == EAGAIN) {
+        } else if (detail::is_accept_transient_error()) {
           continue;
         }
         if (svr_sock_ != INVALID_SOCKET) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -355,6 +355,52 @@ TEST(SetSocketOptTest, TcpNoDelay) {
   detail::close_socket(sock);
 }
 
+TEST(AcceptErrorTest, ClassifiesRetryableFailures) {
+  // accept() reports failures through WSAGetLastError() on Windows and through
+  // errno everywhere else, so each classifier has to read the one its platform
+  // actually sets.
+#ifdef _WIN32
+  for (auto err : {WSAEMFILE, WSAENOBUFS}) {
+    WSASetLastError(err);
+    EXPECT_TRUE(detail::is_accept_resource_error()) << "error " << err;
+    EXPECT_FALSE(detail::is_accept_transient_error()) << "error " << err;
+  }
+
+  for (auto err :
+       {WSAECONNRESET, WSAECONNABORTED, WSAEINTR, WSAEWOULDBLOCK}) {
+    WSASetLastError(err);
+    EXPECT_TRUE(detail::is_accept_transient_error()) << "error " << err;
+    EXPECT_FALSE(detail::is_accept_resource_error()) << "error " << err;
+  }
+
+  for (auto err : {WSAENOTSOCK, WSAEINVAL, WSAEOPNOTSUPP}) {
+    WSASetLastError(err);
+    EXPECT_FALSE(detail::is_accept_resource_error()) << "error " << err;
+    EXPECT_FALSE(detail::is_accept_transient_error()) << "error " << err;
+  }
+
+  WSASetLastError(0);
+#else
+  errno = EMFILE;
+  EXPECT_TRUE(detail::is_accept_resource_error());
+  EXPECT_FALSE(detail::is_accept_transient_error());
+
+  for (auto err : {EINTR, EAGAIN}) {
+    errno = err;
+    EXPECT_TRUE(detail::is_accept_transient_error()) << "errno " << err;
+    EXPECT_FALSE(detail::is_accept_resource_error()) << "errno " << err;
+  }
+
+  for (auto err : {EBADF, EINVAL, ENOTSOCK}) {
+    errno = err;
+    EXPECT_FALSE(detail::is_accept_resource_error()) << "errno " << err;
+    EXPECT_FALSE(detail::is_accept_transient_error()) << "errno " << err;
+  }
+
+  errno = 0;
+#endif
+}
+
 TEST(ClientTest, MoveConstructible) {
   EXPECT_FALSE(std::is_copy_constructible<Client>::value);
   EXPECT_TRUE(std::is_nothrow_move_constructible<Client>::value);


### PR DESCRIPTION
The accept loop in Server::listen_internal() inspects errno, but Winsock never sets the CRT errno - it reports failures through WSAGetLastError(). Both retry branches were therefore dead code on Windows, and every accept() failure fell through to the fatal path, which closes the listening socket and ends listen().

That is reachable in normal operation. WSAECONNRESET is documented for accept() when a peer resets a pending connection before it is accepted (a port scanner is enough to trigger it), and WSAEMFILE/WSAENOBUFS show up under load. One such event permanently stops the server accepting.

Add is_accept_resource_error() and is_accept_transient_error() beside the existing is_connection_error(), which already abstracts the same errno vs WSAGetLastError() difference, and use them in the accept loop.

POSIX behaviour is unchanged: EMFILE still sleeps and retries, EINTR and EAGAIN still retry immediately.