### PR TITLE
Clear svr_sock_ when the accept loop closes it after a fatal error

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -13408,8 +13408,15 @@ inline bool Server::listen_internal() {
         } else if (errno == EINTR || errno == EAGAIN) {
           continue;
         }
-        if (svr_sock_ != INVALID_SOCKET) {
-          detail::close_socket(svr_sock_);
+        // Take svr_sock_ as we close it. Leaving the descriptor behind lets a
+        // later stop() call shutdown()/close() on a value the OS may already
+        // have handed out to a different socket, and leaves keep_alive() in
+        // the workers waiting on a listening socket that is gone. The exchange
+        // also settles the race with a concurrent stop(): whichever side takes
+        // the descriptor closes it exactly once.
+        auto listen_sock = svr_sock_.exchange(INVALID_SOCKET);
+        if (listen_sock != INVALID_SOCKET) {
+          detail::close_socket(listen_sock);
           ret = false;
           output_error_log(Error::Connection, nullptr);
         } else {


### PR DESCRIPTION
On the fatal path the accept loop closes the listening socket but leaves the descriptor in svr_sock_. Two consequences:

- A later stop() reads that stale value and calls shutdown()/close() on it. By then the OS may have reused the descriptor for an unrelated socket - a worker's keep-alive connection, or a socket opened by the application - and that connection is torn down instead.
- keep_alive() in the worker threads tests svr_sock_ to notice shutdown, so the workers keep waiting on a listening socket that no longer exists.

Take the descriptor with exchange(INVALID_SOCKET) before closing it, which is what stop() already does. That also settles the race with a concurrent stop(): whichever side takes the descriptor closes it exactly once, and the other sees INVALID_SOCKET and does nothing.