### PR TITLE
send each credential only to its own hop in write_request

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -14929,8 +14929,13 @@ inline Result ClientImpl::send_(Request &&req) {
 inline void ClientImpl::prepare_default_headers(Request &r, bool for_stream,
                                                 const std::string &ct) {
   (void)for_stream;
-  for (const auto &header : default_headers_) {
-    if (!r.has_header(header.first)) { r.headers.insert(header); }
+  // Default headers are meant for the origin and often carry its credentials
+  // (Authorization, Cookie, API keys). A CONNECT request is read by the proxy,
+  // before the TLS tunnel exists, so none of them go on it.
+  if (r.method != "CONNECT") {
+    for (const auto &header : default_headers_) {
+      if (!r.has_header(header.first)) { r.headers.insert(header); }
+    }
   }
 
   // RFC 9110 5.3 recommends sending control data such as Host first, so

--- a/httplib.h
+++ b/httplib.h
@@ -15611,24 +15611,34 @@ inline bool ClientImpl::write_request(Stream &strm, Request &req,
     }
   }
 
-  if (!basic_auth_password_.empty() || !basic_auth_username_.empty()) {
-    if (!req.has_header("Authorization")) {
-      req.headers.insert(make_basic_authentication_header(
-          basic_auth_username_, basic_auth_password_, false));
+  // Each credential goes only to the hop that reads the message carrying it.
+  // A CONNECT request is read by the proxy, so the origin's Authorization must
+  // not be attached to it; everything sent inside the tunnel it opens is read
+  // by the origin, so Proxy-Authorization must not be attached there.
+  auto is_connect = req.method == "CONNECT";
+
+  if (!is_connect) {
+    if (!basic_auth_password_.empty() || !basic_auth_username_.empty()) {
+      if (!req.has_header("Authorization")) {
+        req.headers.insert(make_basic_authentication_header(
+            basic_auth_username_, basic_auth_password_, false));
+      }
+    }
+
+    if (!bearer_token_auth_token_.empty()) {
+      if (!req.has_header("Authorization")) {
+        req.headers.insert(make_bearer_token_authentication_header(
+            bearer_token_auth_token_, false));
+      }
     }
   }
 
-  if (!bearer_token_auth_token_.empty()) {
-    if (!req.has_header("Authorization")) {
-      req.headers.insert(make_bearer_token_authentication_header(
-          bearer_token_auth_token_, false));
-    }
-  }
-
-  // Proxy-Authorization is only sent when the proxy is actually used for
-  // this target — otherwise NO_PROXY-matched requests would leak proxy
-  // credentials directly to the destination server.
-  if (is_proxy_enabled_for_host(host_)) {
+  // Proxy-Authorization is only sent when the proxy is actually the hop
+  // reading this message: plain HTTP through an enabled proxy, or the CONNECT
+  // that opens a tunnel. Otherwise NO_PROXY-matched requests, and requests
+  // travelling inside a TLS tunnel, would leak proxy credentials to the
+  // destination server.
+  if (is_proxy_enabled_for_host(host_) && (!is_ssl() || is_connect)) {
     if (!proxy_basic_auth_username_.empty() &&
         !proxy_basic_auth_password_.empty() &&
         !req.has_header("Proxy-Authorization")) {

--- a/httplib.h
+++ b/httplib.h
@@ -14929,9 +14929,8 @@ inline Result ClientImpl::send_(Request &&req) {
 inline void ClientImpl::prepare_default_headers(Request &r, bool for_stream,
                                                 const std::string &ct) {
   (void)for_stream;
-  // Default headers are meant for the origin and often carry its credentials
-  // (Authorization, Cookie, API keys). A CONNECT request is read by the proxy,
-  // before the TLS tunnel exists, so none of them go on it.
+  // Default headers are meant for the origin and may carry its credentials, so
+  // keep them off the CONNECT request the proxy reads.
   if (r.method != "CONNECT") {
     for (const auto &header : default_headers_) {
       if (!r.has_header(header.first)) { r.headers.insert(header); }
@@ -15616,33 +15615,23 @@ inline bool ClientImpl::write_request(Stream &strm, Request &req,
     }
   }
 
-  // Each credential goes only to the hop that reads the message carrying it.
-  // A CONNECT request is read by the proxy, so the origin's Authorization must
-  // not be attached to it; everything sent inside the tunnel it opens is read
-  // by the origin, so Proxy-Authorization must not be attached there.
+  // A CONNECT request is read by the proxy; everything sent through the tunnel
+  // it opens is read by the origin. Each credential goes only to its own hop.
   auto is_connect = req.method == "CONNECT";
 
-  if (!is_connect) {
+  if (!is_connect && !req.has_header("Authorization")) {
     if (!basic_auth_password_.empty() || !basic_auth_username_.empty()) {
-      if (!req.has_header("Authorization")) {
-        req.headers.insert(make_basic_authentication_header(
-            basic_auth_username_, basic_auth_password_, false));
-      }
-    }
-
-    if (!bearer_token_auth_token_.empty()) {
-      if (!req.has_header("Authorization")) {
-        req.headers.insert(make_bearer_token_authentication_header(
-            bearer_token_auth_token_, false));
-      }
+      req.headers.insert(make_basic_authentication_header(
+          basic_auth_username_, basic_auth_password_, false));
+    } else if (!bearer_token_auth_token_.empty()) {
+      req.headers.insert(make_bearer_token_authentication_header(
+          bearer_token_auth_token_, false));
     }
   }
 
-  // Proxy-Authorization is only sent when the proxy is actually the hop
-  // reading this message: plain HTTP through an enabled proxy, or the CONNECT
-  // that opens a tunnel. Otherwise NO_PROXY-matched requests, and requests
-  // travelling inside a TLS tunnel, would leak proxy credentials to the
-  // destination server.
+  // Proxy-Authorization is only sent when the proxy reads this message —
+  // otherwise NO_PROXY-matched requests, and requests inside a TLS tunnel,
+  // would leak proxy credentials to the destination server.
   if (is_proxy_enabled_for_host(host_) && (!is_ssl() || is_connect)) {
     if (!proxy_basic_auth_username_.empty() &&
         !proxy_basic_auth_password_.empty() &&

--- a/test/test.cc
+++ b/test/test.cc
@@ -25444,21 +25444,22 @@ private:
 // Sends one request through the CONNECT proxy to the TLS origin with a
 // credential configured for each hop, and checks that each credential reaches
 // only the hop it was configured for: the proxy's on the CONNECT request, the
-// origin's on the tunnelled request.
+// origin's (every header in origin_headers) on the tunnelled request.
 void CredentialsStayWithTheirHop(
     const std::function<void(SSLClient &)> &set_credentials,
-    const std::string &scheme) {
+    const std::string &scheme,
+    const std::vector<std::string> &origin_headers = {"Authorization"}) {
   std::atomic<int> origin_hits{0};
   std::atomic<bool> origin_saw_proxy_authz{false};
-  std::atomic<bool> origin_saw_authz{false};
+  std::atomic<bool> origin_saw_headers{false};
 
   ScopedSSLServer origin;
   origin.svr().Get(".*", [&](const Request &req, Response &res) {
     origin_hits++;
-    if (req.has_header("Proxy-Authorization")) {
-      origin_saw_proxy_authz = true;
-    }
-    if (req.has_header("Authorization")) { origin_saw_authz = true; }
+    origin_saw_proxy_authz = req.has_header("Proxy-Authorization");
+    origin_saw_headers =
+        std::all_of(origin_headers.begin(), origin_headers.end(),
+                    [&](const std::string &h) { return req.has_header(h); });
     res.set_content("ok", "text/plain");
   });
   origin.listen();
@@ -25478,15 +25479,17 @@ void CredentialsStayWithTheirHop(
   EXPECT_EQ(1, origin_hits.load());
   EXPECT_EQ(1, proxy.connect_hits());
 
-  EXPECT_TRUE(origin_saw_authz.load());
+  EXPECT_TRUE(origin_saw_headers.load());
   EXPECT_FALSE(origin_saw_proxy_authz.load())
       << "Proxy-Authorization must not be sent inside the tunnel";
 
   auto connect_req = proxy.connect_request();
   EXPECT_NE(std::string::npos,
             connect_req.find("\r\nProxy-Authorization: " + scheme + " "));
-  EXPECT_EQ(std::string::npos, connect_req.find("\r\nAuthorization: "))
-      << "Authorization must not be sent to the proxy on CONNECT";
+  for (const auto &h : origin_headers) {
+    EXPECT_EQ(std::string::npos, connect_req.find("\r\n" + h + ": "))
+        << h << " must not be sent to the proxy on CONNECT";
+  }
 }
 
 } // namespace proxy_tunnel_test
@@ -25510,44 +25513,14 @@ TEST(ProxyTunnelTest, BearerCredentialsStayWithTheirHop) {
 }
 
 TEST(ProxyTunnelTest, DefaultHeadersStayOffConnect) {
-  // Default headers are meant for the origin and often carry its credentials;
-  // the proxy reading the CONNECT request must see none of them.
-  std::atomic<bool> origin_saw_defaults{false};
-
-  proxy_tunnel_test::ScopedSSLServer origin;
-  origin.svr().Get(".*", [&](const Request &req, Response &res) {
-    origin_saw_defaults =
-        req.get_header_value("Authorization") == "Bearer origin-token" &&
-        req.get_header_value("Cookie") == "sid=origin-session" &&
-        req.get_header_value("X-Api-Key") == "origin-key";
-    res.set_content("ok", "text/plain");
-  });
-  origin.listen();
-
-  proxy_tunnel_test::ScopedConnectProxy proxy(origin.port());
-  ASSERT_NE(0, proxy.port());
-
-  // Pinned to 127.0.0.1 for the same reason as the test below.
-  SSLClient cli("127.0.0.1", origin.port());
-  cli.enable_server_certificate_verification(false);
-  cli.set_proxy("127.0.0.1", proxy.port());
-  cli.set_proxy_basic_auth("proxy-user", "proxy-pass");
-  cli.set_default_headers({{"Authorization", "Bearer origin-token"},
-                           {"Cookie", "sid=origin-session"},
-                           {"X-Api-Key", "origin-key"}});
-
-  auto res = cli.Get("/x");
-  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
-  EXPECT_EQ(StatusCode::OK_200, res->status);
-  EXPECT_EQ(1, proxy.connect_hits());
-  EXPECT_TRUE(origin_saw_defaults.load());
-
-  auto connect_req = proxy.connect_request();
-  EXPECT_NE(std::string::npos,
-            connect_req.find("\r\nProxy-Authorization: Basic "));
-  EXPECT_EQ(std::string::npos, connect_req.find("\r\nAuthorization: "));
-  EXPECT_EQ(std::string::npos, connect_req.find("\r\nCookie: "));
-  EXPECT_EQ(std::string::npos, connect_req.find("\r\nX-Api-Key: "));
+  proxy_tunnel_test::CredentialsStayWithTheirHop(
+      [](SSLClient &cli) {
+        cli.set_proxy_basic_auth("proxy-user", "proxy-pass");
+        cli.set_default_headers({{"Authorization", "Bearer origin-token"},
+                                 {"Cookie", "sid=origin-session"},
+                                 {"X-Api-Key", "origin-key"}});
+      },
+      "Basic", {"Authorization", "Cookie", "X-Api-Key"});
 }
 
 TEST(ProxyTunnelTest, OriginReturning407InsideTunnelDoesNotLeakProxyDigest) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -25509,6 +25509,47 @@ TEST(ProxyTunnelTest, BearerCredentialsStayWithTheirHop) {
       "Bearer");
 }
 
+TEST(ProxyTunnelTest, DefaultHeadersStayOffConnect) {
+  // Default headers are meant for the origin and often carry its credentials;
+  // the proxy reading the CONNECT request must see none of them.
+  std::atomic<bool> origin_saw_defaults{false};
+
+  proxy_tunnel_test::ScopedSSLServer origin;
+  origin.svr().Get(".*", [&](const Request &req, Response &res) {
+    origin_saw_defaults =
+        req.get_header_value("Authorization") == "Bearer origin-token" &&
+        req.get_header_value("Cookie") == "sid=origin-session" &&
+        req.get_header_value("X-Api-Key") == "origin-key";
+    res.set_content("ok", "text/plain");
+  });
+  origin.listen();
+
+  proxy_tunnel_test::ScopedConnectProxy proxy(origin.port());
+  ASSERT_NE(0, proxy.port());
+
+  // Pinned to 127.0.0.1 for the same reason as the test below.
+  SSLClient cli("127.0.0.1", origin.port());
+  cli.enable_server_certificate_verification(false);
+  cli.set_proxy("127.0.0.1", proxy.port());
+  cli.set_proxy_basic_auth("proxy-user", "proxy-pass");
+  cli.set_default_headers({{"Authorization", "Bearer origin-token"},
+                           {"Cookie", "sid=origin-session"},
+                           {"X-Api-Key", "origin-key"}});
+
+  auto res = cli.Get("/x");
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ(1, proxy.connect_hits());
+  EXPECT_TRUE(origin_saw_defaults.load());
+
+  auto connect_req = proxy.connect_request();
+  EXPECT_NE(std::string::npos,
+            connect_req.find("\r\nProxy-Authorization: Basic "));
+  EXPECT_EQ(std::string::npos, connect_req.find("\r\nAuthorization: "));
+  EXPECT_EQ(std::string::npos, connect_req.find("\r\nCookie: "));
+  EXPECT_EQ(std::string::npos, connect_req.find("\r\nX-Api-Key: "));
+}
+
 TEST(ProxyTunnelTest, OriginReturning407InsideTunnelDoesNotLeakProxyDigest) {
   // Origin inside a CONNECT tunnel replying 407 must not trigger the digest
   // retry; otherwise proxy creds would be sent to the origin.

--- a/test/test.cc
+++ b/test/test.cc
@@ -25353,6 +25353,11 @@ public:
 
   int port() const { return port_; }
   int connect_hits() const { return connect_hits_.load(); }
+  // Head of the last CONNECT request, as the proxy saw it on the wire.
+  std::string connect_request() const {
+    std::lock_guard<std::mutex> lock(connect_request_mutex_);
+    return connect_request_;
+  }
 
 private:
   void run() {
@@ -25379,6 +25384,10 @@ private:
         continue;
       }
       connect_hits_++;
+      {
+        std::lock_guard<std::mutex> lock(connect_request_mutex_);
+        connect_request_ = req;
+      }
 
       const char *ok = "HTTP/1.1 200 Connection established\r\n\r\n";
       ::send(client_fd, ok, std::strlen(ok), 0);
@@ -25428,9 +25437,77 @@ private:
   std::thread th_;
   std::atomic<bool> stop_{false};
   std::atomic<int> connect_hits_{0};
+  mutable std::mutex connect_request_mutex_;
+  std::string connect_request_;
 };
 
+// Sends one request through the CONNECT proxy to the TLS origin with a
+// credential configured for each hop, and checks that each credential reaches
+// only the hop it was configured for: the proxy's on the CONNECT request, the
+// origin's on the tunnelled request.
+void CredentialsStayWithTheirHop(
+    const std::function<void(SSLClient &)> &set_credentials,
+    const std::string &scheme) {
+  std::atomic<int> origin_hits{0};
+  std::atomic<bool> origin_saw_proxy_authz{false};
+  std::atomic<bool> origin_saw_authz{false};
+
+  ScopedSSLServer origin;
+  origin.svr().Get(".*", [&](const Request &req, Response &res) {
+    origin_hits++;
+    if (req.has_header("Proxy-Authorization")) {
+      origin_saw_proxy_authz = true;
+    }
+    if (req.has_header("Authorization")) { origin_saw_authz = true; }
+    res.set_content("ok", "text/plain");
+  });
+  origin.listen();
+
+  ScopedConnectProxy proxy(origin.port());
+  ASSERT_NE(0, proxy.port());
+
+  // Pinned to 127.0.0.1 for the same reason as the test below.
+  SSLClient cli("127.0.0.1", origin.port());
+  cli.enable_server_certificate_verification(false);
+  cli.set_proxy("127.0.0.1", proxy.port());
+  set_credentials(cli);
+
+  auto res = cli.Get("/x");
+  ASSERT_TRUE(res) << "Error: " << to_string(res.error());
+  EXPECT_EQ(StatusCode::OK_200, res->status);
+  EXPECT_EQ(1, origin_hits.load());
+  EXPECT_EQ(1, proxy.connect_hits());
+
+  EXPECT_TRUE(origin_saw_authz.load());
+  EXPECT_FALSE(origin_saw_proxy_authz.load())
+      << "Proxy-Authorization must not be sent inside the tunnel";
+
+  auto connect_req = proxy.connect_request();
+  EXPECT_NE(std::string::npos,
+            connect_req.find("\r\nProxy-Authorization: " + scheme + " "));
+  EXPECT_EQ(std::string::npos, connect_req.find("\r\nAuthorization: "))
+      << "Authorization must not be sent to the proxy on CONNECT";
+}
+
 } // namespace proxy_tunnel_test
+
+TEST(ProxyTunnelTest, BasicCredentialsStayWithTheirHop) {
+  proxy_tunnel_test::CredentialsStayWithTheirHop(
+      [](SSLClient &cli) {
+        cli.set_proxy_basic_auth("proxy-user", "proxy-pass");
+        cli.set_basic_auth("origin-user", "origin-pass");
+      },
+      "Basic");
+}
+
+TEST(ProxyTunnelTest, BearerCredentialsStayWithTheirHop) {
+  proxy_tunnel_test::CredentialsStayWithTheirHop(
+      [](SSLClient &cli) {
+        cli.set_proxy_bearer_token_auth("proxy-token");
+        cli.set_bearer_token_auth("origin-token");
+      },
+      "Bearer");
+}
 
 TEST(ProxyTunnelTest, OriginReturning407InsideTunnelDoesNotLeakProxyDigest) {
   // Origin inside a CONNECT tunnel replying 407 must not trigger the digest


### PR DESCRIPTION
**Proxy credentials sent inside the CONNECT tunnel**
ClientImpl::write_request attaches Proxy-Authorization whenever a proxy is enabled for the host, so an SSLClient sends the proxy's Basic or Bearer credentials on every request inside the TLS tunnel, where only the origin reads them, and likewise puts the origin's Authorization on the CONNECT request that only the proxy reads. Both now go to the hop that actually reads the message, reusing the is_ssl() distinction the 407 handling already makes, and the tunnel fixture gains a test per scheme that checks what each hop received.