### PR TITLE
Bound the multipart parser's buffer while it waits for a boundary

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8984,21 +8984,19 @@ public:
         if (buf_start_with(crlf_)) {
           buf_erase(crlf_.size());
           state_ = 1;
+        } else if (buf_start_with(dash_)) {
+          buf_erase(dash_.size());
+          is_valid_ = true;
+          state_ = 5;
         } else {
-          if (dash_.size() > buf_size()) { return true; }
-          if (buf_start_with(dash_)) {
-            buf_erase(dash_.size());
-            is_valid_ = true;
-            state_ = 5;
-          } else {
-            // Only CRLF (another part follows) and "--" (close-delimiter) are
-            // accepted after a boundary; RFC 2046 allows transport-padding in
-            // between, but this parser has never supported it. Either way the
-            // body is already destined to be rejected, so fail now instead of
-            // buffering the rest of it.
-            is_valid_ = false;
-            return false;
-          }
+          // Only CRLF (another part follows) and "--" (close-delimiter) are
+          // accepted after a boundary; RFC 2046 allows transport-padding in
+          // between, but this parser has never supported it. Either way the
+          // body is already destined to be rejected, so fail now instead of
+          // buffering the rest of it. Both are two bytes, so the check above
+          // already guarantees enough buffered data to decide.
+          is_valid_ = false;
+          return false;
         }
         break;
       }

--- a/httplib.h
+++ b/httplib.h
@@ -8849,7 +8849,14 @@ public:
       switch (state_) {
       case 0: { // Initial boundary
         auto pos = buf_find(dash_boundary_crlf_);
-        if (pos == buf_size()) { return true; }
+        if (pos == buf_size()) {
+          // Not found yet: keep only a possible partial boundary at the tail so
+          // that a body which never contains the boundary cannot grow the
+          // buffer (and get rescanned from the start) without bound.
+          auto keep = dash_boundary_crlf_.size() - 1;
+          if (buf_size() > keep) { buf_erase(buf_size() - keep); }
+          return true;
+        }
         buf_erase(pos + dash_boundary_crlf_.size());
         state_ = 1;
         break;
@@ -8977,11 +8984,21 @@ public:
           if (buf_start_with(dash_)) {
             buf_erase(dash_.size());
             is_valid_ = true;
-            buf_erase(buf_size()); // Remove epilogue
+            state_ = 5;
           } else {
-            return true;
+            // Only CRLF (another part follows) and "--" (close-delimiter) are
+            // accepted after a boundary; RFC 2046 allows transport-padding in
+            // between, but this parser has never supported it. Either way the
+            // body is already destined to be rejected, so fail now instead of
+            // buffering the rest of it.
+            is_valid_ = false;
+            return false;
           }
         }
+        break;
+      }
+      case 5: { // Epilogue
+        buf_erase(buf_size());
         break;
       }
       }

