### PR TITLE
split header field parameters outside quoted-strings

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -7290,6 +7290,64 @@ find_content_type(const std::string &path,
   }
 }
 
+// RFC 9110 §5.6.6: a header field parameter value may be a token or a
+// quoted-string, and a quoted-string may itself contain the ';' that
+// separates parameters and the '=' that separates a name from its value.
+// Splitting on those characters unconditionally therefore truncates a value
+// such as filename="a;b" or filename="a=b". Track the quoted-string state so
+// the delimiters are only honoured outside quotes; a backslash escapes the
+// next character inside quotes. `fn` receives the whitespace-trimmed name and
+// value with any surrounding quotes left in place for the caller to strip.
+inline void parse_header_field_parameters(
+    const std::string &s,
+    std::function<void(const std::string &, const std::string &)> fn) {
+  size_t i = 0;
+  const auto n = s.size();
+  while (i < n) {
+    const auto param_beg = i;
+    auto in_quotes = false;
+    for (; i < n; i++) {
+      const auto c = s[i];
+      if (in_quotes) {
+        if (c == '\\' && i + 1 < n) {
+          i++;
+        } else if (c == '"') {
+          in_quotes = false;
+        }
+      } else if (c == '"') {
+        in_quotes = true;
+      } else if (c == ';') {
+        break;
+      }
+    }
+
+    const auto param = s.substr(param_beg, i - param_beg);
+    if (i < n) { i++; } // Skip the ';'
+
+    auto eq = std::string::npos;
+    in_quotes = false;
+    for (size_t j = 0; j < param.size(); j++) {
+      const auto c = param[j];
+      if (in_quotes) {
+        if (c == '\\' && j + 1 < param.size()) {
+          j++;
+        } else if (c == '"') {
+          in_quotes = false;
+        }
+      } else if (c == '"') {
+        in_quotes = true;
+      } else if (c == '=') {
+        eq = j;
+        break;
+      }
+    }
+    if (eq == std::string::npos) { continue; }
+
+    auto key = trim_copy(param.substr(0, eq));
+    if (!key.empty()) { fn(key, trim_copy(param.substr(eq + 1))); }
+  }
+}
+
 inline std::string
 extract_media_type(const std::string &content_type,
                    std::map<std::string, std::string> *params = nullptr) {
@@ -7302,22 +7360,10 @@ extract_media_type(const std::string &content_type,
     media_type = media_type.substr(0, semicolon_pos);
 
     if (params) {
-      // Parse parameters: key=value pairs separated by ';'
-      split(param_str.data(), param_str.data() + param_str.size(), ';',
-            [&](const char *b, const char *e) {
-              std::string key;
-              std::string val;
-              split(b, e, '=', [&](const char *b2, const char *e2) {
-                if (key.empty()) {
-                  key.assign(b2, e2);
-                } else {
-                  val.assign(b2, e2);
-                }
-              });
-              if (!key.empty()) {
-                params->emplace(trim_copy(key), trim_double_quotes_copy(val));
-              }
-            });
+      parse_header_field_parameters(
+          param_str, [&](const std::string &key, const std::string &val) {
+            params->emplace(key, trim_double_quotes_copy(val));
+          });
     }
   }
 
@@ -8759,26 +8805,9 @@ inline bool parse_multipart_boundary(const std::string &content_type,
 }
 
 inline void parse_disposition_params(const std::string &s, Params &params) {
-  std::set<std::string> cache;
-  split(s.data(), s.data() + s.size(), ';', [&](const char *b, const char *e) {
-    std::string kv(b, e);
-    if (cache.find(kv) != cache.end()) { return; }
-    cache.insert(kv);
-
-    std::string key;
-    std::string val;
-    split(b, e, '=', [&](const char *b2, const char *e2) {
-      if (key.empty()) {
-        key.assign(b2, e2);
-      } else {
-        val.assign(b2, e2);
-      }
-    });
-
-    if (!key.empty()) {
-      params.emplace(trim_double_quotes_copy((key)),
-                     trim_double_quotes_copy((val)));
-    }
+  parse_header_field_parameters(s, [&](const std::string &key,
+                                       const std::string &val) {
+    params.emplace(trim_double_quotes_copy(key), trim_double_quotes_copy(val));
   });
 }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -493,6 +493,61 @@ TEST(SanitizeFilenameTest, VariousPatterns) {
   EXPECT_EQ("", httplib::sanitize_filename("   "));
 }
 
+// Forward declaration: in split builds split.py strips `inline` and moves the
+// definition into httplib.cc, so these detail parsers are not visible from the
+// public httplib.h. Re-declaring them here lets the test link in both builds.
+namespace httplib {
+namespace detail {
+void parse_disposition_params(const std::string &s, Params &params);
+std::string extract_media_type(const std::string &content_type,
+                               std::map<std::string, std::string> *params);
+} // namespace detail
+} // namespace httplib
+
+TEST(ParseHeaderFieldParametersTest, QuotedStringDelimiters) {
+  // RFC 9110 5.6.6: a parameter value may be a quoted-string, which can itself
+  // contain the ';' separating parameters and the '=' separating a name from
+  // its value. Splitting on those characters unconditionally truncated the
+  // value, e.g. filename="a;b=c.txt" became filename="a plus a bogus param.
+  {
+    Params params;
+    detail::parse_disposition_params("name=\"field\"; filename=\"a;b=c.txt\"",
+                                     params);
+    EXPECT_EQ("field", params.find("name")->second);
+    EXPECT_EQ("a;b=c.txt", params.find("filename")->second);
+    // The bytes inside the quoted value must not surface as spurious params.
+    EXPECT_EQ(params.end(), params.find("b"));
+    EXPECT_EQ(2u, params.size());
+  }
+
+  // A backslash-escaped quote inside the value must not end it early.
+  {
+    Params params;
+    detail::parse_disposition_params("name=\"f\"; filename=\"a\\\"b.txt\"",
+                                     params);
+    EXPECT_EQ("a\\\"b.txt", params.find("filename")->second);
+  }
+
+  // Well-formed values without quoted delimiters are unchanged.
+  {
+    Params params;
+    detail::parse_disposition_params("name=\"file\"; filename=\"plain.txt\"",
+                                     params);
+    EXPECT_EQ("file", params.find("name")->second);
+    EXPECT_EQ("plain.txt", params.find("filename")->second);
+  }
+
+  // The same splitter parses media-type parameters, e.g. a quoted boundary.
+  {
+    std::map<std::string, std::string> params;
+    auto mt = detail::extract_media_type(
+        "multipart/form-data; boundary=\"a;b\"", &params);
+    EXPECT_EQ("multipart/form-data", mt);
+    EXPECT_EQ("a;b", params["boundary"]);
+    EXPECT_EQ(1u, params.size());
+  }
+}
+
 // Forward declaration (see the base64_encode note below): split builds move the
 // definition into httplib.cc, so re-declaring it here lets the test link.
 namespace httplib {


### PR DESCRIPTION
The multipart parser reads each part's name and filename out of the Content-Disposition header by splitting the parameter list on ';' and each parameter on '=', and extract_media_type does the same for Content-Type parameters. Neither split is aware of quoted-strings, but RFC 9110 5.6.6 lets a parameter value be a quoted-string that itself contains those delimiters, so a part sent as filename="a;b=c.txt" is truncated to "a and picks up a stray b=c.txt parameter, while filename="x=y.txt" collapses to y.txt". The disposition value comes straight off an untrusted multipart body, so the filename an application ends up with can differ from the one the client sent and from the one a proxy or upload filter in front of the server inspected. I noticed it while checking how quoted filenames survive the parser and reproduced it against a part whose filename contains a semicolon. The fix moves both call sites onto a small shared helper that tracks the quoted-string state and only treats ';' and '=' as delimiters outside quotes, with a backslash escaping the next character; values that carry no quoted delimiter parse exactly as before. I kept it to that one helper so the disposition and media-type paths stay in step and there is a single place to reason about the quoting rules. Adds a unit test covering the quoted-delimiter cases.