### PR TITLE
Parse empty Accept list elements per RFC 9110

### DIFF
--- a/example/accept_header.cc
+++ b/example/accept_header.cc
@@ -54,7 +54,6 @@ int main() {
         "text/html;q=-0.1,application/json", // q < 0.0
         "text/html;q=invalid,application/json", // invalid q value
         "invalidtype,application/json",      // invalid media type
-        ",application/json"                  // empty entry
     };
     
     for (const auto& invalid_accept : invalid_examples) {

--- a/httplib.h
+++ b/httplib.h
@@ -7858,8 +7858,7 @@ inline std::string get_combined_header_value(const Headers &headers,
   for (auto it = rng.first; it != rng.second; ++it) {
     // RFC 9110 Section 5.6.1.2: a recipient has to parse and ignore empty list
     // elements, so an empty field line must not contribute a bare comma to the
-    // combined value. parse_accept_header() rejects a leading comma outright,
-    // which would turn a legal request into 400 Bad Request.
+    // combined value.
     if (it->second.empty()) { continue; }
     if (!combined.empty()) { combined += ", "; }
     combined += it->second;
@@ -8836,12 +8835,6 @@ inline bool parse_accept_header(const std::string &s,
   // Empty string is considered valid (no preference)
   if (s.empty()) { return true; }
 
-  // Check for invalid patterns: leading/trailing commas or consecutive commas
-  if (s.front() == ',' || s.back() == ',' ||
-      s.find(",,") != std::string::npos) {
-    return false;
-  }
-
   struct AcceptEntry {
     std::string media_type;
     double quality;
@@ -8857,10 +8850,9 @@ inline bool parse_accept_header(const std::string &s,
     std::string entry(b, e);
     entry = trim_copy(entry);
 
-    if (entry.empty()) {
-      has_invalid_entry = true;
-      return;
-    }
+    // RFC 9110 §5.6.1.2: ignore empty list elements (leading, trailing,
+    // or consecutive commas). "text/html," and ",application/json" are legal.
+    if (entry.empty()) { return; }
 
     AcceptEntry accept_entry;
     accept_entry.order = order++;

--- a/test/test.cc
+++ b/test/test.cc
@@ -1067,13 +1067,27 @@ TEST(ParseAcceptHeaderTest, InvalidCases) {
   EXPECT_FALSE(
       detail::parse_accept_header("invalidtype,application/json", result));
 
-  // Empty media type
+  // RFC 9110 §5.6.1.2: empty list elements are ignored, not a 400
   result.clear();
-  EXPECT_FALSE(detail::parse_accept_header(",application/json", result));
+  EXPECT_TRUE(detail::parse_accept_header(",application/json", result));
+  ASSERT_EQ(result.size(), 1U);
+  EXPECT_EQ(result[0], "application/json");
 
-  // Only commas
   result.clear();
-  EXPECT_FALSE(detail::parse_accept_header(",,,", result));
+  EXPECT_TRUE(detail::parse_accept_header("text/html,", result));
+  ASSERT_EQ(result.size(), 1U);
+  EXPECT_EQ(result[0], "text/html");
+
+  result.clear();
+  EXPECT_TRUE(detail::parse_accept_header("text/html,,application/json", result));
+  ASSERT_EQ(result.size(), 2U);
+  EXPECT_EQ(result[0], "text/html");
+  EXPECT_EQ(result[1], "application/json");
+
+  // Only commas: a legal empty list
+  result.clear();
+  EXPECT_TRUE(detail::parse_accept_header(",,,", result));
+  EXPECT_TRUE(result.empty());
 
   // Valid cases should still work
   EXPECT_TRUE(detail::parse_accept_header("*/*", result));
@@ -1105,6 +1119,12 @@ TEST(ParseAcceptHeaderTest, ContentTypesPopulatedAndInvalidHeaderHandling) {
     res.set_content("bad request", "text/plain");
   });
 
+  std::vector<std::string> empty_element_types;
+  svr.Get("/accept_empty_elements", [&](const Request &req, Response &res) {
+    empty_element_types = req.accept_content_types;
+    res.set_content("ok", "text/plain");
+  });
+
   auto listen_thread = std::thread([&svr]() { svr.listen("localhost", PORT); });
   auto se = detail::scope_exit([&] {
     svr.stop();
@@ -1129,6 +1149,16 @@ TEST(ParseAcceptHeaderTest, ContentTypesPopulatedAndInvalidHeaderHandling) {
                        Headers{{"Accept", "text/html;q=abc,application/json"}});
     ASSERT_TRUE(res) << "Error: " << to_string(res.error());
     EXPECT_EQ(StatusCode::BadRequest_400, res->status);
+  }
+
+  // RFC 9110 empty list elements must not 400 the request.
+  {
+    auto res = cli.Get("/accept_empty_elements",
+                       Headers{{"Accept", "text/html,"}});
+    ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+    EXPECT_EQ(StatusCode::OK_200, res->status);
+    ASSERT_EQ(empty_element_types.size(), 1U);
+    EXPECT_EQ(empty_element_types[0], "text/html");
   }
 }
 
@@ -18519,8 +18549,7 @@ TEST(RepeatedFieldLinesTest, AcceptCombinesEveryFieldLine) {
 
 // RFC 9110 Section 5.6.1.2: empty list elements are parsed and ignored, so an
 // empty field line must not contribute a bare comma to the combined value.
-// parse_accept_header() rejects a leading comma outright, so a stray one would
-// turn a legal request into 400 Bad Request.
+// Empty field lines must not inject a comma into the combined Accept value.
 TEST(RepeatedFieldLinesTest, EmptyFieldLineDoesNotInjectComma) {
   Server svr;
 


### PR DESCRIPTION
## Summary

`parse_accept_header()` rejected `Accept` values with a leading, trailing, or doubled comma, so a legal header like `Accept: text/html,` was answered 400 and the connection was closed.

RFC 9110 §5.6.1.2 requires recipients to parse and ignore empty list elements. Empty entries are now skipped; only genuinely invalid media types or quality values still fail the parse.

## Related Issue

Fixes #2567

## Changes Made

- Stop treating leading/trailing/consecutive commas as a parse failure in `parse_accept_header()`
- Ignore empty comma-separated list elements instead of setting `has_invalid_entry`
- Keep 400 behavior for actually invalid `q` values and media types
- Update unit tests and a client/server round-trip for `Accept: text/html,`
- Drop the empty-entry example from the invalid list in `example/accept_header.cc`

## Testing

Commands executed:

- `g++ -std=c++17 accept_driver.cc` (standalone driver calling `detail::parse_accept_header` from `httplib.h`)
- `./accept_driver`
- `cmake -S . -B build -DHTTPLIB_TEST=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target httplib-test`
- `./build/test/httplib-test --gtest_filter='ParseAcceptHeaderTest.*'`

Results:

- standalone driver: all assertions passed
- 8/8 ParseAcceptHeaderTest tests passed, including `InvalidCases` and `ContentTypesPopulatedAndInvalidHeaderHandling`

## Notes

An all-comma value (`,,,`) is a legal empty list and now succeeds with an empty content-type vector, matching an omitted/empty `Accept` (no preference). Truly invalid entries such as `text/html;q=abc` still return 400.