### PR TITLE
Compress known-length content providers when the client accepts gzip

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -8590,6 +8590,68 @@ inline bool write_content_chunked(Stream &strm,
                                compressor, error);
 }
 
+// Compress a known-length provider as chunked. Length-framing (including a
+// provider that calls done() short of `length`) matches write_content(); the
+// payload is gzip/br/zstd-chunked like write_content_chunked(). Buffering the
+// whole representation would stall streaming providers until they finished.
+template <typename T, typename U>
+inline bool write_content_chunked_known_length(
+    Stream &strm, const ContentProvider &content_provider, size_t offset,
+    size_t length, const T &is_shutting_down, U &compressor) {
+  auto end_offset = offset + length;
+  auto ok = true;
+  auto finished = false;
+  DataSink data_sink;
+
+  auto emit = [&](const std::string &payload) -> bool {
+    if (payload.empty()) { return true; }
+    auto chunk = from_i_to_hex(payload.size()) + "\r\n" + payload + "\r\n";
+    return write_data(strm, chunk.data(), chunk.size());
+  };
+
+  data_sink.write = [&](const char *d, size_t l) -> bool {
+    if (!ok || l == 0) { return ok; }
+    offset += l;
+    std::string payload;
+    if (!compressor.compress(d, l, false,
+                             [&](const char *data, size_t data_len) {
+                               payload.append(data, data_len);
+                               return true;
+                             })) {
+      ok = false;
+      return false;
+    }
+    if (!emit(payload)) { ok = false; }
+    return ok;
+  };
+
+  data_sink.is_writable = [&]() -> bool { return strm.is_peer_alive(); };
+  data_sink.done = [&]() { finished = true; };
+
+  while (offset < end_offset && !finished && !is_shutting_down()) {
+    if (!strm.wait_writable() || !strm.is_peer_alive()) { return false; }
+    if (!content_provider(offset, end_offset - offset, data_sink)) {
+      return false;
+    }
+    if (!ok) { return false; }
+  }
+
+  if (offset < end_offset) { return false; }
+
+  std::string payload;
+  if (!compressor.compress(nullptr, 0, true,
+                           [&](const char *data, size_t data_len) {
+                             payload.append(data, data_len);
+                             return true;
+                           })) {
+    return false;
+  }
+  if (!emit(payload)) { return false; }
+
+  constexpr const char done_marker[] = "0\r\n\r\n";
+  return write_data(strm, done_marker, str_len(done_marker));
+}
+
 template <typename T>
 inline bool redirect(T &cli, Request &req, Response &res,
                      const std::string &path, const std::string &location,
@@ -13059,6 +13121,14 @@ Server::write_content_with_provider(Stream &strm, const Request &req,
         !req.ranges.empty() && res.status == StatusCode::PartialContent_206;
 
     if (!is_partial) {
+      auto type = detail::encoding_type(req, res);
+      if (type != detail::EncodingType::None) {
+        if (auto compressor = detail::make_compressor(type)) {
+          return detail::write_content_chunked_known_length(
+              strm, res.content_provider_, 0, res.content_length_,
+              is_shutting_down, *compressor);
+        }
+      }
       return detail::write_content(strm, res.content_provider_, 0,
                                    res.content_length_, is_shutting_down);
     } else if (req.ranges.size() == 1) {
@@ -13717,8 +13787,11 @@ inline void Server::apply_ranges(const Request &req, Response &res,
 
   if (res.body.empty()) {
     if (res.content_length_ > 0) {
+      auto is_partial =
+          !req.ranges.empty() && res.status == StatusCode::PartialContent_206;
+
       size_t length = 0;
-      if (req.ranges.empty() || res.status != StatusCode::PartialContent_206) {
+      if (!is_partial) {
         length = res.content_length_;
       } else if (req.ranges.size() == 1) {
         auto offset_and_length = detail::get_range_offset_and_length(
@@ -13733,7 +13806,18 @@ inline void Server::apply_ranges(const Request &req, Response &res,
         length = detail::get_multipart_ranges_data_length(
             req, boundary, content_type, res.content_length_);
       }
-      res.set_header("Content-Length", std::to_string(length));
+
+      // Known-length providers leave res.body empty, so the set_content()
+      // compressor never runs. Encode them as chunked instead; 206 stays
+      // uncompressed so Content-Range still names identity bytes.
+      if (!is_partial && type != detail::EncodingType::None &&
+          res.content_provider_) {
+        res.set_header("Transfer-Encoding", "chunked");
+        res.set_header("Content-Encoding", detail::encoding_name(type));
+        res.set_header("Vary", "Accept-Encoding");
+      } else {
+        res.set_header("Content-Length", std::to_string(length));
+      }
     } else {
       if (res.content_provider_) {
         if (res.is_chunked_content_provider_) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -5885,7 +5885,7 @@ TEST_F(ServerTest, GetEmptyFile) {
 }
 
 TEST_F(ServerTest, GetFileContent) {
-  auto res = cli_.Get("/file_content");
+  auto res = cli_.Get("/file_content", Headers{{"Accept-Encoding", ""}});
   ASSERT_TRUE(res) << "Error: " << to_string(res.error());
   EXPECT_EQ(StatusCode::OK_200, res->status);
   EXPECT_EQ("text/html", res->get_header_value("Content-Type"));
@@ -5904,7 +5904,8 @@ TEST_F(ServerTest, GetFileContentWithRange) {
 }
 
 TEST_F(ServerTest, GetFileContentWithContentType) {
-  auto res = cli_.Get("/file_content_with_content_type");
+  auto res = cli_.Get("/file_content_with_content_type",
+                      Headers{{"Accept-Encoding", ""}});
   ASSERT_TRUE(res) << "Error: " << to_string(res.error());
   EXPECT_EQ(StatusCode::OK_200, res->status);
   EXPECT_EQ("text/plain", res->get_header_value("Content-Type"));
@@ -5959,7 +5960,8 @@ TEST_F(ServerTest, HeadMethod200) {
 }
 
 TEST_F(ServerTest, HeadMethod200Static) {
-  auto res = cli_.Head("/mount/dir/index.html");
+  auto res =
+      cli_.Head("/mount/dir/index.html", Headers{{"Accept-Encoding", ""}});
   ASSERT_TRUE(res) << "Error: " << to_string(res.error());
   EXPECT_EQ(StatusCode::OK_200, res->status);
   EXPECT_EQ("text/html", res->get_header_value("Content-Type"));
@@ -6376,7 +6378,7 @@ TEST_F(ServerTest, StaticFileRangeBigFile2) {
 }
 
 TEST_F(ServerTest, StaticFileBigFile) {
-  auto res = cli_.Get("/dir/1MB.txt");
+  auto res = cli_.Get("/dir/1MB.txt", Headers{{"Accept-Encoding", ""}});
   ASSERT_TRUE(res) << "Error: " << to_string(res.error());
   EXPECT_EQ(StatusCode::OK_200, res->status);
   EXPECT_EQ("text/plain", res->get_header_value("Content-Type"));
@@ -6848,7 +6850,7 @@ TEST_F(ServerTest, GetStreamed2) {
 }
 
 TEST_F(ServerTest, GetStreamed) {
-  auto res = cli_.Get("/streamed");
+  auto res = cli_.Get("/streamed", Headers{{"Accept-Encoding", ""}});
   ASSERT_TRUE(res) << "Error: " << to_string(res.error());
   EXPECT_EQ(StatusCode::OK_200, res->status);
   EXPECT_EQ("6", res->get_header_value("Content-Length"));
@@ -6917,7 +6919,8 @@ TEST_F(ServerTest, GetStreamedWithRangeAndNonPartialStatus) {
         std::string("/streamed-with-range?status=") + std::to_string(status);
     auto ctx = path + " Range: " + range;
 
-    auto res = cli_.Get(path, Headers{{"Range", range}});
+    auto res =
+        cli_.Get(path, Headers{{"Range", range}, {"Accept-Encoding", ""}});
     ASSERT_TRUE(res) << ctx << " Error: " << to_string(res.error());
     EXPECT_EQ(status, res->status) << ctx;
     EXPECT_EQ("7", res->get_header_value("Content-Length")) << ctx;
@@ -8725,6 +8728,91 @@ TEST_F(ServerTest, MultipartFormDataGzip) {
 
   ASSERT_TRUE(res) << "Error: " << to_string(res.error());
   EXPECT_EQ(StatusCode::OK_200, res->status);
+}
+
+TEST_F(ServerTest, GzipStaticFile) {
+  Headers headers;
+  headers.emplace("Accept-Encoding", "gzip");
+
+  cli_.set_decompress(false);
+  auto res = cli_.Get("/dir/1MB.txt", headers);
+
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ("gzip", res->get_header_value("Content-Encoding"));
+  EXPECT_EQ("Accept-Encoding", res->get_header_value("Vary"));
+  EXPECT_EQ("chunked", res->get_header_value("Transfer-Encoding"));
+  EXPECT_TRUE(res->get_header_value("Content-Length").empty());
+  EXPECT_LT(res->body.size(), 1048576U);
+  EXPECT_FALSE(res->body.empty());
+}
+
+TEST_F(ServerTest, GzipStaticFileDecompressed) {
+  Headers headers;
+  headers.emplace("Accept-Encoding", "gzip");
+  auto res = cli_.Get("/dir/1MB.txt", headers);
+
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ("gzip", res->get_header_value("Content-Encoding"));
+  EXPECT_EQ(1048576U, res->body.size());
+}
+
+TEST_F(ServerTest, GzipFileContent) {
+  Headers headers;
+  headers.emplace("Accept-Encoding", "gzip");
+  auto res = cli_.Get("/file_content", headers);
+
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ("gzip", res->get_header_value("Content-Encoding"));
+  EXPECT_EQ("test.html", res->body);
+}
+
+TEST_F(ServerTest, GzipKnownLengthContentProvider) {
+  Headers headers;
+  headers.emplace("Accept-Encoding", "gzip");
+  auto res = cli_.Get("/streamed", headers);
+
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ("gzip", res->get_header_value("Content-Encoding"));
+  EXPECT_EQ("aaabbb", res->body);
+}
+
+TEST_F(ServerTest, GzipStaticFileRangeUncompressed) {
+  auto res = cli_.Get("/dir/test.abcde", Headers{
+                                             make_range_header({{2, 3}}),
+                                             {"Accept-Encoding", "gzip"},
+                                         });
+
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::PartialContent_206, res->status);
+  EXPECT_TRUE(res->get_header_value("Content-Encoding").empty());
+  EXPECT_EQ("2", res->get_header_value("Content-Length"));
+  EXPECT_EQ("bytes 2-3/5", res->get_header_value("Content-Range"));
+  EXPECT_EQ(std::string("cd"), res->body);
+}
+
+TEST_F(ServerTest, GzipStaticFileHead) {
+  auto res = cli_.Head("/dir/1MB.txt", {{"Accept-Encoding", "gzip"}});
+
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ("gzip", res->get_header_value("Content-Encoding"));
+  EXPECT_EQ("chunked", res->get_header_value("Transfer-Encoding"));
+  EXPECT_TRUE(res->body.empty());
+}
+
+TEST_F(ServerTest, NoGzipStaticOctetStream) {
+  Headers headers;
+  headers.emplace("Accept-Encoding", "gzip");
+  auto res = cli_.Get("/file", headers);
+
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_FALSE(res->has_header("Content-Encoding"));
+  EXPECT_EQ("5", res->get_header_value("Content-Length"));
 }
 #endif
 
@@ -19633,7 +19721,8 @@ TEST(ErrorHandlingTest, StreamReadTimeout) {
   Client cli("localhost", port);
   cli.set_read_timeout(1, 0); // 1 second timeout
 
-  auto handle = cli.open_stream("GET", "/slow-stream");
+  auto handle =
+      cli.open_stream("GET", "/slow-stream", {}, {{"Accept-Encoding", ""}});
   ASSERT_TRUE(handle.is_valid());
 
   char buf[256];
@@ -19688,7 +19777,8 @@ TEST(ErrorHandlingTest, StreamConnectionClosed) {
   svr.wait_until_ready();
 
   Client cli("localhost", port);
-  auto handle = cli.open_stream("GET", "/will-close");
+  auto handle =
+      cli.open_stream("GET", "/will-close", {}, {{"Accept-Encoding", ""}});
   ASSERT_TRUE(handle.is_valid());
 
   char buf[256];
@@ -19743,7 +19833,8 @@ TEST(ErrorHandlingTest, SSLStreamReadTimeout) {
   cli.enable_server_certificate_verification(false);
   cli.set_read_timeout(1, 0); // 1 second timeout
 
-  auto handle = cli.open_stream("GET", "/slow-stream");
+  auto handle =
+      cli.open_stream("GET", "/slow-stream", {}, {{"Accept-Encoding", ""}});
   ASSERT_TRUE(handle.is_valid());
 
   char buf[256];
@@ -19796,7 +19887,8 @@ TEST(ErrorHandlingTest, SSLStreamConnectionClosed) {
 
   SSLClient cli("localhost", port);
   cli.enable_server_certificate_verification(false);
-  auto handle = cli.open_stream("GET", "/will-close");
+  auto handle =
+      cli.open_stream("GET", "/will-close", {}, {{"Accept-Encoding", ""}});
   ASSERT_TRUE(handle.is_valid());
 
   char buf[256];


### PR DESCRIPTION
## Summary

Static file responses and other known-length content providers were never compressed, even when the client sent `Accept-Encoding: gzip` and the content type is already treated as compressible. The same bytes served through `set_content()` were gzipped.

That covers `set_content_provider(length, ...)`, and through it `set_mount_point()` and `Response::set_file_content()`.

## Related Issue

Fixes #2545

## Changes Made

`Server::apply_ranges()` only ran the compressor when `res.body` was non-empty. A known-length provider has an empty body and a non-zero `content_length_`, so it took the other branch, which set `Content-Length` and returned. `detail::encoding_type()` was computed but never consulted on that path.

When the client accepts a supported encoding and the response is not a 206 range:

- set `Transfer-Encoding: chunked`, `Content-Encoding`, and `Vary: Accept-Encoding`
- write the provider through a compressor, using the same length-framing as `write_content()` (including a provider that calls `done()` short of the advertised length)

Compression is chunked rather than buffering the whole representation into `res.body`. Buffering would stall streaming known-length providers (timeouts, mid-stream abort) until they finished. 206 responses stay uncompressed so `Content-Range` still names identity bytes.

## Testing

Built with `cmake -DHTTPLIB_TEST=ON -DHTTPLIB_REQUIRE_ZLIB=ON` and ran `httplib-test`.

New tests (under `CPPHTTPLIB_ZLIB_SUPPORT`):

- `GzipStaticFile` / `GzipStaticFileDecompressed` — mount point (`/dir/1MB.txt`)
- `GzipFileContent` — `set_file_content()`
- `GzipKnownLengthContentProvider` — `set_content_provider(length)`
- `GzipStaticFileRangeUncompressed` — `Range` stays identity even with `Accept-Encoding: gzip`
- `GzipStaticFileHead` — HEAD gets the same encoding headers
- `NoGzipStaticOctetStream` — `application/octet-stream` is not compressed

Existing tests that pin uncompressed `Content-Length` for full known-length responses now send an empty `Accept-Encoding` so they keep testing the identity representation.

## Notes

Chunked encoding is used instead of a compressed `Content-Length` so mmap/static files and incremental `set_content_provider(length)` handlers share one path with `set_chunked_content_provider()`. Range requests are left uncompressed on purpose (RFC 9110 applies Range to the selected representation after content coding; serving identity ranges is the usual way out).