--- a/httplib.h
+++ b/httplib.h
@@ -8843,6 +8843,11 @@ public:
   bool parse(const char *buf, size_t n, const FormDataHeader &header_callback,
              const ContentReceiver &content_callback) {
 
+    // Once the close delimiter has been seen the rest of the body is epilogue
+    // to be discarded (RFC 2046). Drop it without buffering so a large epilogue
+    // spread across reads is not copied in only to be erased right away.
+    if (state_ == 5) { return true; }
+
     buf_append(buf, n);
 
     while (buf_size() > 0) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -8865,9 +8865,13 @@ TEST(ZstdDecompressor, Decompress) {
 }
 #endif
 
-// Sends a raw request to a server listening at HOST:PORT.
-static bool send_request(time_t read_timeout_sec, const std::string &req,
-                         std::string *resp = nullptr, int port = PORT) {
+// Sends a raw request to a server listening at HOST:PORT, writing it in
+// separate chunks so that the server sees each part in its own read(). Used to
+// place a read boundary at a specific offset of a request body.
+static bool send_request_in_parts(time_t read_timeout_sec,
+                                  const std::vector<std::string> &parts,
+                                  std::string *resp = nullptr,
+                                  int port = PORT) {
   auto error = Error::Success;
 
   auto client_sock = detail::create_client_socket(
@@ -8881,9 +8885,15 @@ static bool send_request(time_t read_timeout_sec, const std::string &req,
   auto ret = detail::process_client_socket(
       client_sock, read_timeout_sec, 0, 0, 0, 0,
       std::chrono::steady_clock::time_point::min(), [&](Stream &strm) {
-        if (req.size() !=
-            static_cast<size_t>(strm.write(req.data(), req.size()))) {
-          return false;
+        for (size_t i = 0; i < parts.size(); i++) {
+          const auto &part = parts[i];
+          if (part.size() !=
+              static_cast<size_t>(strm.write(part.data(), part.size()))) {
+            return false;
+          }
+          if (i + 1 < parts.size()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          }
         }
 
         char buf[512];
@@ -8898,6 +8908,12 @@ static bool send_request(time_t read_timeout_sec, const std::string &req,
   detail::close_socket(client_sock);
 
   return ret;
+}
+
+// Sends a raw request to a server listening at HOST:PORT.
+static bool send_request(time_t read_timeout_sec, const std::string &req,
+                         std::string *resp = nullptr, int port = PORT) {
+  return send_request_in_parts(read_timeout_sec, {req}, resp, port);
 }
 
 TEST(ServerRequestParsingTest, TrimWhitespaceFromHeaderValues) {
@@ -15556,6 +15572,155 @@ TEST(RedirectTest, RedirectToUrlWithQueryParameters) {
   }
 }
 #endif
+
+TEST(MultipartFormDataTest, NoInitialBoundaryParsingIsNotQuadratic) {
+  // A body that never contains the declared boundary must not be accumulated
+  // while the parser waits for it. Buffering it would also make every read
+  // rescan everything seen so far, which is quadratic in the body size.
+  Server svr;
+  svr.Post("/post", [](const Request & /*req*/, Response &res) {
+    res.set_content("ok", "text/plain");
+  });
+
+  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+    ASSERT_FALSE(svr.is_running());
+  });
+
+  svr.wait_until_ready();
+
+  Client cli(HOST, PORT);
+  cli.set_read_timeout(60, 0);
+  cli.set_write_timeout(60, 0);
+
+  // '-' is the worst case: it matches the first character of the boundary, so
+  // every position has to be checked against it.
+  auto post_dashes = [&](size_t size) {
+    const std::string body(size, '-');
+    auto start = std::chrono::steady_clock::now();
+    auto res =
+        cli.Post("/post", body, "multipart/form-data; boundary=simpleboundary");
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  std::chrono::steady_clock::now() - start)
+                  .count();
+    EXPECT_TRUE(res) << "Error: " << to_string(res.error());
+    if (res) { EXPECT_EQ(StatusCode::BadRequest_400, res->status); }
+    return ms;
+  };
+
+  auto small = post_dashes(4u * 1024 * 1024);
+  auto large = post_dashes(16u * 1024 * 1024);
+
+  // Comparing the two sizes rather than checking an absolute duration keeps
+  // this meaningful across build types and CI load, both of which move the
+  // absolute numbers by more than an order of magnitude. Four times the bytes
+  // costs about four times the time when parsing is linear, and about sixteen
+  // times when the body is buffered and rescanned.
+  ASSERT_GT(small, 0) << "timer resolution too coarse to compare";
+  EXPECT_LT(large, small * 10)
+      << "4MB took " << small << "ms but 16MB took " << large
+      << "ms, which suggests the body is being buffered and rescanned";
+}
+
+TEST(MultipartFormDataTest, BoundaryNotFollowedByDelimiterFailsFast) {
+  // A boundary can only be followed by CRLF or by "--", so anything else is
+  // malformed no matter what comes next. The parser must say so right away
+  // instead of buffering the rest of the declared body.
+  Server svr;
+  svr.Post("/post", [](const Request & /*req*/, Response &res) {
+    res.set_content("ok", "text/plain");
+  });
+
+  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+    ASSERT_FALSE(svr.is_running());
+  });
+
+  svr.wait_until_ready();
+
+  // Announce a 1 MB body but send only the malformed prefix. A parser that
+  // buffers instead of failing would still be waiting for the remaining bytes.
+  const std::string body = "--zzzz\r\n"
+                           "Content-Disposition: form-data; name=\"text1\"\r\n"
+                           "\r\n"
+                           "text1"
+                           "\r\n--zzzzXX";
+
+  const std::string req = "POST /post HTTP/1.1\r\n"
+                          "Content-Type: multipart/form-data; boundary=zzzz\r\n"
+                          "Content-Length: 1048576\r\n"
+                          "\r\n" +
+                          body;
+
+  std::string response;
+  ASSERT_TRUE(send_request(3, req, &response));
+  ASSERT_GE(response.size(), 12u) << "no response before the read timeout";
+  EXPECT_EQ("400", response.substr(9, 3));
+}
+
+// Posts a multipart body split into two writes, so that the server sees the
+// split at whatever offset the caller chose, and expects the single "text1"
+// field to come through.
+static void expect_split_multipart_ok(const std::string &body1,
+                                      const std::string &body2) {
+  auto handled = false;
+
+  Server svr;
+  svr.Post("/post", [&](const Request &req, Response &) {
+    EXPECT_EQ(1u, req.form.fields.size());
+    EXPECT_EQ("text1", req.form.get_field("text1"));
+    handled = true;
+  });
+
+  thread t = thread([&] { svr.listen(HOST, PORT); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+    ASSERT_FALSE(svr.is_running());
+    ASSERT_TRUE(handled);
+  });
+
+  svr.wait_until_ready();
+
+  const std::string head =
+      "POST /post HTTP/1.1\r\n"
+      "Content-Type: multipart/form-data; boundary=zzzz\r\n"
+      "Content-Length: " +
+      std::to_string(body1.size() + body2.size()) + "\r\n\r\n";
+
+  std::string response;
+  ASSERT_TRUE(send_request_in_parts(3, {head + body1, body2}, &response));
+  ASSERT_GE(response.size(), 12u) << "no response before the read timeout";
+  EXPECT_EQ("200", response.substr(9, 3));
+}
+
+TEST(MultipartFormDataTest, EpilogueSplitAcrossReadsIsIgnored) {
+  // RFC 2046: everything after the close-delimiter is an epilogue and is to be
+  // ignored, including when it does not arrive in the same read as the
+  // close-delimiter itself.
+  expect_split_multipart_ok("--zzzz\r\n"
+                            "Content-Disposition: form-data; name=\"text1\"\r\n"
+                            "\r\n"
+                            "text1"
+                            "\r\n--zzzz--",
+                            "\r\nthis epilogue must be ignored\r\n");
+}
+
+TEST(MultipartFormDataTest, InitialBoundarySplitAfterLongPreamble) {
+  // The initial boundary may be preceded by a preamble of any length and may
+  // straddle a read boundary. Discarding data while waiting for it must not
+  // throw away a partial boundary sitting at the end of the buffer.
+  expect_split_multipart_ok(std::string(64u * 1024, 'p') + "--zz",
+                            "zz\r\n"
+                            "Content-Disposition: form-data; name=\"text1\"\r\n"
+                            "\r\n"
+                            "text1"
+                            "\r\n--zzzz--\r\n");
+}
 
 TEST(RedirectTest, RedirectToUrlWithPlusInQueryParameters) {
   Server svr;

--- a/test/test.cc
+++ b/test/test.cc
@@ -15389,17 +15389,19 @@ TEST(MultipartFormDataTest, NoInitialBoundaryParsingIsNotQuadratic) {
     return ms;
   };
 
-  auto small = post_dashes(4u * 1024 * 1024);
-  auto large = post_dashes(16u * 1024 * 1024);
+  // Not named `small`/`large`: <rpcndr.h> defines `small` as a macro on
+  // Windows.
+  auto ms_4mb = post_dashes(4u * 1024 * 1024);
+  auto ms_16mb = post_dashes(16u * 1024 * 1024);
 
   // Comparing the two sizes rather than checking an absolute duration keeps
   // this meaningful across build types and CI load, both of which move the
   // absolute numbers by more than an order of magnitude. Four times the bytes
   // costs about four times the time when parsing is linear, and about sixteen
   // times when the body is buffered and rescanned.
-  ASSERT_GT(small, 0) << "timer resolution too coarse to compare";
-  EXPECT_LT(large, small * 10)
-      << "4MB took " << small << "ms but 16MB took " << large
+  ASSERT_GT(ms_4mb, 0) << "timer resolution too coarse to compare";
+  EXPECT_LT(ms_16mb, ms_4mb * 10)
+      << "4MB took " << ms_4mb << "ms but 16MB took " << ms_16mb
       << "ms, which suggests the body is being buffered and rescanned";
 }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -15351,6 +15351,160 @@ TEST(MultipartFormDataTest, ExcessivePartHeaders) {
   EXPECT_EQ(StatusCode::BadRequest_400, res->status);
 }
 
+TEST(MultipartFormDataTest, NoInitialBoundaryParsingIsNotQuadratic) {
+  // A body that never contains the declared boundary must not be accumulated
+  // while the parser waits for it. Buffering it would also make every read
+  // rescan everything seen so far, which is quadratic in the body size.
+  Server svr;
+  svr.Post("/post", [](const Request & /*req*/, Response &res) {
+    res.set_content("ok", "text/plain");
+  });
+
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+    ASSERT_FALSE(svr.is_running());
+  });
+
+  svr.wait_until_ready();
+
+  Client cli(HOST, port);
+  cli.set_read_timeout(60, 0);
+  cli.set_write_timeout(60, 0);
+
+  // '-' is the worst case: it matches the first character of the boundary, so
+  // every position has to be checked against it.
+  auto post_dashes = [&](size_t size) {
+    const std::string body(size, '-');
+    auto start = std::chrono::steady_clock::now();
+    auto res =
+        cli.Post("/post", body, "multipart/form-data; boundary=simpleboundary");
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  std::chrono::steady_clock::now() - start)
+                  .count();
+    EXPECT_TRUE(res) << "Error: " << to_string(res.error());
+    if (res) { EXPECT_EQ(StatusCode::BadRequest_400, res->status); }
+    return ms;
+  };
+
+  auto small = post_dashes(4u * 1024 * 1024);
+  auto large = post_dashes(16u * 1024 * 1024);
+
+  // Comparing the two sizes rather than checking an absolute duration keeps
+  // this meaningful across build types and CI load, both of which move the
+  // absolute numbers by more than an order of magnitude. Four times the bytes
+  // costs about four times the time when parsing is linear, and about sixteen
+  // times when the body is buffered and rescanned.
+  ASSERT_GT(small, 0) << "timer resolution too coarse to compare";
+  EXPECT_LT(large, small * 10)
+      << "4MB took " << small << "ms but 16MB took " << large
+      << "ms, which suggests the body is being buffered and rescanned";
+}
+
+TEST(MultipartFormDataTest, BoundaryNotFollowedByDelimiterFailsFast) {
+  // A boundary can only be followed by CRLF or by "--", so anything else is
+  // malformed no matter what comes next. The parser must say so right away
+  // instead of buffering the rest of the declared body.
+  Server svr;
+  svr.Post("/post", [](const Request & /*req*/, Response &res) {
+    res.set_content("ok", "text/plain");
+  });
+
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+    ASSERT_FALSE(svr.is_running());
+  });
+
+  svr.wait_until_ready();
+
+  // Announce a 1 MB body but send only the malformed prefix. A parser that
+  // buffers instead of failing would still be waiting for the remaining bytes.
+  const std::string body = "--zzzz\r\n"
+                           "Content-Disposition: form-data; name=\"text1\"\r\n"
+                           "\r\n"
+                           "text1"
+                           "\r\n--zzzzXX";
+
+  const std::string req = "POST /post HTTP/1.1\r\n"
+                          "Content-Type: multipart/form-data; boundary=zzzz\r\n"
+                          "Content-Length: 1048576\r\n"
+                          "\r\n" +
+                          body;
+
+  std::string response;
+  ASSERT_TRUE(send_request(3, req, &response, port));
+  ASSERT_GE(response.size(), 12u) << "no response before the read timeout";
+  EXPECT_EQ("400", response.substr(9, 3));
+}
+
+// Posts a multipart body split into two writes, so that the server sees the
+// split at whatever offset the caller chose, and expects the single "text1"
+// field to come through.
+static void expect_split_multipart_ok(const std::string &body1,
+                                      const std::string &body2) {
+  auto handled = false;
+
+  Server svr;
+  svr.Post("/post", [&](const Request &req, Response &) {
+    EXPECT_EQ(1u, req.form.fields.size());
+    EXPECT_EQ("text1", req.form.get_field("text1"));
+    handled = true;
+  });
+
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+    ASSERT_FALSE(svr.is_running());
+    ASSERT_TRUE(handled);
+  });
+
+  svr.wait_until_ready();
+
+  // "Connection: close" makes the server close once it has answered, so the
+  // response drain ends immediately instead of idling until the read timeout.
+  const std::string head =
+      "POST /post HTTP/1.1\r\n"
+      "Content-Type: multipart/form-data; boundary=zzzz\r\n"
+      "Content-Length: " +
+      std::to_string(body1.size() + body2.size()) + "\r\n\r\n";
+
+  std::string response;
+  ASSERT_TRUE(send_request_in_parts(3, {head + body1, body2}, &response, port));
+  ASSERT_GE(response.size(), 12u) << "no response";
+  EXPECT_EQ("200", response.substr(9, 3));
+}
+
+TEST(MultipartFormDataTest, EpilogueSplitAcrossReadsIsIgnored) {
+  // RFC 2046: everything after the close-delimiter is an epilogue and is to be
+  // ignored, including when it does not arrive in the same read as the
+  // close-delimiter itself.
+  expect_split_multipart_ok("--zzzz\r\n"
+                            "Content-Disposition: form-data; name=\"text1\"\r\n"
+                            "\r\n"
+                            "text1"
+                            "\r\n--zzzz--",
+                            "\r\nthis epilogue must be ignored\r\n");
+}
+
+TEST(MultipartFormDataTest, InitialBoundarySplitAfterLongPreamble) {
+  // The initial boundary may be preceded by a preamble of any length and may
+  // straddle a read boundary. Discarding data while waiting for it must not
+  // throw away a partial boundary sitting at the end of the buffer.
+  expect_split_multipart_ok(std::string(64u * 1024, 'p') + "--zz",
+                            "zz\r\n"
+                            "Content-Disposition: form-data; name=\"text1\"\r\n"
+                            "\r\n"
+                            "text1"
+                            "\r\n--zzzz--\r\n");
+}
+
 TEST(MakeFileBodyTest, Basic) {
   const std::string file_content(4096, 'Z');
   const std::string tmp_path = "./httplib_test_make_file_body.bin";
@@ -15572,155 +15726,6 @@ TEST(RedirectTest, RedirectToUrlWithQueryParameters) {
   }
 }
 #endif
