### PR TITLE
Stop a throwing user callback from terminating the server

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -14076,15 +14076,39 @@ inline bool Server::process_and_close_socket(socket_t sock) {
   detail::get_local_ip_and_port(sock, local_addr, local_port);
 
   bool websocket_upgraded = false;
-  auto ret = detail::process_server_socket(
-      svr_sock_, sock, keep_alive_max_count_, keep_alive_timeout_sec_,
-      read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-      write_timeout_usec_,
-      [&](Stream &strm, bool close_connection, bool &connection_closed) {
-        return process_request(strm, remote_addr, remote_port, local_addr,
-                               local_port, close_connection, connection_closed,
-                               nullptr, &websocket_upgraded);
-      });
+  auto serve = [&]() {
+    return detail::process_server_socket(
+        svr_sock_, sock, keep_alive_max_count_, keep_alive_timeout_sec_,
+        read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
+        write_timeout_usec_,
+        [&](Stream &strm, bool close_connection, bool &connection_closed) {
+          return process_request(strm, remote_addr, remote_port, local_addr,
+                                 local_port, close_connection,
+                                 connection_closed, nullptr,
+                                 &websocket_upgraded);
+        });
+  };
+
+#ifdef CPPHTTPLIB_NO_EXCEPTIONS
+  auto ret = serve();
+#else
+  auto ret = false;
+  try {
+    ret = serve();
+  } catch (...) {
+    // process_request() runs only routing() inside its own try/catch. The
+    // content provider, the post-routing / logger / error / expect-100
+    // handlers and a WebSocket handler all run outside it, so an exception
+    // from any of those reaches here. Without this it would unwind into the
+    // task queue - which does not catch - and terminate the whole server.
+    //
+    // It is not turned into a 500: by the time a content provider runs, the
+    // status line and headers are already on the wire. Report it and drop the
+    // connection, which is what the peer sees anyway.
+    ret = false;
+    output_error_log(Error::Unknown, nullptr);
+  }
+#endif
 
   detail::drain_and_close_socket(sock);
   return ret;
@@ -17466,16 +17490,33 @@ inline bool SSLServer::process_and_close_socket(socket_t sock) {
   int local_port = 0;
   detail::get_local_ip_and_port(sock, local_addr, local_port);
 
-  ret = detail::process_server_socket_ssl(
-      svr_sock_, session, sock, keep_alive_max_count_, keep_alive_timeout_sec_,
-      read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-      write_timeout_usec_,
-      [&](Stream &strm, bool close_connection, bool &connection_closed) {
-        return process_request(
-            strm, remote_addr, remote_port, local_addr, local_port,
-            close_connection, connection_closed,
-            [&](Request &req) { req.ssl = session; }, &websocket_upgraded);
-      });
+  auto serve = [&]() {
+    return detail::process_server_socket_ssl(
+        svr_sock_, session, sock, keep_alive_max_count_,
+        keep_alive_timeout_sec_, read_timeout_sec_, read_timeout_usec_,
+        write_timeout_sec_, write_timeout_usec_,
+        [&](Stream &strm, bool close_connection, bool &connection_closed) {
+          return process_request(
+              strm, remote_addr, remote_port, local_addr, local_port,
+              close_connection, connection_closed,
+              [&](Request &req) { req.ssl = session; }, &websocket_upgraded);
+        });
+  };
+
+  // Same guard as Server::process_and_close_socket(); see the comment there.
+  // The scope_exit above already frees the session and closes the socket while
+  // unwinding, but the exception itself still has to be stopped before it
+  // reaches the task queue.
+#ifdef CPPHTTPLIB_NO_EXCEPTIONS
+  ret = serve();
+#else
+  try {
+    ret = serve();
+  } catch (...) {
+    ret = false;
+    output_error_log(Error::Unknown, nullptr);
+  }
+#endif
 
   return ret;
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -1073,6 +1073,94 @@ TEST(ParseAcceptHeaderTest, ContentTypesPopulatedAndInvalidHeaderHandling) {
   }
 }
 
+TEST(ServerExceptionTest, ThrowingContentProviderDoesNotStopTheServer) {
+  Server svr;
+
+  // A content provider runs after process_request()'s try/catch has ended, so
+  // before this was guarded the exception unwound into the task queue and
+  // terminated the whole process - taking every other connection with it.
+  svr.Get("/throws", [](const Request & /*req*/, Response &res) {
+    res.set_content_provider(
+        1024, "text/plain",
+        [](size_t /*offset*/, size_t /*length*/, DataSink & /*sink*/) -> bool {
+          throw std::runtime_error("content provider failed");
+        });
+  });
+
+  svr.Get("/ok", [](const Request & /*req*/, Response &res) {
+    res.set_content("still here", "text/plain");
+  });
+
+  auto port = svr.bind_to_any_port(HOST);
+  std::thread t([&]() { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+  });
+
+  svr.wait_until_ready();
+
+  {
+    Client cli(HOST, port);
+    cli.set_connection_timeout(std::chrono::seconds(5));
+    // The response is already committed to the wire when the provider throws,
+    // so the connection is simply dropped rather than turned into a 500.
+    auto res = cli.Get("/throws");
+    EXPECT_FALSE(res);
+  }
+
+  // The point of the test: the server survived and still serves.
+  {
+    Client cli(HOST, port);
+    cli.set_connection_timeout(std::chrono::seconds(5));
+    auto res = cli.Get("/ok");
+    ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+    EXPECT_EQ(StatusCode::OK_200, res->status);
+    EXPECT_EQ("still here", res->body);
+  }
+
+  EXPECT_TRUE(svr.is_running());
+}
+
+TEST(ServerExceptionTest, ThrowingPostRoutingHandlerDoesNotStopTheServer) {
+  Server svr;
+
+  svr.Get("/", [](const Request & /*req*/, Response &res) {
+    res.set_content("body", "text/plain");
+  });
+
+  std::atomic<int> calls{0};
+  svr.set_post_routing_handler([&](const Request & /*req*/, Response & /*res*/) {
+    if (++calls == 1) { throw std::runtime_error("post-routing failed"); }
+  });
+
+  auto port = svr.bind_to_any_port(HOST);
+  std::thread t([&]() { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+  });
+
+  svr.wait_until_ready();
+
+  {
+    Client cli(HOST, port);
+    cli.set_connection_timeout(std::chrono::seconds(5));
+    auto res = cli.Get("/");
+    EXPECT_FALSE(res);
+  }
+
+  {
+    Client cli(HOST, port);
+    cli.set_connection_timeout(std::chrono::seconds(5));
+    auto res = cli.Get("/");
+    ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+    EXPECT_EQ(StatusCode::OK_200, res->status);
+  }
+
+  EXPECT_TRUE(svr.is_running());
+}
+
 TEST(ServerStartHandlerTest, CalledOnceWhenReady) {
   Server svr;
   svr.Get("/", [](const Request & /*req*/, Response &res) {


### PR DESCRIPTION
Server::process_request() wraps only routing() in a try/catch. Everything else a user supplies runs outside it:

- the content provider, from write_response_core()
- post_routing_handler_, error_handler_, logger_
- expect_100_continue_handler_
- a WebSocket handler, and pre_routing_handler_ on the upgrade path

An exception from any of those unwinds out of process_and_close_socket() into the task queue, which calls the job without a catch, so it reaches the top of a pool thread and terminates the process. One handler that throws takes down every other connection the server is holding.

Non-SSL also leaked the descriptor: drain_and_close_socket() sat after the call rather than in a scope guard, so unwinding skipped it. SSLServer already frees its session and socket through scope_exit, but the exception still escaped.

Catch at the top of both process_and_close_socket() overloads. The exception is not turned into a 500: by the time a content provider runs the status line and headers are already on the wire, so there is nothing left to replace. Report it through the error logger and drop the connection, which is what the peer observes regardless. Requests on other connections are unaffected, and the socket is still drained and closed.

Adds ServerExceptionTest for a throwing content provider and a throwing post-routing handler, each checking that a later request on a new connection still succeeds. Note both abort the test binary without this change - which is the bug, but it means a regression here fails the run rather than one test.