### PR TITLE
Do not let a zero-length write end a chunked body

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8405,8 +8405,15 @@ write_content_chunked(Stream &strm, const ContentProvider &content_provider,
   DataSink data_sink;
 
   data_sink.write = [&](const char *d, size_t l) -> bool {
+    // Writing nothing is not a way to end the body. A zero-length chunk is
+    // the terminator in chunked coding, so it must never be emitted in the
+    // middle of one, and only done()/done_with_trailer() may finish the
+    // message. Treating it as "no more data" (data_available = l > 0) ended
+    // the loop with the terminating chunk still unwritten, and this function
+    // then reported success for a body the peer can never see the end of.
+    if (l == 0) { return ok; }
+
     if (ok) {
-      data_available = l > 0;
       offset += l;
 
       std::string payload;

--- a/test/test.cc
+++ b/test/test.cc
@@ -1934,6 +1934,75 @@ TEST(ParseAcceptEncoding8, AcceptEncodingQValuePriority) {
 #endif
 }
 
+TEST(WriteContentChunkedTest, ZeroLengthWriteDoesNotEndTheBody) {
+  detail::BufferStream strm;
+  detail::nocompressor compressor;
+  auto error = Error::Success;
+  auto step = 0;
+
+  // A provider that happens to have nothing to hand over on one pass - an
+  // empty buffer popped off a queue, say - must not be taken to mean the body
+  // is finished. Before this was fixed the write below ended the loop with the
+  // terminating chunk unwritten, and the function still reported success.
+  auto ret = detail::write_content_chunked(
+      strm,
+      [&](size_t /*offset*/, size_t /*length*/, DataSink &sink) {
+        switch (step++) {
+        case 0: sink.write("", 0); break;
+        case 1: sink.write("hello", 5); break;
+        default: sink.done(); break;
+        }
+        return true;
+      },
+      []() { return false; }, compressor, error);
+
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(Error::Success, error);
+  EXPECT_EQ("5\r\nhello\r\n0\r\n\r\n", strm.get_buffer());
+}
+
+TEST(WriteContentChunkedTest, DoneWithNoDataWritesOnlyTheTerminator) {
+  detail::BufferStream strm;
+  detail::nocompressor compressor;
+  auto error = Error::Success;
+
+  auto ret = detail::write_content_chunked(
+      strm,
+      [](size_t /*offset*/, size_t /*length*/, DataSink &sink) {
+        sink.done();
+        return true;
+      },
+      []() { return false; }, compressor, error);
+
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(Error::Success, error);
+  EXPECT_EQ("0\r\n\r\n", strm.get_buffer());
+}
+
+TEST(WriteContentChunkedTest, TrailersFollowTheTerminatingChunk) {
+  detail::BufferStream strm;
+  detail::nocompressor compressor;
+  auto error = Error::Success;
+  auto sent = false;
+
+  auto ret = detail::write_content_chunked(
+      strm,
+      [&](size_t /*offset*/, size_t /*length*/, DataSink &sink) {
+        if (!sent) {
+          sent = true;
+          sink.write("data", 4);
+        } else {
+          sink.done_with_trailer({{"X-Checksum", "abc"}});
+        }
+        return true;
+      },
+      []() { return false; }, compressor, error);
+
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(Error::Success, error);
+  EXPECT_EQ("4\r\ndata\r\n0\r\nX-Checksum: abc\r\n\r\n", strm.get_buffer());
+}
+
 TEST(BufferStreamTest, read) {
   detail::BufferStream strm1;
   Stream &strm = strm1;


### PR DESCRIPTION
write_content_chunked()'s sink treated "the provider wrote nothing" as "the provider has finished":

    data_available = l > 0;

so sink.write(p, 0) ended the loop. Only done()/done_with_trailer() emit the terminating 0-length chunk, so the body was left unterminated - and the function still returned Success, because the post-loop check only reports the is_shutting_down() case. The peer waits for a last chunk that never arrives until it times out, and on a keep-alive connection anything written next is parsed as a chunk-size line.

A provider reaching a pass with nothing to hand over is ordinary: popping an empty buffer off a queue, or a compressor that has consumed its input without producing output yet. It is not the end of the message.

Ignore zero-length writes instead. A zero-length chunk is the terminator in chunked coding, so it must never be emitted mid-body either way, and data_available is now controlled only by done()/done_with_trailer(). This matches write_content_without_length(), where the sink's write never ends the body.

Adds WriteContentChunkedTest covering the zero-length write, done() with no data at all, and trailers after the terminating chunk. The first fails without this change: the stream comes out empty while the call still reports success.