-
-TEST(MultipartFormDataTest, NoInitialBoundaryParsingIsNotQuadratic) {
-  // A body that never contains the declared boundary must not be accumulated
-  // while the parser waits for it. Buffering it would also make every read
-  // rescan everything seen so far, which is quadratic in the body size.
-  Server svr;
-  svr.Post("/post", [](const Request & /*req*/, Response &res) {
-    res.set_content("ok", "text/plain");
-  });
-
-  thread t = thread([&] { svr.listen(HOST, PORT); });
-  auto se = detail::scope_exit([&] {
-    svr.stop();
-    t.join();
-    ASSERT_FALSE(svr.is_running());
-  });
-
-  svr.wait_until_ready();
-
-  Client cli(HOST, PORT);
-  cli.set_read_timeout(60, 0);
-  cli.set_write_timeout(60, 0);
-
-  // '-' is the worst case: it matches the first character of the boundary, so
-  // every position has to be checked against it.
-  auto post_dashes = [&](size_t size) {
-    const std::string body(size, '-');
-    auto start = std::chrono::steady_clock::now();
-    auto res =
-        cli.Post("/post", body, "multipart/form-data; boundary=simpleboundary");
-    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                  std::chrono::steady_clock::now() - start)
-                  .count();
-    EXPECT_TRUE(res) << "Error: " << to_string(res.error());
-    if (res) { EXPECT_EQ(StatusCode::BadRequest_400, res->status); }
-    return ms;
-  };
-
-  auto small = post_dashes(4u * 1024 * 1024);
-  auto large = post_dashes(16u * 1024 * 1024);
-
-  // Comparing the two sizes rather than checking an absolute duration keeps
-  // this meaningful across build types and CI load, both of which move the
-  // absolute numbers by more than an order of magnitude. Four times the bytes
-  // costs about four times the time when parsing is linear, and about sixteen
-  // times when the body is buffered and rescanned.
-  ASSERT_GT(small, 0) << "timer resolution too coarse to compare";
-  EXPECT_LT(large, small * 10)
-      << "4MB took " << small << "ms but 16MB took " << large
-      << "ms, which suggests the body is being buffered and rescanned";
-}
-
-TEST(MultipartFormDataTest, BoundaryNotFollowedByDelimiterFailsFast) {
-  // A boundary can only be followed by CRLF or by "--", so anything else is
-  // malformed no matter what comes next. The parser must say so right away
-  // instead of buffering the rest of the declared body.
-  Server svr;
-  svr.Post("/post", [](const Request & /*req*/, Response &res) {
-    res.set_content("ok", "text/plain");
-  });
-
-  thread t = thread([&] { svr.listen(HOST, PORT); });
-  auto se = detail::scope_exit([&] {
-    svr.stop();
-    t.join();
-    ASSERT_FALSE(svr.is_running());
-  });
-
-  svr.wait_until_ready();
-
-  // Announce a 1 MB body but send only the malformed prefix. A parser that
-  // buffers instead of failing would still be waiting for the remaining bytes.
-  const std::string body = "--zzzz\r\n"
-                           "Content-Disposition: form-data; name=\"text1\"\r\n"
-                           "\r\n"
-                           "text1"
-                           "\r\n--zzzzXX";
-
-  const std::string req = "POST /post HTTP/1.1\r\n"
-                          "Content-Type: multipart/form-data; boundary=zzzz\r\n"
-                          "Content-Length: 1048576\r\n"
-                          "\r\n" +
-                          body;
-
-  std::string response;
-  ASSERT_TRUE(send_request(3, req, &response));
-  ASSERT_GE(response.size(), 12u) << "no response before the read timeout";
-  EXPECT_EQ("400", response.substr(9, 3));
-}
-
-// Posts a multipart body split into two writes, so that the server sees the
-// split at whatever offset the caller chose, and expects the single "text1"
-// field to come through.
-static void expect_split_multipart_ok(const std::string &body1,
-                                      const std::string &body2) {
-  auto handled = false;
-
-  Server svr;
-  svr.Post("/post", [&](const Request &req, Response &) {
-    EXPECT_EQ(1u, req.form.fields.size());
-    EXPECT_EQ("text1", req.form.get_field("text1"));
-    handled = true;
-  });
-
-  thread t = thread([&] { svr.listen(HOST, PORT); });
-  auto se = detail::scope_exit([&] {
-    svr.stop();
-    t.join();
-    ASSERT_FALSE(svr.is_running());
-    ASSERT_TRUE(handled);
-  });
-
-  svr.wait_until_ready();
-
-  const std::string head =
-      "POST /post HTTP/1.1\r\n"
-      "Content-Type: multipart/form-data; boundary=zzzz\r\n"
-      "Content-Length: " +
-      std::to_string(body1.size() + body2.size()) + "\r\n\r\n";
-
-  std::string response;
-  ASSERT_TRUE(send_request_in_parts(3, {head + body1, body2}, &response));
-  ASSERT_GE(response.size(), 12u) << "no response before the read timeout";
-  EXPECT_EQ("200", response.substr(9, 3));
-}
-
-TEST(MultipartFormDataTest, EpilogueSplitAcrossReadsIsIgnored) {
-  // RFC 2046: everything after the close-delimiter is an epilogue and is to be
-  // ignored, including when it does not arrive in the same read as the
-  // close-delimiter itself.
-  expect_split_multipart_ok("--zzzz\r\n"
-                            "Content-Disposition: form-data; name=\"text1\"\r\n"
-                            "\r\n"
-                            "text1"
-                            "\r\n--zzzz--",
-                            "\r\nthis epilogue must be ignored\r\n");
-}
-
-TEST(MultipartFormDataTest, InitialBoundarySplitAfterLongPreamble) {
-  // The initial boundary may be preceded by a preamble of any length and may
-  // straddle a read boundary. Discarding data while waiting for it must not
-  // throw away a partial boundary sitting at the end of the buffer.
-  expect_split_multipart_ok(std::string(64u * 1024, 'p') + "--zz",
-                            "zz\r\n"
-                            "Content-Disposition: form-data; name=\"text1\"\r\n"
-                            "\r\n"
-                            "text1"
-                            "\r\n--zzzz--\r\n");
-}
 
 TEST(RedirectTest, RedirectToUrlWithPlusInQueryParameters) {
   Server svr;


### PR DESCRIPTION
## Problem

`FormDataParser` buffered the entire request body whenever the declared multipart boundary never appeared in it. State 0 returned without erasing anything, so the buffer grew to the full payload (100 MB by default) and `buf_find` rescanned all of it on every read. The cost grew with the square of the body size, so a single unauthenticated request could pin a core for a long time, and the buffer pinned the body in memory for the whole request. The parser runs for any multipart request even when the handler never looks at the parsed result.

State 4 buffered without bound in the same way when a boundary was followed by neither CRLF nor `--`.

This was introduced in v0.23.0 by de5a255 (#2159), which replaced the erase that had kept the buffer in check.

## Fix

- State 0 now keeps only the last `dash_boundary_crlf_.size() - 1` bytes while it waits. That bounds both the memory and the rescan without capping how long a preamble may be, and a boundary split across reads still parses (which is what #2159 gave up this erase for).
- State 4 now fails right away when a boundary is followed by neither CRLF nor `--`, since no further data can make such a body valid.
- The state 4 change is only safe because the close-delimiter branch now moves to a new state 5 that discards the epilogue. It used to stay in state 4, so an epilogue arriving in a later read fell into the same branch, and an epilogue beginning with CRLF was parsed as a new part and rejected with 400. State 5 fixes that as well.
- `parse()` returns early in state 5 so a large epilogue spread across several reads is dropped without being copied in only to be erased.

Split delimiters (CRLF or `--` arriving one byte at a time) are still handled: the length guards make the parser wait until two bytes are buffered before it decides.

## Tests

Four new tests in `test/test.cc`:

- `NoInitialBoundaryParsingIsNotQuadratic`: posts 4 MB and 16 MB bodies that never contain the boundary and checks the time stays roughly linear in the size rather than quadratic.
- `BoundaryNotFollowedByDelimiterFailsFast`: announces a 1 MB body but sends only a malformed prefix, and expects an immediate 400 instead of the parser waiting for the rest.
- `EpilogueSplitAcrossReadsIsIgnored`: sends the epilogue in a separate read from the close-delimiter and expects 200.
- `InitialBoundarySplitAfterLongPreamble`: places a 64 KB preamble and splits the initial boundary across reads, to confirm the trim does not drop a partial boundary sitting at the end of the buffer.

Verified with the OpenSSL, no-TLS, and split (`httplib.cc`) builds.