### PR TITLE
Give DataSink's optional callbacks safe defaults

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1429,9 +1429,20 @@ public:
   DataSink &operator=(DataSink &&) = delete;
 
   std::function<bool(const char *data, size_t data_len)> write;
-  std::function<bool()> is_writable;
-  std::function<void()> done;
-  std::function<void(const Headers &trailer)> done_with_trailer;
+
+  // Every writer that hands a DataSink to a content provider assigns `write`,
+  // but only write_content_chunked() assigns all of the rest, so a provider
+  // that calls one of the others hits an empty std::function and throws
+  // std::bad_function_call. Nothing on the path catches it, so it reaches the
+  // thread that runs the provider and terminates the process. Default them to
+  // something harmless instead: a sink is writable unless a writer says
+  // otherwise, and a sink that cannot carry trailers still has to finish, so
+  // done_with_trailer() falls back to done(). Capturing `this` is safe because
+  // DataSink is neither copyable nor movable.
+  std::function<bool()> is_writable = []() { return true; };
+  std::function<void()> done = []() {};
+  std::function<void(const Headers &trailer)> done_with_trailer =
+      [this](const Headers & /*trailer*/) { done(); };
   std::ostream os;
 
 private:
@@ -8298,6 +8309,7 @@ inline bool write_content_with_progress(Stream &strm,
   size_t end_offset = offset + length;
   size_t start_offset = offset;
   auto ok = true;
+  auto finished = false;
   DataSink data_sink;
 
   data_sink.write = [&](const char *d, size_t l) -> bool {
@@ -8321,7 +8333,14 @@ inline bool write_content_with_progress(Stream &strm,
 
   data_sink.is_writable = [&]() -> bool { return strm.is_peer_alive(); };
 
-  while (offset < end_offset && !is_shutting_down()) {
+  // The body is framed by `length`, so a provider that reports itself done
+  // before producing that many bytes has truncated it and the response has to
+  // fail. Without this the default no-op done() would leave `offset` short of
+  // `end_offset` with nothing written, and the loop would call the provider
+  // again immediately - a busy loop rather than an error.
+  data_sink.done = [&]() { finished = true; };
+
+  while (offset < end_offset && !finished && !is_shutting_down()) {
     if (!strm.wait_writable() || !strm.is_peer_alive()) {
       error = Error::Write;
       return false;
@@ -8334,7 +8353,7 @@ inline bool write_content_with_progress(Stream &strm,
     }
   }
 
-  if (offset < end_offset) { // exited due to is_shutting_down(), not completion
+  if (offset < end_offset) { // done() early, or exited due to is_shutting_down()
     error = Error::Write;
     return false;
   }
@@ -15312,6 +15331,7 @@ ClientImpl::send_with_content_provider_and_receiver(
 
     if (content_provider) {
       auto ok = true;
+      auto finished = false;
       size_t offset = 0;
       DataSink data_sink;
 
@@ -15335,12 +15355,23 @@ ClientImpl::send_with_content_provider_and_receiver(
         return ok;
       };
 
-      while (ok && offset < content_length) {
+      // As in write_content_with_progress(): the request body is framed by
+      // content_length, so a provider that finishes early has truncated it.
+      // Stop and report it rather than calling the provider forever.
+      data_sink.done = [&]() { finished = true; };
+
+      while (ok && !finished && offset < content_length) {
         if (!content_provider(offset, content_length - offset, data_sink)) {
           error = Error::Canceled;
           output_error_log(error, &req);
           return nullptr;
         }
+      }
+
+      if (offset < content_length) {
+        error = Error::Write;
+        output_error_log(error, &req);
+        return nullptr;
       }
     } else {
       if (!compressor->compress(body, content_length, true,

--- a/test/test.cc
+++ b/test/test.cc
@@ -1934,6 +1934,67 @@ TEST(ParseAcceptEncoding8, AcceptEncodingQValuePriority) {
 #endif
 }
 
+TEST(DataSinkTest, OptionalCallbacksHaveSafeDefaults) {
+  DataSink sink;
+
+  // A default-constructed sink must be safe to call: only `write` is assigned
+  // by every writer, so the rest need defaults or a provider that touches them
+  // throws std::bad_function_call.
+  EXPECT_TRUE(sink.is_writable());
+  EXPECT_NO_THROW(sink.done());
+  EXPECT_NO_THROW(sink.done_with_trailer(Headers{}));
+
+  // done_with_trailer() falls back to done(), so a provider that offers
+  // trailers still finishes on a sink that cannot carry them.
+  auto done_called = false;
+  sink.done = [&]() { done_called = true; };
+  sink.done_with_trailer(Headers{{"X-Trailer", "value"}});
+  EXPECT_TRUE(done_called);
+}
+
+TEST(DataSinkTest, DoneBeforeContentLengthFailsTheWrite) {
+  detail::BufferStream strm;
+  auto error = Error::Success;
+  auto calls = 0;
+
+  // Promises 10 bytes but reports done() after 3. The body is framed by that
+  // length, so the write has to fail; the guard on `calls` keeps the test from
+  // hanging if the provider is ever called repeatedly instead.
+  auto ret = detail::write_content_with_progress(
+      strm,
+      [&](size_t /*offset*/, size_t /*length*/, DataSink &sink) {
+        if (++calls > 3) { return false; }
+        sink.write("abc", 3);
+        sink.done();
+        return true;
+      },
+      0, 10, []() { return false; }, nullptr, error);
+
+  EXPECT_FALSE(ret);
+  EXPECT_EQ(Error::Write, error);
+  EXPECT_EQ(1, calls); // done() is honoured immediately, not retried
+  EXPECT_EQ("abc", strm.get_buffer());
+}
+
+TEST(DataSinkTest, WriteToContentLengthStillSucceeds) {
+  detail::BufferStream strm;
+  auto error = Error::Success;
+
+  auto ret = detail::write_content_with_progress(
+      strm,
+      [](size_t offset, size_t length, DataSink &sink) {
+        std::string chunk(length, 'x');
+        (void)offset;
+        sink.write(chunk.data(), chunk.size());
+        return true;
+      },
+      0, 10, []() { return false; }, nullptr, error);
+
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(Error::Success, error);
+  EXPECT_EQ("xxxxxxxxxx", strm.get_buffer());
+}
+
 TEST(BufferStreamTest, read) {
   detail::BufferStream strm1;
   Stream &strm = strm1;


### PR DESCRIPTION
`DataSink` has four callbacks, but only `write` is assigned by every writer that hands a sink to a content provider:

  write_content_with_progress()   write, is_writable
  write_content_without_length()  write, is_writable, done
  write_content_chunked()         all four
  send_with_content_provider..()  write
  get_multipart_content_provider() write, done   (cur_sink)

A provider that calls one of the unassigned ones invokes an empty std::function, which throws std::bad_function_call. Nothing on that path catches it, so it unwinds out of the thread running the provider and terminates the process. The README's own idiom (`sink.is_writable()`, `sink.done()`) is enough to hit it: `sink.done()` is documented for the without-length overload, but a provider registered through set_content_provider() with a length gets a sink where `done` is empty.

Default the three optional callbacks instead. A sink is writable unless a writer says otherwise, and a sink that cannot carry trailers still has to finish, so done_with_trailer() falls back to done(). Capturing `this` for that is safe because DataSink is neither copyable nor movable.

A no-op `done` alone would only trade the crash for a hang on the two length-framed paths: they loop until `offset` reaches the promised length, so a provider that reports itself done without writing would be called again immediately, forever. Both now record that the provider finished and stop; the body is short of the Content-Length it promised, so the write fails rather than emitting a truncated message.

Adds DataSinkTest covering the defaults, the done_with_trailer fallback, and both the early-done and write-to-completion paths. The first two fail with "bad function call" without this change.