### PR TITLE
Cap the received multipart boundary at RFC 2046's 70 characters

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8659,7 +8659,11 @@ inline bool parse_multipart_boundary(const std::string &content_type,
   auto it = params.find("boundary");
   if (it == params.end()) { return false; }
   boundary = it->second;
-  return !boundary.empty();
+  // RFC 2046 5.1.1 caps a boundary at 70 characters. The parser scans the body
+  // for "--" + boundary, so a body crafted to repeat that delimiter's leading
+  // bytes costs a nearly full comparison at nearly every position: the
+  // boundary's length multiplies the worst-case cost of scanning a body.
+  return !boundary.empty() && boundary.size() <= 70;
 }
 
 inline void parse_disposition_params(const std::string &s, Params &params) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -1510,6 +1510,37 @@ TEST(ParseMultipartBoundaryTest, ValueWithQuotesAndCharset) {
   EXPECT_EQ(boundary, "cpp-httplib-multipart-data");
 }
 
+TEST(ParseMultipartBoundaryTest, LongestAllowedValue) {
+  const string boundary(70, 'a');
+  string content_type = "multipart/form-data; boundary=" + boundary;
+  string parsed;
+  auto ret = detail::parse_multipart_boundary(content_type, parsed);
+  EXPECT_TRUE(ret);
+  EXPECT_EQ(parsed, boundary);
+}
+
+TEST(ParseMultipartBoundaryTest, ValueLongerThanRFCLimit) {
+  // RFC 2046 5.1.1 caps a boundary at 70 characters.
+  string content_type = "multipart/form-data; boundary=" + string(71, 'a');
+  string parsed;
+  auto ret = detail::parse_multipart_boundary(content_type, parsed);
+  EXPECT_FALSE(ret);
+}
+
+TEST(ParseMultipartBoundaryTest, QuotedValueIsMeasuredAfterUnquoting) {
+  // The limit applies to the unquoted value, so a quoted 70 character boundary
+  // is 72 characters on the wire and still valid.
+  const string boundary(70, 'a');
+  string content_type = "multipart/form-data; boundary=\"" + boundary + "\"";
+  string parsed;
+  EXPECT_TRUE(detail::parse_multipart_boundary(content_type, parsed));
+  EXPECT_EQ(parsed, boundary);
+
+  content_type = "multipart/form-data; boundary=\"" + string(71, 'a') + "\"";
+  parsed.clear();
+  EXPECT_FALSE(detail::parse_multipart_boundary(content_type, parsed));
+}
+
 TEST(GetHeaderValueTest, DefaultValue) {
   Headers headers = {{"Dummy", "Dummy"}};
   auto val = detail::get_header_value(headers, "Content-Type", "text/plain", 0);
@@ -15505,6 +15536,54 @@ TEST(MultipartFormDataTest, InitialBoundarySplitAfterLongPreamble) {
                             "\r\n"
                             "text1"
                             "\r\n--zzzz--\r\n");
+}
+
+TEST(MultipartFormDataTest, BoundaryLengthLimitIsEnforced) {
+  // The received boundary was only checked for being non-empty, so it could be
+  // as long as a header is allowed to be. The parser scans the body for
+  // "--" + boundary, so a body crafted to repeat that delimiter's leading bytes
+  // costs a nearly full comparison at nearly every position, making the
+  // boundary's length a multiplier on the worst-case parsing cost. RFC 2046
+  // 5.1.1 caps a boundary at 70 characters; honoring that caps the multiplier.
+  Server svr;
+  svr.Post("/post", [](const Request &req, Response &res) {
+    EXPECT_EQ(1u, req.form.fields.size());
+    EXPECT_EQ("text1", req.form.get_field("text1"));
+    res.set_content("ok", "text/plain");
+  });
+
+  auto port = svr.bind_to_any_port(HOST);
+  thread t = thread([&] { svr.listen_after_bind(); });
+  auto se = detail::scope_exit([&] {
+    svr.stop();
+    t.join();
+    ASSERT_FALSE(svr.is_running());
+  });
+
+  svr.wait_until_ready();
+
+  Client cli(HOST, port);
+
+  auto post_with_boundary_of_length = [&](size_t len) {
+    const std::string boundary(len, 'a');
+    const std::string body =
+        "--" + boundary +
+        "\r\n"
+        "Content-Disposition: form-data; name=\"text1\"\r\n"
+        "\r\n"
+        "text1"
+        "\r\n--" +
+        boundary + "--\r\n";
+    return cli.Post("/post", body, "multipart/form-data; boundary=" + boundary);
+  };
+
+  auto res = post_with_boundary_of_length(70);
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+
+  res = post_with_boundary_of_length(71);
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::BadRequest_400, res->status);
 }
 
 TEST(MakeFileBodyTest, Basic) {


### PR DESCRIPTION
Follow-up to #2557, which bounded the multipart parser against the *body* length. This one bounds the other factor: the boundary length.

## The problem

`parse_multipart_boundary()` only rejected an empty boundary. The received boundary was never checked for length, so it could be as long as a header line is allowed to be. Probing a stock server:

| boundary length | status (before) | status (after) |
|---|---|---|
| 70 B | 200 | 200 |
| 71 B | 200 | 400 |
| 1024 B | 200 | 400 |
| 8146 B | 200 | 400 |
| 8147 B | 400 | 400 |

8146 is what `CPPHTTPLIB_HEADER_MAX_LENGTH` (8192) leaves after `Content-Type: multipart/form-data; boundary=` and the CRLF.

`FormDataParser` searches the body for the delimiter `"--" + boundary + CRLF`, built in `set_boundary()`. `buf_find()` scans for that delimiter's first byte, which is always `'-'`, and at every position that matches calls `start_with()`:

```cpp
size_t buf_find(const std::string &s) const {
  auto c = s.front();          // always '-' for dash_boundary_crlf_
  size_t off = buf_spos_;
  while (off < buf_epos_) {
    auto pos = off;
    while (true) {
      if (pos == buf_epos_) { return buf_size(); }
      if (buf_[pos] == c) { break; }
      pos++;
    }
    ...
    if (start_with(buf_, pos, buf_epos_, s)) { return pos - buf_spos_; }
    off = pos + 1;
  }
  return buf_size();
}
```

`start_with()` compares until the first mismatch, so the cost per candidate position depends on how far the body agrees with the delimiter. A body of `'-'` makes every position a candidate, and a boundary of `'-'` makes each candidate compare the whole delimiter before failing at the CRLF. The worst case is the product of the body length and the boundary length, and only the first factor was bounded.

## Measurement

The parser was driven directly, fed in `CPPHTTPLIB_RECV_BUFSIZ` (16 KB) reads, exactly as `Server::read_content_core()` feeds it. Body and boundary are both all `'-'`, which is the worst case above. Built with Apple clang 17.0.0 (arm64) at `-std=c++11 -O2 -DNDEBUG`, three trials each, on an otherwise idle machine; the numbers below are the minimum of the three (spread was under 1%).

100 MB body, which is the default `CPPHTTPLIB_PAYLOAD_MAX_LENGTH`:

| boundary | CPU time | vs 70 B |
|---|---|---|
| 70 B | 2.587 s | 1.0x |
| 8147 B | 281.832 s | 109x |

8 MB body, to show the shape:

| boundary | CPU time | vs 70 B |
|---|---|---|
| 70 B | 0.211 s | 1.0x |
| 1024 B | 3.081 s | 14.6x |
| 4096 B | 11.359 s | 53.8x |
| 8147 B | 22.091 s | 104.7x |

Cost tracks boundary length almost exactly: 116x the boundary gives 105x the time. One unauthenticated request could buy about 4.7 minutes of a core, and the parser runs for any multipart request whether or not the handler ever looks at the result.

## The fix

RFC 2046 5.1.1 caps a boundary at 70 characters, so honoring that limit bounds the multiplier as well:

```cpp
return !boundary.empty() && boundary.size() <= 70;
```

The check sits after `extract_media_type()`, so it applies to the value after unquoting and trimming: a quoted 70 character boundary (72 bytes on the wire) stays valid, and neither surrounding whitespace nor a duplicate `boundary=` parameter gets past it.

`parse_multipart_boundary()` has exactly one caller, `Server::read_content_core()`, so nothing on the client side changes. Boundaries the library generates itself are 45 characters, well inside the limit. A request declaring a longer boundary gets a 400 before any body byte is read.

## Tests

- `ParseMultipartBoundaryTest.LongestAllowedValue`, `.ValueLongerThanRFCLimit` and `.QuotedValueIsMeasuredAfterUnquoting` cover the parser function itself, and run in every build configuration.
- `MultipartFormDataTest.BoundaryLengthLimitIsEnforced` posts a well-formed multipart body with a 70 character boundary (200) and then a 71 character one (400), end to end through a server.

Verified locally: OpenSSL 848/848, no-TLS 706/706, MbedTLS 843/843, split build, and split build with `-fno-exceptions -DCPPHTTPLIB_NO_EXCEPTIONS`.
