### PR TITLE
Fail make_file_body()'s provider when the file is short

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1523,7 +1523,14 @@ make_file_body(const std::string &filepath) {
       auto to_read = (std::min)(sizeof(buf), length);
       f.read(buf, static_cast<std::streamsize>(to_read));
       auto n = static_cast<size_t>(f.gcount());
-      if (n == 0) { break; }
+      // Out of file with bytes still owed. make_file_body() measured the file
+      // once and that length is already the response's Content-Length, so the
+      // file has been rewritten or truncated since and the body cannot be
+      // completed. Reporting success returned without advancing the caller's
+      // offset, so write_content_with_progress() called this provider again
+      // straight away, got nothing again, and kept going. Fail the way every
+      // other error here does.
+      if (n == 0) { return false; }
       if (!sink.write(buf, n)) { return false; }
       length -= n;
     }

--- a/httplib.h
+++ b/httplib.h
@@ -1523,13 +1523,9 @@ make_file_body(const std::string &filepath) {
       auto to_read = (std::min)(sizeof(buf), length);
       f.read(buf, static_cast<std::streamsize>(to_read));
       auto n = static_cast<size_t>(f.gcount());
-      // Out of file with bytes still owed. make_file_body() measured the file
-      // once and that length is already the response's Content-Length, so the
-      // file has been rewritten or truncated since and the body cannot be
-      // completed. Reporting success returned without advancing the caller's
-      // offset, so write_content_with_progress() called this provider again
-      // straight away, got nothing again, and kept going. Fail the way every
-      // other error here does.
+      // The file is shorter than the size make_file_body() measured, which the
+      // caller has already committed to as Content-Length. The body cannot be
+      // completed, so fail as every other error here does.
       if (n == 0) { return false; }
       if (!sink.write(buf, n)) { return false; }
       length -= n;

--- a/test/test.cc
+++ b/test/test.cc
@@ -474,66 +474,6 @@ TEST(DecodeQueryTest, RejectsNonHexEscapes) {
   EXPECT_EQ("A", decode_query_component("%41", false));
 }
 
-TEST(MakeFileBodyTest, TruncatedFileMakesTheProviderFail) {
-  const std::string path = "./httplib_test_make_file_body_truncated.bin";
-  {
-    std::ofstream ofs(path, std::ios::binary);
-    const std::string content(100, 'A');
-    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
-  }
-  auto cleanup = detail::scope_exit([&] { std::remove(path.c_str()); });
-
-  auto body = make_file_body(path);
-  ASSERT_EQ(100u, body.first);
-  ASSERT_TRUE(static_cast<bool>(body.second));
-
-  // Rewritten shorter after its length was measured - and, on a server, after
-  // that length has already gone out as Content-Length.
-  {
-    std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
-    const std::string content(10, 'A');
-    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
-  }
-
-  std::string written;
-  DataSink sink;
-  sink.write = [&](const char *d, size_t l) {
-    written.append(d, l);
-    return true;
-  };
-
-  // The provider has to report failure. write_content_with_progress() advances
-  // its offset only by what was written, so a provider that returns true
-  // without completing the length it promised is called again straight away,
-  // and again.
-  EXPECT_FALSE(body.second(0, body.first, sink));
-  EXPECT_EQ(std::string(10, 'A'), written);
-}
-
-TEST(MakeFileBodyTest, WholeFileIsSent) {
-  const std::string path = "./httplib_test_make_file_body_whole.bin";
-  const std::string content(9000, 'Z'); // spans more than one 8 KiB read
-  {
-    std::ofstream ofs(path, std::ios::binary);
-    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
-  }
-  auto cleanup = detail::scope_exit([&] { std::remove(path.c_str()); });
-
-  auto body = make_file_body(path);
-  ASSERT_EQ(content.size(), body.first);
-  ASSERT_TRUE(static_cast<bool>(body.second));
-
-  std::string written;
-  DataSink sink;
-  sink.write = [&](const char *d, size_t l) {
-    written.append(d, l);
-    return true;
-  };
-
-  EXPECT_TRUE(body.second(0, body.first, sink));
-  EXPECT_EQ(content, written);
-}
-
 TEST(SanitizeFilenameTest, VariousPatterns) {
   // Path traversal
   EXPECT_EQ("passwd", httplib::sanitize_filename("../../../etc/passwd"));
@@ -16176,6 +16116,66 @@ TEST(MakeFileBodyTest, Basic) {
       cli.Post("/upload", fb.first, fb.second, "application/octet-stream");
   ASSERT_TRUE(res) << "Error: " << to_string(res.error());
   EXPECT_EQ(StatusCode::OK_200, res->status);
+}
+
+TEST(MakeFileBodyTest, TruncatedFileMakesTheProviderFail) {
+  const std::string path = "./httplib_test_make_file_body_truncated.bin";
+  {
+    std::ofstream ofs(path, std::ios::binary);
+    const std::string content(100, 'A');
+    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
+  }
+  auto cleanup = detail::scope_exit([&] { std::remove(path.c_str()); });
+
+  auto body = make_file_body(path);
+  ASSERT_EQ(100u, body.first);
+  ASSERT_TRUE(static_cast<bool>(body.second));
+
+  // Rewritten shorter after its length was measured - and, on a server, after
+  // that length has already gone out as Content-Length.
+  {
+    std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
+    const std::string content(10, 'A');
+    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
+  }
+
+  std::string written;
+  DataSink sink;
+  sink.write = [&](const char *d, size_t l) {
+    written.append(d, l);
+    return true;
+  };
+
+  // The provider has to report failure. write_content_with_progress() advances
+  // its offset only by what was written, so a provider that returns true
+  // without completing the length it promised is called again straight away,
+  // and again.
+  EXPECT_FALSE(body.second(0, body.first, sink));
+  EXPECT_EQ(std::string(10, 'A'), written);
+}
+
+TEST(MakeFileBodyTest, WholeFileIsSent) {
+  const std::string path = "./httplib_test_make_file_body_whole.bin";
+  const std::string content(9000, 'Z'); // spans more than one 8 KiB read
+  {
+    std::ofstream ofs(path, std::ios::binary);
+    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
+  }
+  auto cleanup = detail::scope_exit([&] { std::remove(path.c_str()); });
+
+  auto body = make_file_body(path);
+  ASSERT_EQ(content.size(), body.first);
+  ASSERT_TRUE(static_cast<bool>(body.second));
+
+  std::string written;
+  DataSink sink;
+  sink.write = [&](const char *d, size_t l) {
+    written.append(d, l);
+    return true;
+  };
+
+  EXPECT_TRUE(body.second(0, body.first, sink));
+  EXPECT_EQ(content, written);
 }
 
 TEST(TaskQueueTest, IncreaseAtomicInteger) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -474,6 +474,66 @@ TEST(DecodeQueryTest, RejectsNonHexEscapes) {
   EXPECT_EQ("A", decode_query_component("%41", false));
 }
 
+TEST(MakeFileBodyTest, TruncatedFileMakesTheProviderFail) {
+  const std::string path = "./httplib_test_make_file_body_truncated.bin";
+  {
+    std::ofstream ofs(path, std::ios::binary);
+    const std::string content(100, 'A');
+    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
+  }
+  auto cleanup = detail::scope_exit([&] { std::remove(path.c_str()); });
+
+  auto body = make_file_body(path);
+  ASSERT_EQ(100u, body.first);
+  ASSERT_TRUE(static_cast<bool>(body.second));
+
+  // Rewritten shorter after its length was measured - and, on a server, after
+  // that length has already gone out as Content-Length.
+  {
+    std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
+    const std::string content(10, 'A');
+    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
+  }
+
+  std::string written;
+  DataSink sink;
+  sink.write = [&](const char *d, size_t l) {
+    written.append(d, l);
+    return true;
+  };
+
+  // The provider has to report failure. write_content_with_progress() advances
+  // its offset only by what was written, so a provider that returns true
+  // without completing the length it promised is called again straight away,
+  // and again.
+  EXPECT_FALSE(body.second(0, body.first, sink));
+  EXPECT_EQ(std::string(10, 'A'), written);
+}
+
+TEST(MakeFileBodyTest, WholeFileIsSent) {
+  const std::string path = "./httplib_test_make_file_body_whole.bin";
+  const std::string content(9000, 'Z'); // spans more than one 8 KiB read
+  {
+    std::ofstream ofs(path, std::ios::binary);
+    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
+  }
+  auto cleanup = detail::scope_exit([&] { std::remove(path.c_str()); });
+
+  auto body = make_file_body(path);
+  ASSERT_EQ(content.size(), body.first);
+  ASSERT_TRUE(static_cast<bool>(body.second));
+
+  std::string written;
+  DataSink sink;
+  sink.write = [&](const char *d, size_t l) {
+    written.append(d, l);
+    return true;
+  };
+
+  EXPECT_TRUE(body.second(0, body.first, sink));
+  EXPECT_EQ(content, written);
+}
+
 TEST(SanitizeFilenameTest, VariousPatterns) {
   // Path traversal
   EXPECT_EQ("passwd", httplib::sanitize_filename("../../../etc/passwd"));


### PR DESCRIPTION
make_file_body() measures the file once and returns that length, which on a server is already the response's Content-Length before a byte is read. The provider re-opens the file by path on each call, so if the file has been rewritten or truncated since, the read comes up empty:

    if (n == 0) { break; }
    ...
    return true;

Reporting success without writing leaves the caller's offset where it was, so write_content_with_progress() calls the provider again on the next pass, gets nothing again, and keeps going - a thread spinning on open/seek/read/close until the peer gives up. The file is opened shared, so nothing prevents a writer truncating it mid-transfer.

Return false instead, which is what every other failure in this provider already does: a bad path, a failed seek, a rejected write.

Adds two cases to MakeFileBodyTest, one truncating the file after make_file_body() has measured it and one sending a whole multi-read file unchanged. They drive the returned ContentProvider directly with a DataSink rather than going through write_content_with_progress(), which lives below the split border and so is not available to test.cc in the split build.

cd test && make: 867 tests, 863 passed, 4 skipped, 0 failed (baseline on master is 865/861/4/0). Reverting httplib.h with the tests in place fails the truncation case with "Actual: true".